### PR TITLE
Add confirmation popup for lifting embargoes and deleting files

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemEmbargoForm.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemEmbargoForm.java
@@ -122,7 +122,7 @@ public class EditItemEmbargoForm extends AbstractDSpaceTransformer {
     private void addButtons(Division embargoDiv) throws WingException {
         Para buttonPara = embargoDiv.addPara("buttons", "");
 
-        buttonPara.addButton("submit_lift_emabrgo").setValue(T_submit_lift_embargo);
+        buttonPara.addButton("submit_lift_embargo").setValue(T_submit_lift_embargo);
         buttonPara.addButton("submit_return").setValue(T_submit_return);
     }
 

--- a/dspace/modules/xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -1440,7 +1440,7 @@ function doEditItemEmbargo(itemID)
 			// Our embargo has been updated.
 			result = FlowItemUtils.processEditEmbargo(getDSContext(),itemID,cocoon.request);
 		}
-        else if (cocoon.request.get("submit_lift_emabrgo"))
+        else if (cocoon.request.get("submit_lift_embargo"))
 		{
 			// Our embargo has been updated.
 			result = FlowItemUtils.processLiftEmbargo(getDSContext(),itemID,cocoon.request);

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -1409,4 +1409,38 @@ parameter that is being used (see variable defined above) -->
         </li>
     </xsl:template>
 
+    <!-- Add Confirmations to destructive buttons -->
+    <xsl:template match="//dri:field[@id='aspect.administrative.item.EditItemEmbargoForm.field.submit_lift_embargo']">
+        <!-- Adapted from normalField in dri2xhtml-alt/core/forms.xsl -->
+        <xsl:variable name="submitButtonId" select="translate(@id,'.','_')"/>
+        <input>
+            <xsl:call-template name="fieldAttributes"/>
+            <xsl:if test="@type='button'">
+                <xsl:attribute name="type">submit</xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="value">
+                <xsl:choose>
+                    <xsl:when test="./dri:value[@type='raw']">
+                        <xsl:value-of select="./dri:value[@type='raw']"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="./dri:value[@type='default']"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+            <xsl:if test="dri:value/i18n:text">
+                <xsl:attribute name="i18n:attr">value</xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="onclick">
+                <xsl:text>if(confirm('Are you sure you would like to lift this embargo now?')){ </xsl:text>
+                <xsl:text>  jQuery('#</xsl:text><!--
+                --><xsl:value-of select="$submitButtonId" /><!--
+                --><xsl:text>').submit(); } else {</xsl:text>
+                <xsl:text>return false;</xsl:text>
+                <xsl:text>}</xsl:text>
+            </xsl:attribute>
+            <xsl:apply-templates />
+        </input>
+    </xsl:template>
+
 </xsl:stylesheet>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -1409,8 +1409,8 @@ parameter that is being used (see variable defined above) -->
         </li>
     </xsl:template>
 
-    <!-- Add Confirmations to destructive buttons -->
-    <xsl:template match="//dri:field[@id='aspect.administrative.item.EditItemEmbargoForm.field.submit_lift_embargo']">
+    <xsl:template name="destructiveSubmitButton">
+      <xsl:param name="confirmationText" select="'Are you sure?'" />
         <!-- Adapted from normalField in dri2xhtml-alt/core/forms.xsl -->
         <xsl:variable name="submitButtonId" select="translate(@id,'.','_')"/>
         <input>
@@ -1432,7 +1432,9 @@ parameter that is being used (see variable defined above) -->
                 <xsl:attribute name="i18n:attr">value</xsl:attribute>
             </xsl:if>
             <xsl:attribute name="onclick">
-                <xsl:text>if(confirm('Are you sure you would like to lift this embargo now?')){ </xsl:text>
+                <xsl:text>if(confirm('</xsl:text><!--
+                --><xsl:value-of select="$confirmationText" /><!--
+                --><xsl:text>')){ </xsl:text>
                 <xsl:text>  jQuery('#</xsl:text><!--
                 --><xsl:value-of select="$submitButtonId" /><!--
                 --><xsl:text>').submit(); } else {</xsl:text>
@@ -1441,6 +1443,14 @@ parameter that is being used (see variable defined above) -->
             </xsl:attribute>
             <xsl:apply-templates />
         </input>
+    </xsl:template>
+
+    <!-- Add Confirmations to destructive buttons -->
+    <xsl:template match="//dri:field[@id='aspect.administrative.item.EditItemEmbargoForm.field.submit_lift_embargo']">
+        <xsl:call-template name="destructiveSubmitButton">
+            <xsl:with-param name="confirmationText" select="'Are you sure you would like to lift this embargo now?'" />
+        </xsl:call-template>
+
     </xsl:template>
 
 </xsl:stylesheet>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -1409,6 +1409,7 @@ parameter that is being used (see variable defined above) -->
         </li>
     </xsl:template>
 
+    <!-- Confirmations for destructive buttons -->
     <xsl:template name="destructiveSubmitButton">
       <xsl:param name="confirmationText" select="'Are you sure?'" />
         <!-- Adapted from normalField in dri2xhtml-alt/core/forms.xsl -->
@@ -1445,12 +1446,18 @@ parameter that is being used (see variable defined above) -->
         </input>
     </xsl:template>
 
-    <!-- Add Confirmations to destructive buttons -->
+    <!-- Confirm before lifting embargo -->
     <xsl:template match="//dri:field[@id='aspect.administrative.item.EditItemEmbargoForm.field.submit_lift_embargo']">
         <xsl:call-template name="destructiveSubmitButton">
             <xsl:with-param name="confirmationText" select="'Are you sure you would like to lift this embargo now?'" />
         </xsl:call-template>
+    </xsl:template>
 
+    <!-- Confirm before deleting data files in submission overview -->
+    <xsl:template match="//dri:field[starts-with(@id,'aspect.submission.submit.OverviewStep.field.submit_delete_dataset')]">
+        <xsl:call-template name="destructiveSubmitButton">
+            <xsl:with-param name="confirmationText" select="'Are you sure you would like to delete this Data file?'" />
+        </xsl:call-template>
     </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Adds an XSL template destructiveSubmitButton that uses JavaScript confirm() before submitting the form.

Feature described in https://trello.com/c/e0uQjkPP
