### PR TITLE
Remove "extra" authentication from HIVE

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/datadryad/app/xmlui/aspect/ame/AMENavigation.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/app/xmlui/aspect/ame/AMENavigation.java
@@ -48,16 +48,8 @@ public class AMENavigation extends AbstractDSpaceTransformer implements Cacheabl
     		{
                 if(AuthorizeConfiguration.authorizeManage(this.context,"extract-meta",item))
                 {
-                    try
-                    {
-                        AuthorizeManager.authorizeAction(this.context, item.getCollections()[0].getCommunities()[0], Constants.ADMIN);
-
-                        context.setHead(T_context_head);
-                        context.addItem().addXref(contextPath+"/item/ame?itemID="+item.getID(), T_context_ame);
-                    }catch (AuthorizeException e)
-                    {
-
-                    }
+                    context.setHead(T_context_head);
+                    context.addItem().addXref(contextPath+"/item/ame?itemID="+item.getID(), T_context_ame);
                 }
             }
     	}


### PR DESCRIPTION
Since we recently modified the way the authentication system works,
this unneccessary authentication in the HIVE system has been causing
problems for curators. Curators were unable to navigate to certain
screens, such as the screen for editing bitstreams.
