### PR TITLE
Expand subscribe_mailinglist template

### DIFF
--- a/dspace/config/emails/subscribe_mailinglist
+++ b/dspace/config/emails/subscribe_mailinglist
@@ -6,4 +6,4 @@
 #
 Subject: subscribe address={0}
 
-Please subscribe {0} to the dryad-announce mmailing list. Thanks!
+Please subscribe {0} to the dryad-announce mailing list. Thanks!

--- a/dspace/config/emails/subscribe_mailinglist
+++ b/dspace/config/emails/subscribe_mailinglist
@@ -5,3 +5,5 @@
 # See org.dspace.core.Email for information on the format of this file.
 #
 Subject: subscribe address={0}
+
+Please subscribe {0} to the dryad-announce mmailing list. Thanks!


### PR DESCRIPTION
The template needs more human-readable information. Now that the mailing list is
handled by Google Groups, there is no way to subscribe by simply sending an email.
I have configured the production server to send these emails to help@datadryad.org,
and they will be processed manually.
