### PR TITLE
Gmail API journal submit system

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2479,6 +2479,8 @@ solr.default.filter.override=location
 submit.journal.config=${default.submit.journal.config}
 
 submit.journal.credential.dir = ${dspace.dir}/submission/credential
+
+# Copy the json line for this property from dev.datadryad.org/gmail.settings.xml to your maven settings.xml
 submit.journal.clientsecrets = ${default.submit.journal.clientsecret}
 submit.journal.email = dryad.journal.submit@gmail.com
 submit.journal.email.label = journal-submit

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2478,6 +2478,9 @@ solr.default.filter.override=location
 # This configuration is set by the Maven profiles:
 submit.journal.config=${default.submit.journal.config}
 
+# this sets the frequency of the email harvester, in number of seconds.
+submit.journal.email.timer = ${default.submit.journal.email.timer}
+
 # Settings for Gmail account and associated OAuth stuff
 submit.journal.credential.dir = ${dspace.dir}/submission/credential
 submit.journal.email = ${default.submit.journal.email}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2481,7 +2481,7 @@ submit.journal.config=${default.submit.journal.config}
 # Settings for Gmail account and associated OAuth stuff
 submit.journal.credential.dir = ${dspace.dir}/submission/credential
 submit.journal.email = ${default.submit.journal.email}
-submit.journal.email.label = journal-submit
+submit.journal.email.label = ${default.submit.journal.label}
 submit.journal.email.testlabel = test_gmail_api
 
 # OAuth requires a clientsecret for the credential exchange, associated with the submit.journal.email gmail account.

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2478,12 +2478,18 @@ solr.default.filter.override=location
 # This configuration is set by the Maven profiles:
 submit.journal.config=${default.submit.journal.config}
 
+# Settings for Gmail account and associated OAuth stuff
 submit.journal.credential.dir = ${dspace.dir}/submission/credential
-
-# Copy the json line for this property from dev.datadryad.org/gmail.settings.xml to your maven settings.xml
-submit.journal.clientsecrets = ${default.submit.journal.clientsecret}
-submit.journal.email = dryad.journal.submit@gmail.com
+submit.journal.email = ${default.submit.journal.email}
 submit.journal.email.label = journal-submit
+submit.journal.email.testlabel = test_gmail_api
+
+# OAuth requires a clientsecret for the credential exchange, associated with the submit.journal.email gmail account.
+# The json can be obtained at https://console.developers.google.com/project/journal-submit/apiui/credential
+# and is the downloaded JSON for "Client ID for native application."
+# Copy the json line for this property from dev.datadryad.org/gmail.settings.xml to your maven settings.xml
+
+submit.journal.clientsecrets = ${default.submit.journal.clientsecret}
 
 # Location User will be directed to for submission.
 submit.dataset.collection=10255/2

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2478,6 +2478,11 @@ solr.default.filter.override=location
 # This configuration is set by the Maven profiles:
 submit.journal.config=${default.submit.journal.config}
 
+submit.journal.credential.dir = ${dspace.dir}/submission/credential
+submit.journal.clientsecrets = ${default.submit.journal.clientsecret}
+submit.journal.email = dryad.journal.submit@gmail.com
+submit.journal.email.label = journal-submit
+
 # Location User will be directed to for submission.
 submit.dataset.collection=10255/2
 submit.publications.collection=10255/3

--- a/dspace/modules/journal-submit/pom.xml
+++ b/dspace/modules/journal-submit/pom.xml
@@ -120,7 +120,18 @@
 		  <version>4.8.1</version>
 		  <scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.apis</groupId>
+			<artifactId>google-api-services-gmail</artifactId>
+			<version>v1-rev7-1.19.0</version>
+			<scope>compile</scope>
+		</dependency>
 
+		<dependency>
+			<groupId>com.google.api-client</groupId>
+			<artifactId>google-api-client</artifactId>
+			<version>1.19.0</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -106,6 +106,21 @@ public class DryadEmailSubmission extends HttpServlet {
                 LOGGER.info(e.getMessage());
                 throw new RuntimeException(e.getMessage());
             }
