### PR TITLE
Correct total number of log records when count=0

### DIFF
--- a/dspace/modules/dataone-mn/dataone-mn-webapp/src/main/java/org/dspace/dataonemn/DataOneLogger.java
+++ b/dspace/modules/dataone-mn/dataone-mn-webapp/src/main/java/org/dspace/dataonemn/DataOneLogger.java
@@ -181,10 +181,6 @@ public class DataOneLogger {
             log.error("Solr server threw an exception while retreiving log records: ",e);
             log.info("Solr query was: " + solrQuery.getQuery());
         }
-        if (matchingEntries.size() == 0){
-            // is this necessary, or correct?
-           return new LogResults(HttpServletResponse.SC_OK,0,emptyResults);
-        }
         final StringBuffer entryResults = new StringBuffer(200);
         for(LogEntry le : matchingEntries){
             entryResults.append(le.getXml());


### PR DESCRIPTION
When the DataONE log aggregator is requesting log entries, it starts
by making a request like /mn/log?count=0. The aggregator expects the
response document to contain zero rows, but still contain a correct
total for the number of rows that matched the query. This expectation
aligns with standard SOLR behavior.

Our logging code was erroneously short-circuiting this behavior and
returning a result document that always declared total=0. This commit
removes the short-circuit.
