### PR TITLE
Add Publication DOI as an allowed element in metadata emails

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForManuscriptCentral.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForManuscriptCentral.java
@@ -69,6 +69,7 @@ public class EmailParserForManuscriptCentral extends EmailParser {
 	fieldToXMLTagTable.put("journal embargo period", "Journal_Embargo_Period");
 	fieldToXMLTagTable.put("ms dryad id","Manuscript");
 	fieldToXMLTagTable.put("ms reference number","Manuscript");
+        fieldToXMLTagTable.put("publication doi","Publication_DOI");
 	fieldToXMLTagTable.put("ms title","Article_Title");
 	fieldToXMLTagTable.put("ms authors","Authors");
 	fieldToXMLTagTable.put("contact author","Corresponding_Author");


### PR DESCRIPTION
This is to support the newly-defined [Publication DOI](http://wiki.datadryad.org/Journal_Metadata#Publication_DOI) field.