+        } else if (requestURI.contains("run")) {
+            try {
+                ArrayList<MimeMessage> messages = DryadGmailService.processJournalEmails();
+                if (messages != null) {
+                    for (MimeMessage message : messages) {
+                        try {
+                            processMimeMessage(message);
+                        } catch (Exception details) {
+                            LOGGER.info("Exception thrown: " + details.getMessage() + ", " + details.getClass().getName());
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.info("Exception thrown: " + e.getMessage() + ", " + e.getClass().getName());
+            }
         } else {
             aResponse.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
                     "GET is not supported, you must POST to this service");

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -28,19 +28,11 @@ import org.jdom.output.XMLOutputter;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.StringReader;
+import java.io.*;
 
+import java.lang.Exception;
+import java.lang.RuntimeException;
+import java.lang.String;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -78,17 +70,17 @@ public class DryadEmailSubmission extends HttpServlet {
      * Handles the HTTP <code>GET</code> method by informing the caller that
      * <code>GET</code> is not supported, only <code>POST</code>.
      *
-     * @param aRequest A servlet request
+     * @param aRequest  A servlet request
      * @param aResponse A servlet response
      * @throws ServletException If a servlet-specific error occurs
-     * @throws IOException If an I/O error occurs
+     * @throws IOException      If an I/O error occurs
      */
     @Override
     protected void doGet(HttpServletRequest aRequest,
-            HttpServletResponse aResponse) throws ServletException, IOException {
-        aResponse.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
-        "GET is not supported, you must POST to this service");
-    }
+                         HttpServletResponse aResponse) throws ServletException, IOException {
+            aResponse.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+                    "GET is not supported, you must POST to this service");
+        }
 
     /**
      * Handles the HTTP <code>POST</code> method.
@@ -96,127 +88,27 @@ public class DryadEmailSubmission extends HttpServlet {
      * @param aRequest A servlet request
      * @param aResponse A servlet response
      * @throws ServletException If a servlet-specific error occurs
-     * @throws IOException If an I/O error occurs
+     * @throws IOException      If an I/O error occurs
      */
     @Override
     protected void doPost(HttpServletRequest aRequest,
-            HttpServletResponse aResponse) throws ServletException, IOException {
-        PrintWriter toBrowser = getWriter(aResponse);
-        InputStream postBody = aRequest.getInputStream();
-        Session session = Session.getInstance(new Properties());
+                          HttpServletResponse aResponse) throws ServletException, IOException {
 
         LOGGER.info("Request encoding: " + aRequest.getCharacterEncoding());
+        }
 
         try {
             MimeMessage mime = new MimeMessage(session, postBody);
-            String contentType = mime.getContentType();
-            String encoding = mime.getEncoding();
-            String contentID = mime.getContentID();
-
-            LOGGER.info("MIME contentType/ID/encoding: " + contentType
-                        + " " + contentID + " " + encoding);
-
-            Part part = getTextPart(mime);
-            if (part == null){
-                throw new SubmissionException("Unexpected email type: "
-                        + mime.getContent().getClass().getName() + " reported content-type was " + contentType);
-            }
-
-            String message;
-            if (encoding != null) {
-                message = (String)part.getContent();
-            }
-            else {
-                InputStream in = part.getInputStream();
-                InputStreamReader isr = new InputStreamReader(in, "UTF-8");
-                BufferedReader br = new BufferedReader(isr);
-                StringBuilder builder = new StringBuilder();
-                String line;
-
-                while ((line = br.readLine()) != null) {
-                    builder.append(line);
-                    builder.append(System.getProperty("line.separator"));
-                }
-
-                message = builder.toString();
-            }
-
-            Address[] addresses = mime.getFrom();
-
-            // Then we can hand off to implementer of EmailParser
-            ParsingResult result = processMessage(message);
-
-            // Do this because this is what the parsers are expecting to
-            // build the corresponding author field from
-            for (Address address : addresses) {
-                message = "From: " + address.toString()
-                + System.getProperty("line.separator") + message;
-                result.setSenderEmailAddress(address.toString());
-            }
-
-            if (result.getStatus() != null) {
-                throw new SubmissionException(result.getStatus());
-            }
-
-            // isHas?
-            if (result.isHasFlawedId()) {
-                throw new SubmissionException("Result ID is flawed: "
-                        + result.getSubmissionId());
-            }
-
-            // We'll use JDOM b/c the libs are already included in DSpace
-            SAXBuilder saxBuilder = new SAXBuilder();
-            String xml = result.getSubmissionData().toString();
-
-            // FIXME: Individual Email parsers don't supply a root element
-            // Our JDOM classes below will add version, encoding, etc.
-            xml = "<DryadEmailSubmission>"
-                + System.getProperty("line.separator") + xml
-                + "</DryadEmailSubmission>";
-
-            StringReader xmlReader = new StringReader(xml);
-
-            try {
-                Format format = Format.getPrettyFormat();
-                XMLOutputter toFile = new XMLOutputter(format);
-                Document doc = saxBuilder.build(xmlReader);
-                String journalCode = result.getJournalCode();
-
-                LOGGER.debug("Getting metadata dir for " + journalCode);
-
-                PartnerJournal journal = myJournals.get(journalCode);
-
-                if (journal == null ) {
-                    throw new SubmissionRuntimeException("Journal (" + journalCode + ") not properly registered");
-                }
-
-                File dir = journal.getMetadataDir();
-                String submissionId = result.getSubmissionId();
-                String filename = DryadJournalSubmissionUtils.escapeFilename(submissionId + ".xml");
-                File file = new File(dir, filename);
-                FileOutputStream out = new FileOutputStream(file);
-                OutputStreamWriter writer = new OutputStreamWriter(out, "UTF-8");
-
-                // And we write the output to our submissions directory
-                toFile.output(doc, new BufferedWriter(writer));
-            }
-            catch (JDOMException details) {
-                LOGGER.debug(xml);
-
-                throw new SubmissionRuntimeException(details);
-            }
-
+            String xml = processMimeMessage(mime);
             // Nice to return our result in case we are debugging output
             toBrowser.println(xml);
             toBrowser.close();
-        }
-        catch (Exception details) {
+        } catch (Exception details) {
             sendEmailIfConfigured(details);
 
             if (details instanceof SubmissionException) {
                 throw (SubmissionException) details;
-            }
-            else {
+            } else {
                 throw new SubmissionException(details);
             }
         }
@@ -225,22 +117,22 @@ public class DryadEmailSubmission extends HttpServlet {
     /**
      * This method was added because multipart content may contain other multipart content; this
      * needs to dig down until some text is found
+     *
      * @param part Either the full message or a part
      * @return a part with text/plain content
      * @throws MessagingException
      * @throws IOException
      */
-    private Part getTextPart(Part part) throws MessagingException, IOException{
+    private Part getTextPart(Part part) throws MessagingException, IOException {
         String contentType = part.getContentType();
 
-        if (contentType != null && contentType.startsWith("text/plain")){
+        if (contentType != null && contentType.startsWith("text/plain")) {
             return part;   //
-        }
-        else if (contentType != null &&
+        } else if (contentType != null &&
                 contentType.startsWith("multipart/alternative") ||
-                contentType.startsWith("multipart/mixed")){    //could just use multipart as prefix, but what does this cover?
-            Multipart mp = (Multipart)part.getContent();
-            for (int i=0, count = mp.getCount();i<count;i++){
+                contentType.startsWith("multipart/mixed")) {    //could just use multipart as prefix, but what does this cover?
+            Multipart mp = (Multipart) part.getContent();
+            for (int i = 0, count = mp.getCount(); i < count; i++) {
                 Part p = mp.getBodyPart(i);
                 Part pt = getTextPart(p);
                 if (pt != null)
@@ -262,15 +154,14 @@ public class DryadEmailSubmission extends HttpServlet {
         if ((propFileName = System.getProperty(PROPERTIES_PROPERTY)) != null) {
             try {
                 props.load(new InputStreamReader(new FileInputStream(propFileName), "UTF-8"));
-            }
-            catch (IOException details) {
+            } catch (IOException details) {
                 throw new SubmissionException(details);
             }
 
         }
         // Otherwise, we're running in the standard DSpace Tomcat
         else {
-            if(!ConfigurationManager.isConfigured()) {
+            if (!ConfigurationManager.isConfigured()) {
                 // not configured
                 // Get config parameter
                 String config = getServletContext().getInitParameter("dspace.config");
@@ -289,8 +180,7 @@ public class DryadEmailSubmission extends HttpServlet {
 
             try {
                 props.load(new InputStreamReader(new FileInputStream(propFile), "UTF-8"));
-            }
-            catch (IOException details) {
+            } catch (IOException details) {
                 throw new SubmissionException(details);
             }
 
@@ -314,19 +204,16 @@ public class DryadEmailSubmission extends HttpServlet {
 
                     if (journals.containsKey(code)) {
                         journal = journals.get(code);
-                    }
-                    else {
+                    } else {
                         journal = new PartnerJournal(code);
                         journals.put(code, journal);
                     }
 
                     if (property.equals("parsingScheme")) {
                         journal.setParsingScheme(props.getProperty(propName));
-                    }
-                    else if (property.equals("metadataDir")) {
+                    } else if (property.equals("metadataDir")) {
                         journal.setMetadataDir(props.getProperty(propName));
-                    }
-                    else if (property.equals("fullname")) {
+                    } else if (property.equals("fullname")) {
                         journal.setFullName(props.getProperty(propName));
                     }
                     // else ignore
@@ -348,15 +235,15 @@ public class DryadEmailSubmission extends HttpServlet {
      * we can send email through there using their template system.
      *
      * @param aException An exception that was thrown in the process of
-     *        receiving a journal submission
+     *                   receiving a journal submission
      * @throws SubmissionException
      * @throws IOException
      */
     private void sendEmailIfConfigured(Exception aException)
-    throws SubmissionException {
+            throws SubmissionException {
         try {
             if (ConfigurationManager.isConfigured()) {
-                String exceptionMessage = aException.getMessage();
+                String exceptionMessage = aException.toString();
                 StringBuilder message = new StringBuilder(exceptionMessage);
                 String admin = ConfigurationManager.getProperty("mail.admin");
                 String logDir = ConfigurationManager.getProperty("log.dir");
@@ -364,7 +251,7 @@ public class DryadEmailSubmission extends HttpServlet {
 
                 if (logDir == null || admin == null) {
                     throw new SubmissionException(
-                    "DSpace mail is not properly configured");
+                            "DSpace mail is not properly configured");
                 }
 
                 for (StackTraceElement trace : aException.getStackTrace()) {
@@ -379,92 +266,186 @@ public class DryadEmailSubmission extends HttpServlet {
                 email.addArgument(logDir + "/journal-submit.log");
                 email.send();
             }
-        }
-        catch (Exception details) {
+        } catch (Exception details) {
             if (details instanceof SubmissionException) {
                 throw (SubmissionException) details;
-            }
-            else {
+            } else {
                 throw new SubmissionException(details);
             }
         }
     }
 
-    private ParsingResult processMessage(String aMessage)
-    throws SubmissionException {
+    private String processMimeMessage (MimeMessage mime) throws Exception {
+        LOGGER.info("MIME contentType/ID/encoding: " + mime.getContentType()
+                    + " " + mime.getContentID() + " " + mime.getEncoding());
+
+        Part part = getTextPart(mime);
+        if (part == null) {
+            throw new SubmissionException("Unexpected email type: "
+                    + mime.getContent().getClass().getName() + " reported content-type was " + mime.getContentType());
+        }
+
+        String message;
+        if (mime.getEncoding() != null) {
+            message = (String) part.getContent();
+        } else {
+            InputStream in = part.getInputStream();
+            InputStreamReader isr = new InputStreamReader(in, "UTF-8");
+            BufferedReader br = new BufferedReader(isr);
+            StringBuilder builder = new StringBuilder();
+            String line;
+
+            while ((line = br.readLine()) != null) {
+                builder.append(line);
+                builder.append(System.getProperty("line.separator"));
+            }
+
+            message = builder.toString();
+        }
+
+        // Then we can hand off to implementer of EmailParser
+        ParsingResult result = parseMessage(message, mime.getFrom());
+
+        if (result.getStatus() != null) {
+            throw new SubmissionException(result.getStatus());
+        }
+
+        // isHas?
+        if (result.isHasFlawedId()) {
+            throw new SubmissionException("Result ID is flawed: "
+                    + result.getSubmissionId());
+        }
+
+        return parseToXML(result);
+
+    }
+
+    private String parseToXML (ParsingResult result) {
+
+        // We'll use JDOM b/c the libs are already included in DSpace
+        SAXBuilder saxBuilder = new SAXBuilder();
+        String xml = result.getSubmissionData().toString();
+
+        // FIXME: Individual Email parsers don't supply a root element
+        // Our JDOM classes below will add version, encoding, etc.
+        xml = "<DryadEmailSubmission>"
+                + System.getProperty("line.separator") + xml
+                + "</DryadEmailSubmission>";
+
+        StringReader xmlReader = new StringReader(xml);
+
+        try {
+            Format format = Format.getPrettyFormat();
+            XMLOutputter toFile = new XMLOutputter(format);
+            Document doc = saxBuilder.build(xmlReader);
+            String journalCode = result.getJournalCode();
+
+            LOGGER.debug("Getting metadata dir for " + journalCode);
+
+            PartnerJournal journal = myJournals.get(journalCode);
+
+            if (journal == null) {
+                throw new SubmissionRuntimeException("Journal (" + journalCode + ") not properly registered");
+            }
+
+            File dir = journal.getMetadataDir();
+            String submissionId = result.getSubmissionId();
+            String filename = DryadJournalSubmissionUtils.escapeFilename(submissionId + ".xml");
+            File file = new File(dir, filename);
+            LOGGER.info ("wrote xml to file " + file.getAbsolutePath());
+            FileOutputStream out = new FileOutputStream(file);
+            OutputStreamWriter writer = new OutputStreamWriter(out, "UTF-8");
+
+            // And we write the output to our submissions directory
+            toFile.output(doc, new BufferedWriter(writer));
+        } catch (Exception details) {
+            LOGGER.debug(xml);
+            throw new SubmissionRuntimeException(details);
+        }
+        return xml;
+    }
+
+
+    private ParsingResult parseMessage(String aMessage, Address[] addresses)
+            throws SubmissionException {
         List<String> lines = new ArrayList<String>();
         Scanner emailScanner = new Scanner(aMessage);
         String journalName = null;
         String journalCode = null;
-
+        Pattern journalCodePattern = Pattern.compile("^\\s*>*\\s*(Journal Code):\\s*(.+)");
+        Pattern journalNamePattern = Pattern.compile("^\\s*>*\\s*(JOURNAL|Journal Name):\\s*(.+)");
+        boolean dryadContentStarted = false;
         while (emailScanner.hasNextLine()) {
             String line = emailScanner.nextLine();
 
             if (StringUtils.stripToEmpty(line).equals("")) {
                 continue;
-            }
-            else {
-                Pattern journalCodePattern = Pattern.compile("^(Journal Code):(.+)");
+            } else {
                 Matcher journalCodeMatcher = journalCodePattern.matcher(line);
-
-                if(journalCodeMatcher.find()) {
+                if (journalCodeMatcher.find()) {
                     journalCode = StringUtils.stripToEmpty(journalCodeMatcher.group(2));
                     // strip out leading NBSP if present
-                    if (journalCode.codePointAt(0) == 160){
+                    if (journalCode.codePointAt(0) == 160) {
                         journalCode = journalCode.substring(1);
                     }
+                    dryadContentStarted = true;
                 }
 
-                Pattern journalNamePattern = Pattern.compile("^(JOURNAL|Journal Name):(.+)");
                 Matcher journalNameMatcher = journalNamePattern.matcher(line);
-
                 if (journalNameMatcher.find()) {
                     journalName = StringUtils.stripToEmpty(journalNameMatcher.group(2));
-                    if (journalName.codePointAt(0) == 160){          //Journal of Heredity has started inserting NBSP in several fields, including journal title
+                    if (journalName.codePointAt(0) == 160) {          //Journal of Heredity has started inserting NBSP in several fields, including journal title
                         journalName = journalName.substring(1);
                     }
+                    dryadContentStarted = true;
                 }
 
+                if (dryadContentStarted) {
+                    lines.add(line);
+                }
                 // Stop reading lines at EndDryadContent
-                if(line.contains("EndDryadContent")) {
+                if (line.contains("EndDryadContent")) {
                     break;
                 }
-                lines.add(line);
             }
         }
-
         // After reading the entire message, attempt to find the PartnerJournal object by
         // Journal Code.  If Journal Code is not present, fall back to Journal Name
-        if(journalCode == null) {
+        if (journalCode == null) {
             LOGGER.debug("Journal Code not found in message, trying by journal name: " + journalName);
-            if(journalName != null) {
+            if (journalName != null) {
                 journalCode = myJournalNames.get(journalName);
             } else {
                 throw new SubmissionException("Journal Code not present and Journal Name not found in message");
             }
-            if(journalCode == null) {
+            if (journalCode == null) {
                 throw new SubmissionException("Journal Name " + journalName + " did not match a known Journal Code");
             }
         }
 
         if (journalCode != null) {
             PartnerJournal journal = myJournals.get(journalCode);
-            if (journal != null){
+            if (journal != null) {
                 EmailParser parser = journal.getParser();
                 ParsingResult result = parser.parseMessage(lines);
 
                 result.setJournalCode(journalCode);
                 result.setJournalName(journalName);
 
+                // Do this because this is what the parsers are expecting to
+                // build the corresponding author field from
+                for (Address address : addresses) {
+                    result.setSenderEmailAddress(address.toString());
+                }
+
                 return result;
-            }
-            else {
+            } else {
                 throw new SubmissionException("Journal " + journalCode + " not found in configuration");
             }
-        }
-        else {
+        } else {
             throw new SubmissionException("Journal code not found in message");
         }
+
     }
 
     private Map<String, PartnerJournal> validate(
@@ -476,8 +457,7 @@ public class DryadEmailSubmission extends HttpServlet {
             if (!journal.isComplete()) {
                 throw new SubmissionRuntimeException(journal.getName()
                         + "'s configuration isn't complete");
-            }
-            else {
+            } else {
                 // now store our metadata by the journal name instead of code
                 results.put(journalCode, journal);
             }
@@ -517,7 +497,7 @@ public class DryadEmailSubmission extends HttpServlet {
      * @throws IOException If there is trouble getting a writer
      */
     private PrintWriter getWriter(HttpServletResponse aResponse)
-    throws IOException {
+            throws IOException {
         aResponse.setContentType("xml/application; charset=UTF-8");
         return aResponse.getWriter();
     }

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -95,7 +95,6 @@ public class DryadEmailSubmission extends HttpServlet {
                           HttpServletResponse aResponse) throws ServletException, IOException {
 
         LOGGER.info("Request encoding: " + aRequest.getCharacterEncoding());
-        }
 
         try {
             MimeMessage mime = new MimeMessage(session, postBody);

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -25,8 +25,8 @@ import org.jdom.input.SAXBuilder;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -55,14 +55,13 @@ import java.util.regex.Pattern;
 
 /**
  * Email processing servlet.
- * 
+ *
  * @author Kevin S. Clarke <ksclarke@gmail.com>
  */
 @SuppressWarnings("serial")
 public class DryadEmailSubmission extends HttpServlet {
 
-    private static Logger LOGGER = LoggerFactory
-    .getLogger(DryadEmailSubmission.class);
+    private static final Logger LOGGER = Logger.getLogger(DryadEmailSubmission.class);
 
     private static String PROPERTIES_PROPERTY = "dryad.properties.filename";
 
@@ -70,15 +69,15 @@ public class DryadEmailSubmission extends HttpServlet {
 
     // Maps not concurrent but we only access, don't write to except at init()
     // map of Journal Codes to Journals
-    private static Map<String, PartnerJournal> myJournals; 
-    
+    private static Map<String, PartnerJournal> myJournals;
+
     // map of Journal Names to Journal Codes (in case code is not preent in submission)
     private static Map<String, String> myJournalNames;
 
     /**
      * Handles the HTTP <code>GET</code> method by informing the caller that
      * <code>GET</code> is not supported, only <code>POST</code>.
-     * 
+     *
      * @param aRequest A servlet request
      * @param aResponse A servlet response
      * @throws ServletException If a servlet-specific error occurs
@@ -93,7 +92,7 @@ public class DryadEmailSubmission extends HttpServlet {
 
     /**
      * Handles the HTTP <code>POST</code> method.
-     * 
+     *
      * @param aRequest A servlet request
      * @param aResponse A servlet response
      * @throws ServletException If a servlet-specific error occurs
@@ -106,9 +105,7 @@ public class DryadEmailSubmission extends HttpServlet {
         InputStream postBody = aRequest.getInputStream();
         Session session = Session.getInstance(new Properties());
 
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("Request encoding: " + aRequest.getCharacterEncoding());
-        }
+        LOGGER.info("Request encoding: " + aRequest.getCharacterEncoding());
 
         try {
             MimeMessage mime = new MimeMessage(session, postBody);
@@ -116,14 +113,12 @@ public class DryadEmailSubmission extends HttpServlet {
             String encoding = mime.getEncoding();
             String contentID = mime.getContentID();
 
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("MIME contentType/ID/encoding: " + contentType
+            LOGGER.info("MIME contentType/ID/encoding: " + contentType
                         + " " + contentID + " " + encoding);
-            }
 
             Part part = getTextPart(mime);
             if (part == null){
-                throw new SubmissionException("Unexpected email type: " 
+                throw new SubmissionException("Unexpected email type: "
                         + mime.getContent().getClass().getName() + " reported content-type was " + contentType);
             }
 
@@ -187,9 +182,7 @@ public class DryadEmailSubmission extends HttpServlet {
                 Document doc = saxBuilder.build(xmlReader);
                 String journalCode = result.getJournalCode();
 
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Getting metadata dir for " + journalCode);
-                }
+                LOGGER.debug("Getting metadata dir for " + journalCode);
 
                 PartnerJournal journal = myJournals.get(journalCode);
 
@@ -208,9 +201,7 @@ public class DryadEmailSubmission extends HttpServlet {
                 toFile.output(doc, new BufferedWriter(writer));
             }
             catch (JDOMException details) {
-                if (LOGGER.isErrorEnabled()) {
-                    LOGGER.debug(xml);
-                }
+                LOGGER.debug(xml);
 
                 throw new SubmissionRuntimeException(details);
             }
@@ -245,7 +236,7 @@ public class DryadEmailSubmission extends HttpServlet {
         if (contentType != null && contentType.startsWith("text/plain")){
             return part;   //
         }
-        else if (contentType != null && 
+        else if (contentType != null &&
                 contentType.startsWith("multipart/alternative") ||
                 contentType.startsWith("multipart/mixed")){    //could just use multipart as prefix, but what does this cover?
             Multipart mp = (Multipart)part.getContent();
@@ -276,10 +267,6 @@ public class DryadEmailSubmission extends HttpServlet {
                 throw new SubmissionException(details);
             }
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Using {} properties from {}", new Object[] {
-                        props.size(), propFileName });
-            }
         }
         // Otherwise, we're running in the standard DSpace Tomcat
         else {
@@ -289,7 +276,7 @@ public class DryadEmailSubmission extends HttpServlet {
                 String config = getServletContext().getInitParameter("dspace.config");
 
                 // Load in DSpace config
-                ConfigurationManager.loadConfig(config);                
+                ConfigurationManager.loadConfig(config);
             }
 
             String journalPropFile = ConfigurationManager.getProperty("submit.journal.config");
@@ -307,9 +294,6 @@ public class DryadEmailSubmission extends HttpServlet {
                 throw new SubmissionException(details);
             }
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Using properties from {}",propFile);
-            }
         }
 
         // Next, turn those properties into something we can use
@@ -351,9 +335,7 @@ public class DryadEmailSubmission extends HttpServlet {
             }
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Checking that all journals are correctly registered");
-        }
+        LOGGER.debug("Checking that all journals are correctly registered");
 
         // Returns validated map or throws an exception if there are problems
         myJournals = validate(journals);
@@ -364,7 +346,7 @@ public class DryadEmailSubmission extends HttpServlet {
     /**
      * If we're running within DSpace (and not the Maven/Jetty test instance),
      * we can send email through there using their template system.
-     * 
+     *
      * @param aException An exception that was thrown in the process of
      *        receiving a journal submission
      * @throws SubmissionException
@@ -418,10 +400,6 @@ public class DryadEmailSubmission extends HttpServlet {
         while (emailScanner.hasNextLine()) {
             String line = emailScanner.nextLine();
 
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace("line=" + line);
-            }
-
             if (StringUtils.stripToEmpty(line).equals("")) {
                 continue;
             }
@@ -436,7 +414,7 @@ public class DryadEmailSubmission extends HttpServlet {
                         journalCode = journalCode.substring(1);
                     }
                 }
-                
+
                 Pattern journalNamePattern = Pattern.compile("^(JOURNAL|Journal Name):(.+)");
                 Matcher journalNameMatcher = journalNamePattern.matcher(line);
 
@@ -468,7 +446,7 @@ public class DryadEmailSubmission extends HttpServlet {
                 throw new SubmissionException("Journal Name " + journalName + " did not match a known Journal Code");
             }
         }
-        
+
         if (journalCode != null) {
             PartnerJournal journal = myJournals.get(journalCode);
             if (journal != null){
@@ -504,11 +482,9 @@ public class DryadEmailSubmission extends HttpServlet {
                 results.put(journalCode, journal);
             }
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Registered journal: " + journal.toString());
-            }
+            LOGGER.debug("Registered journal: " + journal.toString());
         }
-        
+
         return results;
     }
 
@@ -525,7 +501,7 @@ public class DryadEmailSubmission extends HttpServlet {
 
     /**
      * Returns a short description of the servlet.
-     * 
+     *
      * @return a String containing servlet description
      */
     @Override
@@ -535,7 +511,7 @@ public class DryadEmailSubmission extends HttpServlet {
 
     /**
      * Returns a PrintWriter with the correct character encoding set.
-     * 
+     *
      * @param aResponse In which to set the character encoding
      * @return A <code>PrintWriter</code> to send text through
      * @throws IOException If there is trouble getting a writer

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -563,7 +563,7 @@ public class DryadEmailSubmission extends HttpServlet {
         @Override
         public void run() {
             ArrayList<String> labels = new ArrayList<String>();
-            labels.add("journal-submit");
+            labels.add(ConfigurationManager.getProperty("submit.journal.email.label"));
             try {
                 List<Message> messages = dryadGmailService.retrieveMessagesWithLabels(labels);
                 // Print ID of each Thread.

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -367,8 +367,7 @@ public class DryadEmailSubmission extends HttpServlet {
             throw new SubmissionException(result.getStatus());
         }
 
-        // isHas?
-        if (result.isHasFlawedId()) {
+        if (result.hasFlawedId()) {
             throw new SubmissionException("Result ID is flawed: "
                     + result.getSubmissionId());
         }

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -280,7 +280,8 @@ public class DryadEmailSubmission extends HttpServlet {
         LOGGER.debug("scheduling email harvesting");
         myEmailHarvester = new Timer();
         // schedule email harvesting to happen once an hour
-        myEmailHarvester.schedule(new DryadEmailSubmissionHarvester(), 0, 1000 * 60 * 60);
+        int timerInterval = Integer.parseInt(ConfigurationManager.getProperty("submit.journal.email.timer"));
+        myEmailHarvester.schedule(new DryadEmailSubmissionHarvester(), 0, 1000 * timerInterval);
     }
 
     /**

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -106,18 +106,7 @@ public class DryadEmailSubmission extends HttpServlet {
             return;
         } else if (requestURI.contains("test")) {
             try {
-                dryadGmailService = new DryadGmailService();
-                ArrayList<String> labels = new ArrayList<String>();
-                labels.add("test_gmail_api");
-                List<Message> messages = dryadGmailService.retrieveMessagesWithLabels(labels);
-                // Print ID of each Thread.
-                if (messages != null) {
-                    ArrayList<String> processedMessageIDs = new ArrayList<String>();
-                    LOGGER.info("got " + messages.size() + " test messages");
-                    for (Message message : messages) {
-                        LOGGER.info("Message: " + message.getId() + ", " + message.getSnippet());
-                    }
-                }
+                LOGGER.info(DryadGmailService.testMethod());
             } catch (IOException e) {
                 LOGGER.info(e.getMessage());
                 throw new RuntimeException(e.getMessage());

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -97,6 +97,9 @@ public class DryadEmailSubmission extends HttpServlet {
         LOGGER.info("Request encoding: " + aRequest.getCharacterEncoding());
 
         try {
+            PrintWriter toBrowser = getWriter(aResponse);
+            InputStream postBody = aRequest.getInputStream();
+            Session session = Session.getInstance(new Properties());
             MimeMessage mime = new MimeMessage(session, postBody);
             String xml = processMimeMessage(mime);
             // Nice to return our result in case we are debugging output

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -30,9 +30,6 @@ import org.apache.log4j.Logger;
 
 import java.io.*;
 
-import java.lang.Exception;
-import java.lang.RuntimeException;
-import java.lang.String;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -264,8 +264,8 @@ public class DryadEmailSubmission extends HttpServlet {
 
         LOGGER.debug("scheduling email harvesting");
         myEmailHarvester = new Timer();
-        // schedule email harvesting to happen once a day
-        myEmailHarvester.schedule(new DryadEmailSubmissionHarvester(), 0, 1000 * 60 * 60 * 24);
+        // schedule email harvesting to happen once an hour
+        myEmailHarvester.schedule(new DryadEmailSubmissionHarvester(), 0, 1000 * 60 * 60);
     }
 
     /**

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
@@ -112,7 +112,7 @@ public class DryadGmailService {
         DryadGmailService dryadGmailService = new DryadGmailService();
         // TEST CASE:
         ArrayList<String> labels = new ArrayList<String>();
-        labels.add("test_gmail_api");
+        labels.add(ConfigurationManager.getProperty("submit.journal.email.testlabel"));
 
         String result = "messages ";
 

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
@@ -161,10 +161,14 @@ public class DryadGmailService {
             }
         }
 
+        List<Message> messages = new ArrayList<Message>();
+        if (labelIDs.isEmpty()) {
+            return messages;
+        }
+
         ListMessagesResponse response = myGmailService.users().messages().list(myUserID)
                 .setLabelIds(labelIDs).execute();
 
-        List<Message> messages = new ArrayList<Message>();
         while (response.getMessages() != null) {
             messages.addAll(response.getMessages());
             if (response.getNextPageToken() != null) {

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
@@ -1,0 +1,213 @@
+package org.datadryad.submission;
+import org.dspace.core.*;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.auth.oauth2.*;
+import com.google.api.client.auth.oauth2.DataStoreCredentialRefreshListener;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.api.services.gmail.Gmail;
+import com.google.api.services.gmail.model.*;
+
+import java.lang.RuntimeException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+import java.io.*;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+public class DryadGmailService {
+    private static final Logger LOGGER = Logger.getLogger(DryadGmailService.class);
+    private static final String SCOPE = "https://www.googleapis.com/auth/gmail.modify";
+    private static final String APP_NAME = "Dryad Email Authorization";
+
+    private String myUserID;
+    private GoogleClientSecrets myClientSecrets;
+    private FileDataStoreFactory myDataStoreFactory;
+    private HttpTransport myHttpTransport;
+    private JsonFactory myJsonFactory;
+    private Credential myCredential;
+    private Gmail myGmailService;
+    private GoogleAuthorizationCodeFlow myAuthCodeFlow;
+
+    /**
+     * Instantiate a DryadGmailService object.
+     *
+     * @param credentialPath Path to the location of the clientSecretsFile and the credential DataStore.
+     * @param scope authorization scope
+     * @param user account to be authorized
+     * @throws IOException
+     */
+    public DryadGmailService(File credentialPath, String clientsecretsFile, String scope, String user) {
+        myUserID = user;
+        try {
+            myDataStoreFactory = new FileDataStoreFactory(credentialPath);
+            myHttpTransport = new NetHttpTransport();
+            myJsonFactory = new JacksonFactory();
+            myClientSecrets = GoogleClientSecrets.load(myJsonFactory, new StringReader (clientsecretsFile));
+
+        } catch (IOException e) {
+            throw new RuntimeException("Client secret loading failed; please check the file at "+ clientsecretsFile.toString());
+        }
+        try {
+            myAuthCodeFlow = new GoogleAuthorizationCodeFlow.Builder(myHttpTransport, myJsonFactory, myClientSecrets, Arrays.asList(scope))
+                    .setDataStoreFactory(myDataStoreFactory)
+                    .setAccessType("offline")
+                    .setApprovalPrompt("force")
+                    .addRefreshListener(new DataStoreCredentialRefreshListener(myUserID,myDataStoreFactory))
+                    .build();
+            myCredential = getMyCredential();
+        } catch (IOException e) {
+            throw new RuntimeException(e.toString());
+        }
+    }
+
+    // Default constructor builds a DryadGmailService for the dryad-journal-submit@gmail.com account
+    public DryadGmailService() {
+        this(new File(ConfigurationManager.getProperty("submit.journal.credential.dir")), ConfigurationManager.getProperty("submit.journal.clientsecrets").toString(), SCOPE, ConfigurationManager.getProperty("submit.journal.email"));
+    }
+
+    public void authorize (String code) {
+        GoogleAuthorizationCodeTokenRequest codeTokenRequest = myAuthCodeFlow.newTokenRequest(code);
+
+        try {
+            GoogleTokenResponse response = codeTokenRequest.setRedirectUri(GoogleOAuthConstants.OOB_REDIRECT_URI).execute();
+            myCredential = myAuthCodeFlow.createAndStoreCredential(response, myUserID);
+        } catch (IOException e) {
+            throw new RuntimeException("couldn't authorize: code was " + code + "\n" + e.toString());
+        }
+        return;
+    }
+
+    public String getAuthorizationURLString() {
+        return myAuthCodeFlow.newAuthorizationUrl().setRedirectUri(GoogleOAuthConstants.OOB_REDIRECT_URI).build();
+    }
+
+    public Credential getMyCredential() {
+        try {
+            return myAuthCodeFlow.loadCredential(myUserID);
+        } catch (IOException e) {
+            throw new RuntimeException("couldn't load credential: " + e.getMessage());
+        }
+    }
+
+    public Gmail getMyGmailService() {
+        if (myGmailService == null) {
+            // Create a new authorized Gmail API client
+            myGmailService = new Gmail.Builder(myHttpTransport, myJsonFactory, getMyCredential()).build();
+        }
+        return myGmailService;
+    }
+
+    public String getMyUserID() {
+        return myUserID;
+    }
+
+    public static String testMethod() throws IOException {
+        DryadGmailService dryadGmailService = new DryadGmailService();
+        // TEST CASE:
+        ArrayList<String> labels = new ArrayList<String>();
+        labels.add("test_gmail_api");
+
+        String result = "messages ";
+
+        List<Message> messages = dryadGmailService.listMessagesWithLabels(labels);
+        // Print ID of each Thread.
+        if (messages != null) {
+            for (Message m : messages) {
+                Message message = dryadGmailService.myGmailService.users().messages().get(dryadGmailService.myUserID, m.getId()).execute();
+                result = result + "\n" + message.getSnippet();
+            }
+        }
+        return result;
+    }
+
+    public List<Message> retrieveMessagesWithLabels (List<String> labels) throws IOException {
+        List<Message> messages = listMessagesWithLabels(labels);
+
+        ArrayList<Message> resultMessages = new ArrayList<Message>();
+        // Print ID of each Thread.
+        if (messages != null) {
+            for (Message m : messages) {
+                Message message = getMyGmailService().users().messages().get(getMyUserID(), m.getId()).setFormat("raw").execute();
+                resultMessages.add(message);
+            }
+        }
+        return resultMessages;
+    }
+
+    /**
+     * List all Messages of the user's mailbox with labelIds applied.
+     *
+     * @param labels Only return Messages with these labels applied.
+     * @throws IOException
+     */
+    private List<Message> listMessagesWithLabels(List<String> labels) throws IOException {
+        ArrayList<String> labelIDs = new ArrayList<String>();
+
+        ListLabelsResponse labelsResponse = getMyGmailService().users().labels().list(getMyUserID()).execute();
+        List<Label> labelList = labelsResponse.getLabels();
+        for (Label label : labelList) {
+            for (String labelName : labels) {
+                if (label.getName().equals(labelName)) {
+                    labelIDs.add(label.getId());
+                }
+            }
+        }
+
+        ListMessagesResponse response = myGmailService.users().messages().list(myUserID)
+                .setLabelIds(labelIDs).execute();
+
+        List<Message> messages = new ArrayList<Message>();
+        while (response.getMessages() != null) {
+            messages.addAll(response.getMessages());
+            if (response.getNextPageToken() != null) {
+                String pageToken = response.getNextPageToken();
+                response = myGmailService.users().messages().list(myUserID).setLabelIds(labelIDs)
+                        .setPageToken(pageToken).execute();
+            } else {
+                break;
+            }
+        }
+
+        return messages;
+    }
+
+    /**
+     * Modify the labels a message is associated with.
+     *
+     * @param messageId ID of Message to Modify.
+     * @param labelsToAdd List of label ids to add.
+     * @param labelsToRemove List of label ids to remove.
+     * @throws IOException
+     */
+    public void modifyMessage(String messageId, List<String> labelsToAdd, List<String> labelsToRemove) throws IOException {
+        ArrayList<String> labelIDsToAdd = new ArrayList<String>();
+        ArrayList<String> labelIDsToRemove = new ArrayList<String>();
+
+        ListLabelsResponse labelsResponse = myGmailService.users().labels().list(myUserID).execute();
+        List<Label> labelList = labelsResponse.getLabels();
+        for (Label label : labelList) {
+            for (String labelName : labelsToAdd) {
+                if (label.getName().equals(labelName)) {
+                    labelIDsToAdd.add(label.getId());
+                }
+            }
+            for (String labelName : labelsToRemove) {
+                if (label.getName().equals(labelName)) {
+                    labelIDsToRemove.add(label.getId());
+                }
+            }
+        }
+        ModifyMessageRequest mods = new ModifyMessageRequest().setAddLabelIds(labelIDsToAdd)
+                .setRemoveLabelIds(labelIDsToRemove);
+        Message message = myGmailService.users().messages().modify(myUserID, messageId, mods).execute();
+    }
+
+}
+

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
@@ -110,18 +110,19 @@ public class DryadGmailService {
 
     public static String testMethod() throws IOException {
         DryadGmailService dryadGmailService = new DryadGmailService();
-        // TEST CASE:
+
         ArrayList<String> labels = new ArrayList<String>();
         labels.add(ConfigurationManager.getProperty("submit.journal.email.testlabel"));
 
-        String result = "messages ";
+        String result = "";
 
-        List<Message> messages = dryadGmailService.listMessagesWithLabels(labels);
+        List<Message> messages = dryadGmailService.retrieveMessagesWithLabels(labels);
         // Print ID of each Thread.
         if (messages != null) {
-            for (Message m : messages) {
-                Message message = dryadGmailService.myGmailService.users().messages().get(dryadGmailService.myUserID, m.getId()).execute();
-                result = result + "\n" + message.getSnippet();
+            ArrayList<String> processedMessageIDs = new ArrayList<String>();
+            result = result + ("got " + messages.size() + " test messages");
+            for (Message message : messages) {
+                result = result + ("Message: " + message.getId() + ", " + message.getSnippet());
             }
         }
         return result;

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/ParsingResult.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/ParsingResult.java
@@ -28,19 +28,19 @@ public class ParsingResult {
 
 
     /** whether an parsed submission id is valid. */
-    private boolean hasFlawedId = false;
+    private boolean flawedId = false;
     /**
-     * @return the hasFlawedId
+     * @return the flawedId
      */
-    public boolean isHasFlawedId() {
-        return hasFlawedId;
+    public boolean hasFlawedId() {
+        return flawedId;
     }
 
     /**
-     * @param hasFlawedId the hasFlawedId to set
+     * @param flawedId the flawedId to set
      */
-    public void setHasFlawedId(boolean hasFlawedId) {
-        this.hasFlawedId = hasFlawedId;
+    public void setFlawedId(boolean flawedId) {
+        this.flawedId = flawedId;
     }
 
 
@@ -142,7 +142,7 @@ public class ParsingResult {
         return "********* ParsingResult: contents: start\n" + 
             "submissionId="+ submissionId + ",\n" +
             "senderEmailAddress=" + senderEmailAddress+ ",\n" +
-            "hasFlawedId="+hasFlawedId + ",\n"+
+            "flawedId="+ flawedId + ",\n"+
             "submissionData=" + submissionData.toString()
             + "\n********** ParsingResult: contents: end:\n";
     }

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/ParsingResult.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/ParsingResult.java
@@ -39,7 +39,7 @@ public class ParsingResult {
     /**
      * @param flawedId the flawedId to set
      */
-    public void setFlawedId(boolean flawedId) {
+    public void setHasFlawedId(boolean flawedId) {
         this.flawedId = flawedId;
     }
 

--- a/dspace/modules/journal-submit/src/main/webapp/WEB-INF/web.xml
+++ b/dspace/modules/journal-submit/src/main/webapp/WEB-INF/web.xml
@@ -25,7 +25,8 @@
 		<display-name>DryadEmailSubmission</display-name>
 		<servlet-name>DryadEmailSubmission</servlet-name>
 		<servlet-class>org.datadryad.submission.DryadEmailSubmission</servlet-class>
-	</servlet>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
 
 	<servlet-mapping>
 		<servlet-name>DryadEmailSubmission</servlet-name>


### PR DESCRIPTION
First draft of code to call Gmail's API directly to retrieve journal submission emails from the dryad.journal.submit@gmail.com email account.

In order to enable this functionality, you need to insert the json clientsecret in your machine's maven settings.xml. An example can be found at dev.datadryad.org:/home/dhdryad/gmail.settings.xml.

Testing and detailed configuration instructions can be found on the wiki: http://wiki.datadryad.org/Journal_Metadata_Processing_Technology