### PR TITLE
Direct automated emails to automated-nofications list

### DIFF
--- a/dspace/config/DryadJournalSubmission.properties
+++ b/dspace/config/DryadJournalSubmission.properties
@@ -18,9 +18,9 @@ journal.amjbot.allowReviewWorkflow = true
 journal.amjbot.publicationBlackout = false
 journal.amjbot.subscriptionPaid = true
 journal.amjbot.sponsorName = The Botanical Society of America
-journal.amjbot.notifyOnReview = rhund@botany.org, amcpherson@botany.org, admin@datadryad.org, curator@datadryad.org
-journal.amjbot.notifyOnArchive = rhund@botany.org, amcpherson@botany.org, admin@datadryad.org, curator@datadryad.org
-journal.amjbot.notifyWeekly = rhund@botany.org, amcpherson@botany.org, admin@datadryad.org, curator@datadryad.org
+journal.amjbot.notifyOnReview = rhund@botany.org, amcpherson@botany.org, automated-messages@datadryad.org
+journal.amjbot.notifyOnArchive = rhund@botany.org, amcpherson@botany.org, automated-messages@datadryad.org
+journal.amjbot.notifyWeekly = rhund@botany.org, amcpherson@botany.org, automated-messages@datadryad.org
 
 
 # American Naturalist
@@ -34,8 +34,8 @@ journal.amNat.publicationBlackout = false
 journal.amNat.subscriptionPaid = true
 journal.amNat.sponsorName = American Society of Naturalists
 journal.amNat.notifyOnReview =
-journal.amNat.notifyOnArchive = pmorse@press.uchicago.edu, admin@datadryad.org, curator@datadryad.org
-journal.amNat.notifyWeekly = amnat@press.uchicago.edu, judieb@email.arizona.edu, whitlock@zoology.ubc.ca, admin@datadryad.org, curator@datadryad.org
+journal.amNat.notifyOnArchive = pmorse@press.uchicago.edu, automated-messages@datadryad.org
+journal.amNat.notifyWeekly = amnat@press.uchicago.edu, judieb@email.arizona.edu, whitlock@zoology.ubc.ca, automated-messages@datadryad.org
 
 # Applications in Plant Sciences
 journal.appPlantSci.fullname = Applications in Plant Sciences
@@ -47,9 +47,9 @@ journal.appPlantSci.allowReviewWorkflow = false
 journal.appPlantSci.publicationBlackout = true
 journal.appPlantSci.subscriptionPaid = true
 journal.appPlantSci.sponsorName = The Botanical Society of America
-journal.appPlantSci.notifyOnReview = apps@botany.org, bparada@botany.org, admin@datadryad.org, curator@datadryad.org
-journal.appPlantSci.notifyOnArchive = apps@botany.org, bparada@botany.org, admin@datadryad.org, curator@datadryad.org
-journal.appPlantSci.notifyWeekly = apps@botany.org, bparada@botany.org, admin@datadryad.org, curator@datadryad.org
+journal.appPlantSci.notifyOnReview = apps@botany.org, bparada@botany.org, automated-messages@datadryad.org
+journal.appPlantSci.notifyOnArchive = apps@botany.org, bparada@botany.org, automated-messages@datadryad.org
+journal.appPlantSci.notifyWeekly = apps@botany.org, bparada@botany.org, automated-messages@datadryad.org
 
 # Biodiversity Data Journal
 journal.BDJ.fullname = Biodiversity Data Journal
@@ -61,9 +61,9 @@ journal.BDJ.allowReviewWorkflow = false
 journal.BDJ.publicationBlackout = true
 journal.BDJ.subscriptionPaid = true
 journal.BDJ.sponsorName = Pensoft
-journal.BDJ.notifyOnReview = bdj@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.BDJ.notifyOnArchive = bdj@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.BDJ.notifyWeekly = bdj@pensoft.net, info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.BDJ.notifyOnReview = bdj@pensoft.net, automated-messages@datadryad.org
+journal.BDJ.notifyOnArchive = bdj@pensoft.net, automated-messages@datadryad.org
+journal.BDJ.notifyWeekly = bdj@pensoft.net, info@pensoft.net, automated-messages@datadryad.org
 
 # Biological Journal of the Linnean Society 
 journal.BJLS.fullname = Biological Journal of the Linnean Society
@@ -76,8 +76,8 @@ journal.BJLS.publicationBlackout = false
 journal.BJLS.subscriptionPaid = false
 journal.BJLS.sponsorName = 
 journal.BJLS.notifyOnReview = 
-journal.BJLS.notifyOnArchive = J.A.Allen@soton.ac.uk, BIJ@wiley.com, admin@datadryad.org, curator@datadryad.org
-journal.BJLS.notifyWeekly = J.A.Allen@soton.ac.uk, BIJ@wiley.com, admin@datadryad.org, curator@datadryad.org
+journal.BJLS.notifyOnArchive = J.A.Allen@soton.ac.uk, BIJ@wiley.com, automated-messages@datadryad.org
+journal.BJLS.notifyWeekly = J.A.Allen@soton.ac.uk, BIJ@wiley.com, automated-messages@datadryad.org
 
 # BIOLETTS
 journal.BIOLETTS.fullname = Biology Letters
@@ -90,8 +90,8 @@ journal.BIOLETTS.publicationBlackout = false
 journal.BIOLETTS.subscriptionPaid = true
 journal.BIOLETTS.sponsorName = The Royal Society
 journal.BIOLETTS.notifyOnReview = 
-journal.BIOLETTS.notifyOnArchive = biologyletters@royalsociety.org, admin@datadryad.org, curator@datadryad.org
-journal.BIOLETTS.notifyWeekly = biologyletters@royalsociety.org, admin@datadryad.org, curator@datadryad.org
+journal.BIOLETTS.notifyOnArchive = biologyletters@royalsociety.org, automated-messages@datadryad.org
+journal.BIOLETTS.notifyWeekly = biologyletters@royalsociety.org, automated-messages@datadryad.org
 
 # biorisk
 journal.biorisk.fullname = BioRisk
@@ -103,9 +103,9 @@ journal.biorisk.allowReviewWorkflow = true
 journal.biorisk.publicationBlackout = false
 journal.biorisk.subscriptionPaid = true
 journal.biorisk.sponsorName = Pensoft
-journal.biorisk.notifyOnReview = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.biorisk.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.biorisk.notifyWeekly= journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.biorisk.notifyOnReview = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.biorisk.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.biorisk.notifyWeekly= journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
 
 
 # BMC Evolutionary Biology
@@ -116,9 +116,9 @@ journal.BMCEvolBiol.integrated=true
 journal.BMCEvolBiol.allowReviewWorkflow=true
 journal.BMCEvolBiol.publicationBlackout=false
 journal.BMCEvolBiol.embargoAllowed = false
-journal.BMCEvolBiol.notifyOnArchive=Christopher.Foote@biomedcentral.com, admin@datadryad.org, curator@datadryad.org
-journal.BMCEvolBiol.notifyOnReview=Christopher.Foote@biomedcentral.com, admin@datadryad.org, curator@datadryad.org
-journal.BMCEvolBiol.notifyWeekly=Christopher.Foote@biomedcentral.com, amye.kenall@biomedcentral.com, admin@datadryad.org, curator@datadryad.org
+journal.BMCEvolBiol.notifyOnArchive=Christopher.Foote@biomedcentral.com, automated-messages@datadryad.org
+journal.BMCEvolBiol.notifyOnReview=Christopher.Foote@biomedcentral.com, automated-messages@datadryad.org
+journal.BMCEvolBiol.notifyWeekly=Christopher.Foote@biomedcentral.com, amye.kenall@biomedcentral.com, automated-messages@datadryad.org
 
 # BMC Ecology
 journal.BMCEcol.fullname = BMC Ecology
@@ -128,9 +128,9 @@ journal.BMCEcol.integrated=true
 journal.BMCEcol.allowReviewWorkflow=true
 journal.BMCEcol.publicationBlackout=false
 journal.BMCEcol.embargoAllowed = false
-journal.BMCEcol.notifyOnArchive=Simon.Harold@biomedcentral.com, admin@datadryad.org, curator@datadryad.org
-journal.BMCEcol.notifyOnReview=Simon.Harold@biomedcentral.com, admin@datadryad.org, curator@datadryad.org
-journal.BMCEcol.notifyWeekly=Simon.Harold@biomedcentral.com, amye.kenall@biomedcentral.com, admin@datadryad.org, curator@datadryad.org
+journal.BMCEcol.notifyOnArchive=Simon.Harold@biomedcentral.com, automated-messages@datadryad.org
+journal.BMCEcol.notifyOnReview=Simon.Harold@biomedcentral.com, automated-messages@datadryad.org
+journal.BMCEcol.notifyWeekly=Simon.Harold@biomedcentral.com, amye.kenall@biomedcentral.com, automated-messages@datadryad.org
 
 # BMJ Open
 journal.bmjOpen.fullname = BMJ Open
@@ -142,9 +142,9 @@ journal.bmjOpen.allowReviewWorkflow = true
 journal.bmjOpen.publicationBlackout = false
 journal.bmjOpen.subscriptionPaid = false
 journal.bmjOpen.sponsorName = BMJ Publishing Group
-journal.bmjOpen.notifyOnReview = editorial.bmjopen@bmjgroup.com, admin@datadryad.org, curator@datadryad.org
-journal.bmjOpen.notifyOnArchive = editorial.bmjopen@bmjgroup.com, admin@datadryad.org, curator@datadryad.org
-journal.bmjOpen.notifyWeekly = editorial.bmjopen@bmjgroup.com, RSands@bmjgroup.com, admin@datadryad.org, curator@datadryad.org
+journal.bmjOpen.notifyOnReview = editorial.bmjopen@bmjgroup.com, automated-messages@datadryad.org
+journal.bmjOpen.notifyOnArchive = editorial.bmjopen@bmjgroup.com, automated-messages@datadryad.org
+journal.bmjOpen.notifyWeekly = editorial.bmjopen@bmjgroup.com, RSands@bmjgroup.com, automated-messages@datadryad.org
 
 
 # Comparative Cytogenetics
@@ -157,9 +157,9 @@ journal.compcytogen.allowReviewWorkflow = true
 journal.compcytogen.publicationBlackout = false
 journal.compcytogen.subscriptionPaid = true
 journal.compcytogen.sponsorName = Pensoft
-journal.compcytogen.notifyOnReview = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.compcytogen.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.compcytogen.notifyWeekly = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.compcytogen.notifyOnReview = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.compcytogen.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.compcytogen.notifyWeekly = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
 
 
 # Deutsche Entomologische Zeitschrift
@@ -173,8 +173,8 @@ journal.DEZ.publicationBlackout = true
 journal.DEZ.subscriptionPaid = true
 journal.DEZ.sponsorName = Pensoft
 #journal.DEZ.notifyOnReview = 
-journal.DEZ.notifyOnArchive = layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.DEZ.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.DEZ.notifyOnArchive = layout@pensoft.net, automated-messages@datadryad.org
+journal.DEZ.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org
 
 # Ecography
 journal.ECOG.fullname = Ecography
@@ -183,8 +183,8 @@ journal.ECOG.parsingScheme = manuscriptCentral
 journal.ECOG.embargoAllowed = true
 journal.ECOG.integrated = true
 journal.ECOG.allowReviewWorkflow = false
-journal.ECOG.notifyOnArchive = ecography@Oikosoffice.lu.se, curator@datadryad.org
-journal.ECOG.notifyWeekly = ecography@Oikosoffice.lu.se, curator@datadryad.org
+journal.ECOG.notifyOnArchive = ecography@Oikosoffice.lu.se, automated-messages@datadryad.org
+journal.ECOG.notifyWeekly = ecography@Oikosoffice.lu.se, automated-messages@datadryad.org
 journal.ECOG.publicationBlackout = false
 journal.ECOG.subscriptionPaid = true
 journal.ECOG.sponsorName = Nordic Society Oikos
@@ -198,9 +198,9 @@ journal.ecap.embargoAllowed = true
 journal.ecap.allowReviewWorkflow = false
 journal.ecap.publicationBlackout = false
 journal.ecap.subscriptionPaid = false
-journal.ecap.notifyOnReview = esa_pubs@cornell.edu, rhp24@cornell.edu, admin@datadryad.org, curator@datadryad.org
-journal.ecap.notifyOnArchive = esa_pubs@cornell.edu, rhp24@cornell.edu, admin@datadryad.org, curator@datadryad.org
-journal.ecap.notifyWeekly = esa_pubs@cornell.edu, rhp24@cornell.edu, admin@datadryad.org, curator@datadryad.org
+journal.ecap.notifyOnReview = esa_pubs@cornell.edu, rhp24@cornell.edu, automated-messages@datadryad.org
+journal.ecap.notifyOnArchive = esa_pubs@cornell.edu, rhp24@cornell.edu, automated-messages@datadryad.org
+journal.ecap.notifyWeekly = esa_pubs@cornell.edu, rhp24@cornell.edu, automated-messages@datadryad.org
 
 
 # Ecological Monographs
@@ -213,9 +213,9 @@ journal.ecoMono.allowReviewWorkflow = false
 journal.ecoMono.publicationBlackout = false
 journal.ecoMono.subscriptionPaid = true
 journal.ecoMono.sponsorName = Ecological Society of America
-journal.ecoMono.notifyOnReview = esa_pubs@cornell.edu, rhp24@cornell.edu, eicem@fas.harvard.edu, admin@datadryad.org, curator@datadryad.org
-journal.ecoMono.notifyOnArchive = esa_pubs@cornell.edu, rhp24@cornell.edu, eicem@fas.harvard.edu, admin@datadryad.org, curator@datadryad.org
-journal.ecoMono.notifyWeekly = esa_pubs@cornell.edu, rhp24@cornell.edu, eicem@fas.harvard.edu, admin@datadryad.org, curator@datadryad.org
+journal.ecoMono.notifyOnReview = esa_pubs@cornell.edu, rhp24@cornell.edu, eicem@fas.harvard.edu, automated-messages@datadryad.org
+journal.ecoMono.notifyOnArchive = esa_pubs@cornell.edu, rhp24@cornell.edu, eicem@fas.harvard.edu, automated-messages@datadryad.org
+journal.ecoMono.notifyWeekly = esa_pubs@cornell.edu, rhp24@cornell.edu, eicem@fas.harvard.edu, automated-messages@datadryad.org
 
 
 # Ecology
@@ -227,9 +227,9 @@ journal.ecol.embargoAllowed = true
 journal.ecol.allowReviewWorkflow = false
 journal.ecol.publicationBlackout = true
 journal.ecol.subscriptionPaid = false
-journal.ecol.notifyOnReview = esa_pubs@cornell.edu, rhp24@cornell.edu, admin@datadryad.org, curator@datadryad.org
-journal.ecol.notifyOnArchive = esa_pubs@cornell.edu, rhp24@cornell.edu, admin@datadryad.org, curator@datadryad.org
-journal.ecol.notifyWeekly = esa_pubs@cornell.edu, rhp24@cornell.edu, admin@datadryad.org, curator@datadryad.org
+journal.ecol.notifyOnReview = esa_pubs@cornell.edu, rhp24@cornell.edu, automated-messages@datadryad.org
+journal.ecol.notifyOnArchive = esa_pubs@cornell.edu, rhp24@cornell.edu, automated-messages@datadryad.org
+journal.ecol.notifyWeekly = esa_pubs@cornell.edu, rhp24@cornell.edu, automated-messages@datadryad.org
 
 # Ecology Letters
 journal.ECOLETS.fullname = Ecology Letters
@@ -242,8 +242,8 @@ journal.ECOLETS.publicationBlackout = true
 journal.ECOLETS.subscriptionPaid = false
 journal.ECOLETS.sponsorName = 
 journal.ECOLETS.notifyOnReview =
-journal.ECOLETS.notifyOnArchive = maholyoak@ucdavis.edu, admin@datadryad.org, curator@datadryad.org
-journal.ECOLETS.notifyWeekly = maholyoak@ucdavis.edu, ecolets@univ-montp2.fr, admin@datadryad.org, curator@datadryad.org
+journal.ECOLETS.notifyOnArchive = maholyoak@ucdavis.edu, automated-messages@datadryad.org
+journal.ECOLETS.notifyWeekly = maholyoak@ucdavis.edu, ecolets@univ-montp2.fr, automated-messages@datadryad.org
 
 # Ecology and Evolution
 journal.ECE3.fullname = Ecology and Evolution
@@ -254,9 +254,9 @@ journal.ECE3.allowReviewWorkflow=false
 journal.ECE3.publicationBlackout=true
 journal.ECE3.subscriptionPaid = true
 journal.ECE3.sponsorName = Ecology and Evolution
-journal.ECE3.notifyOnArchive=ecoevo@wiley.com, ece@wiley.com, admin@datadryad.org, curator@datadryad.org
-journal.ECE3.notifyOnReview=ecoevo@wiley.com, admin@datadryad.org, curator@datadryad.org
-journal.ECE3.notifyWeekly=ecoevo@wiley.com, icaswell@wiley.com, ece@wiley.com, admin@datadryad.org, curator@datadryad.org
+journal.ECE3.notifyOnArchive=ecoevo@wiley.com, ece@wiley.com, automated-messages@datadryad.org
+journal.ECE3.notifyOnReview=ecoevo@wiley.com, automated-messages@datadryad.org
+journal.ECE3.notifyWeekly=ecoevo@wiley.com, icaswell@wiley.com, ece@wiley.com, automated-messages@datadryad.org
 
 # Elementa
 journal.Elementa.fullname = Elementa: Science of the Anthropocene
@@ -269,8 +269,8 @@ journal.Elementa.publicationBlackout = true
 journal.Elementa.subscriptionPaid = true
 journal.Elementa.sponsorName = Elementa: Science of the Anthropocene
 journal.Elementa.notifyOnReview =
-journal.Elementa.notifyOnArchive = lhladik@elementascience.org, mkurtz@elementascience.org, admin@datadryad.org, curator@datadryad.org
-journal.Elementa.notifyWeekly = lhladik@elementascience.org, mkurtz@elementascience.org, admin@datadryad.org, curator@datadryad.org
+journal.Elementa.notifyOnArchive = lhladik@elementascience.org, mkurtz@elementascience.org, automated-messages@datadryad.org
+journal.Elementa.notifyWeekly = lhladik@elementascience.org, mkurtz@elementascience.org, automated-messages@datadryad.org
 
 
 # eLife
@@ -283,9 +283,9 @@ journal.eLife.allowReviewWorkflow = true
 journal.eLife.publicationBlackout = true
 journal.eLife.subscriptionPaid = true
 journal.eLife.sponsorName = eLife
-journal.eLife.notifyOnReview = editorial@elifesciences.org, admin@datadryad.org, curator@datadryad.org
-journal.eLife.notifyOnArchive = editorial@elifesciences.org, admin@datadryad.org, curator@datadryad.org
-journal.eLife.notifyWeekly = editorial@elifesciences.org, admin@datadryad.org, curator@datadryad.org
+journal.eLife.notifyOnReview = editorial@elifesciences.org, automated-messages@datadryad.org
+journal.eLife.notifyOnArchive = editorial@elifesciences.org, automated-messages@datadryad.org
+journal.eLife.notifyWeekly = editorial@elifesciences.org, automated-messages@datadryad.org
 
 # Evolution
 journal.evolution.fullname = Evolution
@@ -298,8 +298,8 @@ journal.evolution.publicationBlackout = false
 journal.evolution.notifyOnReview = 
 journal.evolution.subscriptionPaid = true
 journal.evolution.sponsorName = Society for the Study of Evolution
-journal.evolution.notifyOnArchive = evoedoffice@wiley.com, admin@datadryad.org, curator@datadryad.org
-journal.evolution.notifyWeekly = evoedoffice@wiley.com, admin@datadryad.org, curator@datadryad.org
+journal.evolution.notifyOnArchive = evoedoffice@wiley.com, automated-messages@datadryad.org
+journal.evolution.notifyWeekly = evoedoffice@wiley.com, automated-messages@datadryad.org
 
 
 # Evolutionary Applications
@@ -313,8 +313,8 @@ journal.EvolApp.publicationBlackout = false
 journal.EvolApp.subscriptionPaid = true
 journal.EvolApp.sponsorName = Evolutionary Applications
 journal.EvolApp.notifyOnReview =
-journal.EvolApp.notifyOnArchive = sunderwood@wiley.com, evolappl@wiley.com, wechan@wiley.com, admin@datadryad.org, curator@datadryad.org
-journal.EvolApp.notifyWeekly = evolappl@wiley.com, wechan@wiley.com, admin@datadryad.org, curator@datadryad.org
+journal.EvolApp.notifyOnArchive = sunderwood@wiley.com, evolappl@wiley.com, wechan@wiley.com, automated-messages@datadryad.org
+journal.EvolApp.notifyWeekly = evolappl@wiley.com, wechan@wiley.com, automated-messages@datadryad.org
 
 
 # Faculty of 1000 Research
@@ -325,9 +325,9 @@ journal.EvolApp.notifyWeekly = evolappl@wiley.com, wechan@wiley.com, admin@datad
 #journal.F1000R.embargoAllowed = true
 #journal.F1000R.allowReviewWorkflow =
 #journal.F1000R.publicationBlackout = true
-#journal.F1000R.notifyOnReview = research@f1000.com, admin@datadryad.org, curator@datadryad.org
-#journal.F1000R.notifyOnArchive = research@f1000.com, admin@datadryad.org, curator@datadryad.org
-#journal.F1000R.notifyWeekly = research@f1000.com, admin@datadryad.org, curator@datadryad.org
+#journal.F1000R.notifyOnReview = research@f1000.com, automated-messages@datadryad.org
+#journal.F1000R.notifyOnArchive = research@f1000.com, automated-messages@datadryad.org
+#journal.F1000R.notifyWeekly = research@f1000.com, automated-messages@datadryad.org
 
 # Frontiers in Ecology and the Environment
 #journal.ecoFrontiers.fullname = Frontiers in Ecology and the Environment
@@ -351,9 +351,9 @@ journal.FE.allowReviewWorkflow = false
 journal.FE.publicationBlackout = true
 journal.FE.subscriptionPaid = true
 journal.FE.sponsorName = British Ecological Society
-journal.FE.notifyOnReview = managingeditor@functionalecology.org, admin@functionalecology.org, admin@datadryad.org, curator@datadryad.org
-journal.FE.notifyOnArchive = managingeditor@functionalecology.org, admin@functionalecology.org, admin@datadryad.org, curator@datadryad.org
-journal.FE.notifyWeekly = managingeditor@functionalecology.org, admin@functionalecology.org, admin@datadryad.org, curator@datadryad.org
+journal.FE.notifyOnReview = managingeditor@functionalecology.org, admin@functionalecology.org, automated-messages@datadryad.org
+journal.FE.notifyOnArchive = managingeditor@functionalecology.org, admin@functionalecology.org, automated-messages@datadryad.org
+journal.FE.notifyWeekly = managingeditor@functionalecology.org, admin@functionalecology.org, automated-messages@datadryad.org
 
 # GMS German Medical Science 
 journal.GMSGMS.fullname = GMS German Medical Science
@@ -365,9 +365,9 @@ journal.GMSGMS.allowReviewWorkflow = true
 journal.GMSGMS.publicationBlackout = false
 journal.GMSGMS.subscriptionPaid = true
 journal.GMSGMS.sponsorName = German National Library of Medicine
-journal.GMSGMS.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSGMS.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSGMS.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSGMS.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSGMS.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSGMS.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS German Plastic, Reconstructive and Aesthetic Surgery
 journal.GMSGPRAS.fullname = GMS German Plastic, Reconstructive and Aesthetic Surgery
@@ -379,9 +379,9 @@ journal.GMSGPRAS.allowReviewWorkflow = true
 journal.GMSGPRAS.publicationBlackout = true
 journal.GMSGPRAS.subscriptionPaid = true
 journal.GMSGPRAS.sponsorName = German National Library of Medicine
-journal.GMSGPRAS.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSGPRAS.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSGPRAS.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSGPRAS.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSGPRAS.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSGPRAS.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Health Technology Assessment
 journal.GMSHTA.fullname = GMS Health Technology Assessment
@@ -393,9 +393,9 @@ journal.GMSHTA.allowReviewWorkflow = true
 journal.GMSHTA.publicationBlackout = true
 journal.GMSHTA.subscriptionPaid = true
 journal.GMSHTA.sponsorName = German National Library of Medicine
-journal.GMSHTA.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSHTA.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSHTA.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSHTA.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSHTA.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSHTA.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Hygiene and Infection Control
 journal.GMSHIC.fullname = GMS Hygiene and Infection Control
@@ -407,9 +407,9 @@ journal.GMSHIC.allowReviewWorkflow = true
 journal.GMSHIC.publicationBlackout = true
 journal.GMSHIC.subscriptionPaid = true
 journal.GMSHIC.sponsorName = German National Library of Medicine
-journal.GMSHIC.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSHIC.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSHIC.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSHIC.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSHIC.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSHIC.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Infectious Diseases
 journal.GMSID.fullname = GMS Infectious Diseases
@@ -421,9 +421,9 @@ journal.GMSID.allowReviewWorkflow = true
 journal.GMSID.publicationBlackout = true
 journal.GMSID.subscriptionPaid = true
 journal.GMSID.sponsorName = German National Library of Medicine
-journal.GMSID.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSID.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSID.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSID.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSID.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSID.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Interdisciplinary Plastic and Reconstructive Surgery DGPW
 journal.GMSIPRS.fullname = GMS Interdisciplinary Plastic and Reconstructive Surgery DGPW
@@ -435,9 +435,9 @@ journal.GMSIPRS.allowReviewWorkflow = true
 journal.GMSIPRS.publicationBlackout = true
 journal.GMSIPRS.subscriptionPaid = true
 journal.GMSIPRS.sponsorName = German National Library of Medicine
-journal.GMSIPRS.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSIPRS.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSIPRS.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSIPRS.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSIPRS.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSIPRS.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Medizin - Bibliothek - Information
 journal.GMSMBI.fullname = GMS Medizin - Bibliothek - Information
@@ -449,9 +449,9 @@ journal.GMSMBI.allowReviewWorkflow = true
 journal.GMSMBI.publicationBlackout = true
 journal.GMSMBI.subscriptionPaid = true
 journal.GMSMBI.sponsorName = German National Library of Medicine
-journal.GMSMBI.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSMBI.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSMBI.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSMBI.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSMBI.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSMBI.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Medizinische Informatik, Biometrie und Epidemiologie
 journal.GMSMIBE.fullname = GMS Medizinische Informatik, Biometrie und Epidemiologie
@@ -463,9 +463,9 @@ journal.GMSMIBE.allowReviewWorkflow = true
 journal.GMSMIBE.publicationBlackout = true
 journal.GMSMIBE.subscriptionPaid = true
 journal.GMSMIBE.sponsorName = German National Library of Medicine
-journal.GMSMIBE.notifyOnReview = gms@zbmed.de, curator@datadryad.org, admin@datadryad.org
-journal.GMSMIBE.notifyOnArchive = gms@zbmed.de, curator@datadryad.org, admin@datadryad.org
-journal.GMSMIBE.notifyWeekly = gms@zbmed.de, curator@datadryad.org, admin@datadryad.org
+journal.GMSMIBE.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSMIBE.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSMIBE.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Onkologische Rehabilitation und Sozialmedizin
 journal.GMSORS.fullname = GMS Onkologische Rehabilitation und Sozialmedizin
@@ -477,9 +477,9 @@ journal.GMSORS.allowReviewWorkflow = true
 journal.GMSORS.publicationBlackout = true
 journal.GMSORS.subscriptionPaid = true
 journal.GMSORS.sponsorName = German National Library of Medicine
-journal.GMSORS.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSORS.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSORS.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSORS.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSORS.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSORS.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Zeitschrift für Medizinische Ausbildung
 journal.GMSZMA.fullname = GMS Zeitschrift für Medizinische Ausbildung
@@ -491,9 +491,9 @@ journal.GMSZMA.allowReviewWorkflow = true
 journal.GMSZMA.publicationBlackout = true
 journal.GMSZMA.subscriptionPaid = true
 journal.GMSZMA.sponsorName = German National Library of Medicine
-journal.GMSZMA.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSZMA.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSZMA.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSZMA.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSZMA.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSZMA.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Zeitschrift zur Förderung der Qualitätssicherung in medizinischen Laboratorien
 journal.GMSLAB.fullname = GMS Zeitschrift zur Förderung der Qualitätssicherung in medizinischen Laboratorien
@@ -505,9 +505,9 @@ journal.GMSLAB.allowReviewWorkflow = true
 journal.GMSLAB.publicationBlackout = true
 journal.GMSLAB.subscriptionPaid = true
 journal.GMSLAB.sponsorName = German National Library of Medicine
-journal.GMSLAB.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSLAB.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-journal.GMSLAB.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+journal.GMSLAB.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSLAB.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+journal.GMSLAB.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 
 # Heredity
@@ -521,8 +521,8 @@ journal.heredity.publicationBlackout = false
 journal.heredity.subscriptionPaid = true
 journal.heredity.sponsorName = The Genetics Society
 journal.heredity.notifyOnReview =
-journal.heredity.notifyOnArchive = heredity@cardiff.ac.uk, admin@datadryad.org, curator@datadryad.org
-journal.heredity.notifyWeekly = R.Vickerstaff@nature.com,  heredity@cardiff.ac.uk, admin@datadryad.org, curator@datadryad.org
+journal.heredity.notifyOnArchive = heredity@cardiff.ac.uk, automated-messages@datadryad.org
+journal.heredity.notifyWeekly = R.Vickerstaff@nature.com,  heredity@cardiff.ac.uk, automated-messages@datadryad.org
 
 # Interface Focus 
 journal.intF.fullname = Interface Focus 
@@ -547,9 +547,9 @@ journal.ijm.integrated = true
 journal.ijm.embargoAllowed = true
 journal.ijm.allowReviewWorkflow = true
 journal.ijm.publicationBlackout = false
-journal.ijm.notifyOnReview = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.ijm.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.ijm.notifyWeekly = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.ijm.notifyOnReview = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.ijm.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.ijm.notifyWeekly = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
 
 
 # Integrative and Comparative Biology
@@ -576,8 +576,8 @@ journal.EvolBiol.publicationBlackout = false
 journal.EvolBiol.subscriptionPaid = true
 journal.EvolBiol.sponsorName = European Society for Evolutionary Biology
 journal.EvolBiol.notifyOnReview =
-journal.EvolBiol.notifyOnArchive = jebeditorial@eseb.org, jeb@wiley.com, admin@datadryad.org, curator@datadryad.org
-journal.EvolBiol.notifyWeekly = jebeditorial@eseb.org, jeb@wiley.com, mgr@st-andrews.ac.uk, admin@datadryad.org, curator@datadryad.org
+journal.EvolBiol.notifyOnArchive = jebeditorial@eseb.org, jeb@wiley.com, automated-messages@datadryad.org
+journal.EvolBiol.notifyWeekly = jebeditorial@eseb.org, jeb@wiley.com, mgr@st-andrews.ac.uk, automated-messages@datadryad.org
 
 
 # Journal of Animal Ecology
@@ -591,8 +591,8 @@ journal.JAE.publicationBlackout = true
 journal.JAE.subscriptionPaid = true
 journal.JAE.sponsorName = British Ecological Society
 journal.JAE.notifyOnReview =
-journal.JAE.notifyOnArchive = managingeditor@journalofanimalecology.org, admin@journalofanimalecology.org, curator@datadryad.org, admin@datadryad.org 
-journal.JAE.notifyWeekly = managingeditor@journalofanimalecology.org, admin@journalofanimalecology.org, curator@datadryad.org, admin@datadryad.org 
+journal.JAE.notifyOnArchive = managingeditor@journalofanimalecology.org, admin@journalofanimalecology.org, automated-messages@datadryad.org 
+journal.JAE.notifyWeekly = managingeditor@journalofanimalecology.org, admin@journalofanimalecology.org, automated-messages@datadryad.org 
 
 
 # Journal of Applied Ecology
@@ -606,8 +606,8 @@ journal.JAPPL.publicationBlackout = true
 journal.JAPPL.subscriptionPaid = true
 journal.JAPPL.sponsorName = British Ecological Society
 journal.JAPPL.notifyOnReview =
-journal.JAPPL.notifyOnArchive = managingeditor@journalofappliedecology.org, admin@journalofappliedecology.org, admin@datadryad.org, curator@datadryad.org
-journal.JAPPL.notifyWeekly = admin@journalofappliedecology.org, managingeditor@journalofappliedecology.org, admin@datadryad.org, curator@datadryad.org
+journal.JAPPL.notifyOnArchive = managingeditor@journalofappliedecology.org, admin@journalofappliedecology.org, automated-messages@datadryad.org
+journal.JAPPL.notifyWeekly = admin@journalofappliedecology.org, managingeditor@journalofappliedecology.org, automated-messages@datadryad.org
 
 # Journal of Avian Biology
 journal.JAV.fullname = Journal of Avian Biology
@@ -616,8 +616,8 @@ journal.JAV.parsingScheme = manuscriptCentral
 journal.JAV.embargoAllowed = true
 journal.JAV.integrated=true
 journal.JAV.allowReviewWorkflow=false
-journal.JAV.notifyOnArchive = jab@oikosoffice.lu.se, curator@datadryad.org
-journal.JAV.notifyWeekly = jab@oikosoffice.lu.se, curator@datadryad.org
+journal.JAV.notifyOnArchive = jab@oikosoffice.lu.se, automated-messages@datadryad.org
+journal.JAV.notifyWeekly = jab@oikosoffice.lu.se, automated-messages@datadryad.org
 journal.JAV.publicationBlackout=false
 journal.JAV.subscriptionPaid = true
 journal.JAV.sponsorName = Nordic Society Oikos
@@ -647,8 +647,8 @@ journal.JECOL.publicationBlackout=true
 journal.JECOL.subscriptionPaid = true
 journal.JECOL.sponsorName = British Ecological Society
 journal.JECOL.notifyOnReview =
-journal.JECOL.notifyOnArchive = managingeditor@journalofecology.org, admin@journalofecology.org, admin@datadryad.org, curator@datadryad.org
-journal.JECOL.notifyWeekly = admin@journalofecology.org, managingeditor@journalofecology.org, admin@datadryad.org, curator@datadryad.org
+journal.JECOL.notifyOnArchive = managingeditor@journalofecology.org, admin@journalofecology.org, automated-messages@datadryad.org
+journal.JECOL.notifyWeekly = admin@journalofecology.org, managingeditor@journalofecology.org, automated-messages@datadryad.org
 
 
 # Journal of Fish and Wildlife Management
@@ -661,9 +661,9 @@ journal.jfwm.allowReviewWorkflow = true
 journal.jfwm.publicationBlackout = false
 journal.jfwm.subscriptionPaid = true
 journal.jfwm.sponsorName = U.S. Fish and Wildlife Service
-journal.jfwm.notifyOnReview = anne_post@fws.gov, john_wenburg@fws.gov, jcigard@allenpress.com, curator@datadryad.org, admin@datadryad.org
-journal.jfwm.notifyOnArchive = anne_post@fws.gov, john_wenburg@fws.gov, jcigard@allenpress.com, admin@datadryad.org, curator@datadryad.org
-journal.jfwm.notifyWeekly = anne_post@fws.gov, scipublishing@fws.gov, John_Wenburg@fws.gov, jcigard@allenpress.com, admin@datadryad.org, curator@datadryad.org 
+journal.jfwm.notifyOnReview = anne_post@fws.gov, john_wenburg@fws.gov, jcigard@allenpress.com, automated-messages@datadryad.org
+journal.jfwm.notifyOnArchive = anne_post@fws.gov, john_wenburg@fws.gov, jcigard@allenpress.com, automated-messages@datadryad.org
+journal.jfwm.notifyWeekly = anne_post@fws.gov, scipublishing@fws.gov, John_Wenburg@fws.gov, jcigard@allenpress.com, automated-messages@datadryad.org 
 
 # Journal of Heredity
 journal.jhered.fullname = Journal of Heredity
@@ -676,8 +676,8 @@ journal.jhered.publicationBlackout = false
 journal.jhered.subscriptionPaid = true
 journal.jhered.sponsorName = American Genetic Association
 journal.jhered.notifyOnReview = 
-journal.jhered.notifyOnArchive = jhered@oup.com, AGAJOH@oregonstate.edu, admin@datadryad.org, curator@datadryad.org
-journal.jhered.notifyWeekly = agajoh@oregonstate.edu, scott.baker@oregonstate.edu,  admin@datadryad.org, curator@datadryad.org
+journal.jhered.notifyOnArchive = jhered@oup.com, AGAJOH@oregonstate.edu, automated-messages@datadryad.org
+journal.jhered.notifyWeekly = agajoh@oregonstate.edu, scott.baker@oregonstate.edu,  automated-messages@datadryad.org
 
 
 # Journal of Hymenoptera Research
@@ -691,8 +691,8 @@ journal.jhr.publicationBlackout = false
 journal.jhr.subscriptionPaid = true
 journal.jhr.sponsorName = Pensoft
 journal.jhr.notifyOnReview =
-journal.jhr.notifyOnArchive = jhr@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.jhr.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.jhr.notifyOnArchive = jhr@pensoft.net, automated-messages@datadryad.org
+journal.jhr.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org
 
 # Journal of Open Public Health Data
 journal.JOPHD.fullname = Journal of Open Public Health Data
@@ -702,9 +702,9 @@ journal.JOPHD.integrated = true
 journal.JOPHD.embargoAllowed = true
 journal.JOPHD.allowReviewWorkflow = true
 journal.JOPHD.publicationBlackout = false
-journal.JOPHD.notifyOnReview = editor.jophd@ubiquitypress.com, admin@datadryad.org, curator@datadryad.org
-journal.JOPHD.notifyOnArchive = editor.jophd@ubiquitypress.com, admin@datadryad.org, curator@datadryad.org
-journal.JOPHD.notifyWeekly = brian.hole@ubiquitypress.com, editor.jophd@ubiquitypress.com, admin@datadryad.org, curator@datadryad.org
+journal.JOPHD.notifyOnReview = editor.jophd@ubiquitypress.com, automated-messages@datadryad.org
+journal.JOPHD.notifyOnArchive = editor.jophd@ubiquitypress.com, automated-messages@datadryad.org
+journal.JOPHD.notifyWeekly = brian.hole@ubiquitypress.com, editor.jophd@ubiquitypress.com, automated-messages@datadryad.org
 
 
 # Journal of Paleontology
@@ -717,9 +717,9 @@ journal.JPALEO.allowReviewWorkflow = true
 journal.JPALEO.publicationBlackout = false
 journal.JPALEO.subscriptionPaid = true
 journal.JPALEO.sponsorName = The Paleontological Society
-journal.JPALEO.notifyOnReview = hagemansj@appstate.edu, admin@datadryad.org, curator@datadryad.org
-journal.JPALEO.notifyOnArchive = km.huber@verizon.net, hagemansj@appstate.edu, admin@datadryad.org, curator@datadryad.org
-journal.JPALEO.notifyWeekly = km.huber@verizon.net, hagemansj@appstate.edu, admin@datadryad.org, curator@datadryad.org
+journal.JPALEO.notifyOnReview = hagemansj@appstate.edu, automated-messages@datadryad.org
+journal.JPALEO.notifyOnArchive = km.huber@verizon.net, hagemansj@appstate.edu, automated-messages@datadryad.org
+journal.JPALEO.notifyWeekly = km.huber@verizon.net, hagemansj@appstate.edu, automated-messages@datadryad.org
 
 # Journal of the Royal Society Interface 
 journal.jRoyalInt.fullname = Journal of the Royal Society Interface
@@ -759,8 +759,8 @@ journal.MEE.publicationBlackout = true
 journal.MEE.subscriptionPaid = true
 journal.MEE.sponsorName = British Ecological Society
 journal.MEE.notifyOnReview =
-journal.MEE.notifyOnArchive = coordinator@methodsinecologyandevolution.org, admin@datadryad.org, curator@datadryad.org
-journal.MEE.notifyWeekly = coordinator@methodsinecologyandevolution.org, admin@datadryad.org, curator@datadryad.org
+journal.MEE.notifyOnArchive = coordinator@methodsinecologyandevolution.org, automated-messages@datadryad.org
+journal.MEE.notifyWeekly = coordinator@methodsinecologyandevolution.org, automated-messages@datadryad.org
 
 # Molecular Ecology
 journal.MolEcol.fullname = Molecular Ecology
@@ -772,9 +772,9 @@ journal.MolEcol.allowReviewWorkflow = true
 journal.MolEcol.publicationBlackout = false
 journal.MolEcol.subscriptionPaid = true
 journal.MolEcol.sponsorName = Molecular Ecology
-journal.MolEcol.notifyOnReview = ryan-molecol@scherle.org, editorial.office@molecol.com, managing.editor@molecol.com, admin@datadryad.org, curator@datadryad.org
-journal.MolEcol.notifyOnArchive = editorial.office@molecol.com, admin@datadryad.org, curator@datadryad.org
-journal.MolEcol.notifyWeekly = editorial.office@molecol.com, managing.editor@molecol.com, admin@datadryad.org, curator@datadryad.org
+journal.MolEcol.notifyOnReview = ryan-molecol@scherle.org, editorial.office@molecol.com, managing.editor@molecol.com, automated-messages@datadryad.org
+journal.MolEcol.notifyOnArchive = editorial.office@molecol.com, automated-messages@datadryad.org
+journal.MolEcol.notifyWeekly = editorial.office@molecol.com, managing.editor@molecol.com, automated-messages@datadryad.org
 
 
 # Molecular Ecology Resources
@@ -787,9 +787,9 @@ journal.MolEcolRes.allowReviewWorkflow = true
 journal.MolEcolRes.publicationBlackout = false
 journal.MolEcolRes.subscriptionPaid = true
 journal.MolEcolRes.sponsorName = Molecular Ecology Resources
-journal.MolEcolRes.notifyOnReview = editorial.office@molecol.com, managing.editor@molecol.com, admin@datadryad.org, curator@datadryad.org
-journal.MolEcolRes.notifyOnArchive = editorial.office@molecol.com, admin@datadryad.org, curator@datadryad.org
-journal.MolEcolRes.notifyWeekly = editorial.office@molecol.com, managing.editor@molecol.com, admin@datadryad.org, curator@datadryad.org
+journal.MolEcolRes.notifyOnReview = editorial.office@molecol.com, managing.editor@molecol.com, automated-messages@datadryad.org
+journal.MolEcolRes.notifyOnArchive = editorial.office@molecol.com, automated-messages@datadryad.org
+journal.MolEcolRes.notifyWeekly = editorial.office@molecol.com, managing.editor@molecol.com, automated-messages@datadryad.org
 
 
 # Molecular Phylogenetics and Evolution
@@ -814,9 +814,9 @@ journal.mycokeys.allowReviewWorkflow = true
 journal.mycokeys.publicationBlackout = true
 journal.mycokeys.subscriptionPaid = true
 journal.mycokeys.sponsorName = Pensoft
-journal.mycokeys.notifyOnReview = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.mycokeys.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.mycokeys.notifyWeekly= journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.mycokeys.notifyOnReview = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.mycokeys.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.mycokeys.notifyWeekly= journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
 
 
 # Nature Conservation
@@ -829,9 +829,9 @@ journal.natureconservation.allowReviewWorkflow = true
 journal.natureconservation.publicationBlackout = false
 journal.natureconservation.subscriptionPaid = true
 journal.natureconservation.sponsorName = Pensoft
-journal.natureconservation.notifyOnReview = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.natureconservation.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.natureconservation.notifyWeekly= journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.natureconservation.notifyOnReview = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.natureconservation.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.natureconservation.notifyWeekly= journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
 
 
 # neobiota
@@ -844,9 +844,9 @@ journal.neobiota.allowReviewWorkflow = true
 journal.neobiota.publicationBlackout = false
 journal.neobiota.subscriptionPaid = true
 journal.neobiota.sponsorName = Pensoft
-journal.neobiota.notifyOnReview = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.neobiota.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.neobiota.notifyWeekly = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.neobiota.notifyOnReview = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.neobiota.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.neobiota.notifyWeekly = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
 
 # Nordic Journal of Botany
 journal.NJB.fullname = Nordic Journal of Botany
@@ -855,8 +855,8 @@ journal.NJB.parsingScheme = manuscriptCentral
 journal.NJB.embargoAllowed = true
 journal.NJB.integrated= true
 journal.NJB.allowReviewWorkflow= false
-journal.NJB.notifyOnArchive = njb@oikosoffice.lu.se, curator@datadryad.org, admin@datadryad.org
-journal.NJB.notifyWeekly = njb@oikosoffice.lu.se, curator@datadryad.org, admin@datadryad.org
+journal.NJB.notifyOnArchive = njb@oikosoffice.lu.se, automated-messages@datadryad.org
+journal.NJB.notifyWeekly = njb@oikosoffice.lu.se, automated-messages@datadryad.org
 journal.NJB.publicationBlackout= false
 journal.NJB.subscriptionPaid = true
 journal.NJB.sponsorName = Nordic Society Oikos
@@ -872,8 +872,8 @@ journal.NL.publicationBlackout = true
 journal.NL.subscriptionPaid = true
 journal.NL.sponsorName = Pensoft
 #journal.NL.notifyOnReview = 
-journal.NL.notifyOnArchive = layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.NL.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.NL.notifyOnArchive = layout@pensoft.net, automated-messages@datadryad.org
+journal.NL.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org
 
 # Oikos
 journal.OIK.fullname = Oikos
@@ -882,8 +882,8 @@ journal.OIK.parsingScheme = manuscriptCentral
 journal.OIK.embargoAllowed = true
 journal.OIK.integrated= true
 journal.OIK.allowReviewWorkflow= false
-journal.OIK.notifyOnArchive = oikos@oikosoffice.lu.se, curator@datadryad.org, admin@datadryad.org
-journal.OIK.notifyWeekly = oikos@oikosoffice.lu.se, curator@datadryad.org, admin@datadryad.org
+journal.OIK.notifyOnArchive = oikos@oikosoffice.lu.se, automated-messages@datadryad.org
+journal.OIK.notifyWeekly = oikos@oikosoffice.lu.se, automated-messages@datadryad.org
 journal.OIK.publicationBlackout= false
 journal.OIK.subscriptionPaid = true
 journal.OIK.sponsorName = Nordic Society Oikos
@@ -914,9 +914,9 @@ journal.paleobiology.allowReviewWorkflow = true
 journal.paleobiology.publicationBlackout = false
 journal.paleobiology.subscriptionPaid = true
 journal.paleobiology.sponsorName = The Paleontological Society
-journal.paleobiology.notifyOnReview = jtejada@flmnh.ufl.edu, natashaatkins1@gmail.com, admin@datadryad.org, curator@datadryad.org
-journal.paleobiology.notifyOnArchive = jtejada@flmnh.ufl.edu, natashaatkins1@gmail.com, admin@datadryad.org, curator@datadryad.org
-journal.paleobiology.notifyWeekly = jtejada@flmnh.ufl.edu, natashaatkins1@gmail.com, admin@datadryad.org, curator@datadryad.org
+journal.paleobiology.notifyOnReview = jtejada@flmnh.ufl.edu, natashaatkins1@gmail.com, automated-messages@datadryad.org
+journal.paleobiology.notifyOnArchive = jtejada@flmnh.ufl.edu, natashaatkins1@gmail.com, automated-messages@datadryad.org
+journal.paleobiology.notifyWeekly = jtejada@flmnh.ufl.edu, natashaatkins1@gmail.com, automated-messages@datadryad.org
 
 # Palaeontology
 journal.PALA.fullname = Palaeontology
@@ -928,9 +928,9 @@ journal.PALA.allowReviewWorkflow=true
 journal.PALA.publicationBlackout=true
 journal.PALA.subscriptionPaid = true
 journal.PALA.sponsorName = The Palaeontological Association
-journal.PALA.notifyOnReview=editor@sallyandnik.co.uk, admin@datadryad.org, curator@datadryad.org
-journal.PALA.notifyOnArchive = editor@sallyandnik.co.uk, admin@datadryad.org, curator@datadryad.org
-journal.PALA.notifyWeekly=a.smith@nhm.ac.uk, admin@datadryad.org, curator@datadryad.org
+journal.PALA.notifyOnReview=editor@sallyandnik.co.uk, automated-messages@datadryad.org
+journal.PALA.notifyOnArchive = editor@sallyandnik.co.uk, automated-messages@datadryad.org
+journal.PALA.notifyWeekly=a.smith@nhm.ac.uk, automated-messages@datadryad.org
 
 # Papers in Palaeontology
 journal.PP.fullname = Papers in Palaeontology
@@ -941,9 +941,9 @@ journal.PP.embargoAllowed = false
 journal.PP.allowReviewWorkflow=true
 journal.PP.publicationBlackout=true
 journal.PP.subscriptionPaid = true
-journal.PP.notifyOnReview=editor@palass.org, admin@datadryad.org, curator@datadryad.org
-journal.PP.notifyOnArchive = editor@palass.org, admin@datadryad.org, curator@datadryad.org
-journal.PP.notifyWeekly=a.smith@nhm.ac.uk, admin@datadryad.org, curator@datadryad.org
+journal.PP.notifyOnReview=editor@palass.org, automated-messages@datadryad.org
+journal.PP.notifyOnArchive = editor@palass.org, automated-messages@datadryad.org
+journal.PP.notifyWeekly=a.smith@nhm.ac.uk, automated-messages@datadryad.org
 
 
 # Philosophical Transactions of the Royal Society A
@@ -985,9 +985,9 @@ journal.phytokeys.allowReviewWorkflow = true
 journal.phytokeys.publicationBlackout = true
 journal.phytokeys.subscriptionPaid = true
 journal.phytokeys.sponsorName = Pensoft
-journal.phytokeys.notifyOnReview = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.phytokeys.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.phytokeys.notifyWeekly= journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.phytokeys.notifyOnReview = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.phytokeys.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.phytokeys.notifyWeekly= journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
 
 # The Plant Cell
 journal.plantcell.fullname = The Plant Cell
@@ -999,9 +999,9 @@ journal.plantcell.allowReviewWorkflow = false
 journal.plantcell.publicationBlackout = true
 journal.plantcell.subscriptionPaid = true
 journal.plantcell.sponsorName = American Society of Plant Biologists
-journal.plantcell.notifyOnReview = admin@datadryad.org, curator@datadryad.org
-journal.plantcell.notifyOnArchive = admin@datadryad.org, curator@datadryad.org
-journal.plantcell.notifyWeekly= admin@datadryad.org, curator@datadryad.org
+journal.plantcell.notifyOnReview = automated-messages@datadryad.org
+journal.plantcell.notifyOnArchive = automated-messages@datadryad.org
+journal.plantcell.notifyWeekly= automated-messages@datadryad.org
 
 # Plant Physiology
 journal.plantphys.fullname = Plant Physiology
@@ -1013,9 +1013,9 @@ journal.plantphys.allowReviewWorkflow = false
 journal.plantphys.publicationBlackout = true
 journal.plantphys.subscriptionPaid = true
 journal.plantphys.sponsorName = American Society of Plant Biologists
-journal.plantphys.notifyOnReview = admin@datadryad.org, curator@datadryad.org
-journal.plantphys.notifyOnArchive = admin@datadryad.org, curator@datadryad.org
-journal.plantphys.notifyWeekly= admin@datadryad.org, curator@datadryad.org
+journal.plantphys.notifyOnReview = automated-messages@datadryad.org
+journal.plantphys.notifyOnArchive = automated-messages@datadryad.org
+journal.plantphys.notifyWeekly= automated-messages@datadryad.org
 
 # Plant Science Bulletin
 journal.plantSciB.fullname = Plant Science Bulletin
@@ -1039,9 +1039,9 @@ journal.pbiology.integrated = true
 journal.pbiology.embargoAllowed = false
 journal.pbiology.allowReviewWorkflow = true
 journal.pbiology.publicationBlackout = true
-journal.pbiology.notifyOnReview = plosbiology@plos.org, rjarmy@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pbiology.notifyOnArchive = plosbiology@plos.org, khickling@plos.org, rjarmy@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pbiology.notifyWeekly = rjarmy@plos.org, plosbiology@plos.org, khickling@plos.org, eganley@plos.org admin@datadryad.org, curator@datadryad.org
+journal.pbiology.notifyOnReview = plosbiology@plos.org, rjarmy@plos.org, automated-messages@datadryad.org
+journal.pbiology.notifyOnArchive = plosbiology@plos.org, khickling@plos.org, rjarmy@plos.org, automated-messages@datadryad.org
+journal.pbiology.notifyWeekly = rjarmy@plos.org, plosbiology@plos.org, khickling@plos.org, eganley@plos.org automated-messages@datadryad.org
 
 
 # PLOS Computational Biology
@@ -1052,9 +1052,9 @@ journal.pcompbiol.integrated = true
 journal.pcompbiol.embargoAllowed = false
 journal.pcompbiol.allowReviewWorkflow = true
 journal.pcompbiol.publicationBlackout = true
-journal.pcompbiol.notifyOnReview = ploscompbiol@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pcompbiol.notifyOnArchive = ploscompbiol@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pcompbiol.notifyWeekly = ploscompbiol@plos.org, admin@datadryad.org, curator@datadryad.org
+journal.pcompbiol.notifyOnReview = ploscompbiol@plos.org, automated-messages@datadryad.org
+journal.pcompbiol.notifyOnArchive = ploscompbiol@plos.org, automated-messages@datadryad.org
+journal.pcompbiol.notifyWeekly = ploscompbiol@plos.org, automated-messages@datadryad.org
 
 # PLOS Genetics
 journal.pgenetics.fullname = PLOS Genetics
@@ -1064,9 +1064,9 @@ journal.pgenetics.integrated= true
 journal.pgenetics.embargoAllowed = false
 journal.pgenetics.allowReviewWorkflow=true
 journal.pgenetics.publicationBlackout=true
-journal.pgenetics.notifyOnReview= rdickin@plos.org, plosgenetics@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pgenetics.notifyOnArchive = rdickin@plos.org, plosgenetics@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pgenetics.notifyWeekly = plosgenetics@plos.org, admin@datadryad.org, curator@datadryad.org
+journal.pgenetics.notifyOnReview= rdickin@plos.org, plosgenetics@plos.org, automated-messages@datadryad.org
+journal.pgenetics.notifyOnArchive = rdickin@plos.org, plosgenetics@plos.org, automated-messages@datadryad.org
+journal.pgenetics.notifyWeekly = plosgenetics@plos.org, automated-messages@datadryad.org
 
 # PLOS Medicine
 journal.pmedicine.fullname = PLOS Medicine
@@ -1076,9 +1076,9 @@ journal.pmedicine.integrated = true
 journal.pmedicine.embargoAllowed = false
 journal.pmedicine.allowReviewWorkflow = true
 journal.pmedicine.publicationBlackout = true
-journal.pmedicine.notifyOnReview = plosmedicine@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pmedicine.notifyOnArchive = plosmedicine@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pmedicine.notifyWeekly = plosmedicine@plos.org, admin@datadryad.org, curator@datadryad.org
+journal.pmedicine.notifyOnReview = plosmedicine@plos.org, automated-messages@datadryad.org
+journal.pmedicine.notifyOnArchive = plosmedicine@plos.org, automated-messages@datadryad.org
+journal.pmedicine.notifyWeekly = plosmedicine@plos.org, automated-messages@datadryad.org
 
 # PLOS Neglected Tropical Diseases
 journal.pntd.fullname = PLOS Neglected Tropical Diseases
@@ -1088,9 +1088,9 @@ journal.pntd.integrated = true
 journal.pntd.embargoAllowed = false
 journal.pntd.allowReviewWorkflow = true
 journal.pntd.publicationBlackout = true
-journal.pntd.notifyOnReview = plosntds@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pntd.notifyOnArchive = plosntds@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pntd.notifyWeekly = plosntds@plos.org, admin@datadryad.org, curator@datadryad.org
+journal.pntd.notifyOnReview = plosntds@plos.org, automated-messages@datadryad.org
+journal.pntd.notifyOnArchive = plosntds@plos.org, automated-messages@datadryad.org
+journal.pntd.notifyWeekly = plosntds@plos.org, automated-messages@datadryad.org
 
 
 # PLOS ONE
@@ -1101,9 +1101,9 @@ journal.pone.integrated= true
 journal.pone.embargoAllowed = false
 journal.pone.allowReviewWorkflow = true
 journal.pone.publicationBlackout = true
-journal.pone.notifyOnReview = plosone@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pone.notifyOnArchive = plosone@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.pone.notifyWeekly = plosone@plos.org, admin@datadryad.org, curator@datadryad.org
+journal.pone.notifyOnReview = plosone@plos.org, automated-messages@datadryad.org
+journal.pone.notifyOnArchive = plosone@plos.org, automated-messages@datadryad.org
+journal.pone.notifyWeekly = plosone@plos.org, automated-messages@datadryad.org
 
 # PLOS Pathogens
 journal.ppathogens.fullname = PLOS Pathogens
@@ -1113,9 +1113,9 @@ journal.ppathogens.integrated = true
 journal.ppathogens.embargoAllowed = false
 journal.ppathogens.allowReviewWorkflow = true
 journal.ppathogens.publicationBlackout = true
-journal.ppathogens.notifyOnReview = plospathogens@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.ppathogens.notifyOnArchive = plospathogens@plos.org, admin@datadryad.org, curator@datadryad.org
-journal.ppathogens.notifyWeekly = plospathogens@plos.org, admin@datadryad.org, curator@datadryad.org
+journal.ppathogens.notifyOnReview = plospathogens@plos.org, automated-messages@datadryad.org
+journal.ppathogens.notifyOnArchive = plospathogens@plos.org, automated-messages@datadryad.org
+journal.ppathogens.notifyWeekly = plospathogens@plos.org, automated-messages@datadryad.org
 
 # Proceedings of the Royal Society A
 journal.ProcA.fullname = Proceedings of the Royal Society A
@@ -1142,8 +1142,8 @@ journal.RSOS.publicationBlackout = false
 journal.RSOS.subscriptionPaid = true
 journal.RSOS.sponsorName = The Royal Society
 journal.RSOS.notifyOnReview = 
-journal.RSOS.notifyOnArchive = emilie.aime@royalsociety.org, openscience@royalsociety.org, admin@datadryad.org, curator@datadryad.org
-journal.RSOS.notifyWeekly = emilie.aime@royalsociety.org, openscience@royalsociety.org, admin@datadryad.org, curator@datadryad.org
+journal.RSOS.notifyOnArchive = emilie.aime@royalsociety.org, openscience@royalsociety.org, automated-messages@datadryad.org
+journal.RSOS.notifyWeekly = emilie.aime@royalsociety.org, openscience@royalsociety.org, automated-messages@datadryad.org
 
 # Proceedings of the Royal Society B: Biological Sciences
 journal.RSPB.fullname = Proceedings of the Royal Society B
@@ -1155,8 +1155,8 @@ journal.RSPB.allowReviewWorkflow = true
 journal.RSPB.publicationBlackout = false
 journal.RSPB.subscriptionPaid = true
 journal.RSPB.sponsorName = The Royal Society
-journal.RSPB.notifyOnReview = admin@datadryad.org, curator@datadryad.org
-journal.RSPB.notifyOnArchive = rhiannon.meaden@royalsociety.org, proceedingsB@royalsociety.org, admin@datadryad.org, curator@datadryad.org
+journal.RSPB.notifyOnReview = automated-messages@datadryad.org
+journal.RSPB.notifyOnArchive = rhiannon.meaden@royalsociety.org, proceedingsB@royalsociety.org, automated-messages@datadryad.org
 journal.RSPB.notifyWeekly = rhiannon.meaden@royalsociety.org, proceedingsB@royalsociety.org, procb_proofs@royalsociety.org
 
 # Scientific Data
@@ -1169,9 +1169,9 @@ journal.SDATA.allowReviewWorkflow = true
 journal.SDATA.publicationBlackout = true
 journal.SDATA.subscriptionPaid = true
 journal.SDATA.sponsorName = Nature Publishing Group
-journal.SDATA.notifyOnReview = S.Payne@nature.com, admin@datadryad.org, curator@datadryad.org
-journal.SDATA.notifyOnArchive = S.Payne@nature.com, admin@datadryad.org, curator@datadryad.org
-journal.SDATA.notifyWeekly = S.Payne@nature.com, admin@datadryad.org, curator@datadryad.org
+journal.SDATA.notifyOnReview = S.Payne@nature.com, automated-messages@datadryad.org
+journal.SDATA.notifyOnArchive = S.Payne@nature.com, automated-messages@datadryad.org
+journal.SDATA.notifyWeekly = S.Payne@nature.com, automated-messages@datadryad.org
 
 # Special Papers in Paleontology --- NOT INTEGRATED -- When integrating, verify configuration
 journal.SPALA.fullname = Special Papers in Paleontology
@@ -1183,9 +1183,9 @@ journal.SPALA.allowReviewWorkflow = false
 journal.SPALA.publicationBlackout = true
 journal.SPALA.subscriptionPaid = true
 journal.SPALA.sponsorName = The Palaeontological Association 
-journal.SPALA.notifyOnReview = admin@datadryad.org, curator@datadryad.org
-journal.SPALA.notifyOnArchive =  admin@datadryad.org, curator@datadryad.org
-journal.SPALA.notifyWeekly = admin@datadryad.org, curator@datadryad.org
+journal.SPALA.notifyOnReview = automated-messages@datadryad.org
+journal.SPALA.notifyOnArchive =  automated-messages@datadryad.org
+journal.SPALA.notifyWeekly = automated-messages@datadryad.org
 
 
 # Subterranean Biology
@@ -1198,9 +1198,9 @@ journal.subtbiol.allowReviewWorkflow = true
 journal.subtbiol.publicationBlackout = true
 journal.subtbiol.subscriptionPaid = true
 journal.subtbiol.sponsorName = Pensoft 
-journal.subtbiol.notifyOnReview = subtbiol@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.subtbiol.notifyOnArchive = subtbiol@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.subtbiol.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.subtbiol.notifyOnReview = subtbiol@pensoft.net, automated-messages@datadryad.org
+journal.subtbiol.notifyOnArchive = subtbiol@pensoft.net, automated-messages@datadryad.org
+journal.subtbiol.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org
 
 
 # Systematic Biology
@@ -1213,9 +1213,9 @@ journal.SystBiol.allowReviewWorkflow = true
 journal.SystBiol.publicationBlackout = false
 journal.SystBiol.subscriptionPaid = true
 journal.SystBiol.sponsorName = Society of Systematic Biologists
-journal.SystBiol.notifyOnReview = ron.debry@uc.edu, sysbio.editorialoffice@oup.com, admin@datadryad.org, curator@datadryad.org
-journal.SystBiol.notifyOnArchive = ron.debry@uc.edu, sysbio.editorialoffice@oup.com, sysbio@oup.com, admin@datadryad.org, curator@datadryad.org
-journal.SystBiol.notifyWeekly = sysbio.editorialoffice@oup.com, admin@datadryad.org, curator@datadryad.org
+journal.SystBiol.notifyOnReview = ron.debry@uc.edu, sysbio.editorialoffice@oup.com, automated-messages@datadryad.org
+journal.SystBiol.notifyOnArchive = ron.debry@uc.edu, sysbio.editorialoffice@oup.com, sysbio@oup.com, automated-messages@datadryad.org
+journal.SystBiol.notifyWeekly = sysbio.editorialoffice@oup.com, automated-messages@datadryad.org
 
 # Systematic Botany
 journal.SYSBOT.fullname = Systematic Botany
@@ -1227,8 +1227,8 @@ journal.SYSBOT.allowReviewWorkflow = false
 journal.SYSBOT.publicationBlackout = true
 journal.SYSBOT.subscriptionPaid = true
 journal.SYSBOT.sponsorName = American Society of Plant Taxonomists
-journal.SYSBOT.notifyOnReview = systbot@gmail.com, curator@datadryad.org
-journal.SYSBOT.notifyOnArchive = systematicbotanyme@gmail.com, curator@datadryad.org
+journal.SYSBOT.notifyOnReview = systbot@gmail.com, automated-messages@datadryad.org
+journal.SYSBOT.notifyOnArchive = systematicbotanyme@gmail.com, automated-messages@datadryad.org
 journal.SYSBOT.notifyWeekly = systbot@gmail.com
 
 # ZooKeys
@@ -1241,9 +1241,9 @@ journal.ZooKeys.allowReviewWorkflow = true
 journal.ZooKeys.publicationBlackout = true
 journal.ZooKeys.subscriptionPaid = true
 journal.ZooKeys.sponsorName = Pensoft
-journal.ZooKeys.notifyOnReview = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.ZooKeys.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.ZooKeys.notifyWeekly = journals@pensoft.net, layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.ZooKeys.notifyOnReview = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.ZooKeys.notifyOnArchive = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
+journal.ZooKeys.notifyWeekly = journals@pensoft.net, layout@pensoft.net, automated-messages@datadryad.org
 
 
 # Zoological Systematics and Evolution
@@ -1257,5 +1257,5 @@ journal.ZSE.publicationBlackout = true
 journal.ZSE.subscriptionPaid = true
 journal.ZSE.sponsorName = Pensoft
 #journal.ZSE.notifyOnReview = 
-journal.ZSE.notifyOnArchive = layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-journal.ZSE.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+journal.ZSE.notifyOnArchive = layout@pensoft.net, automated-messages@datadryad.org
+journal.ZSE.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org

--- a/dspace/config/DryadJournalSubmission.testing.properties
+++ b/dspace/config/DryadJournalSubmission.testing.properties
@@ -20,8 +20,8 @@ journal.test.allowReviewWorkflow = true
 journal.test.publicationBlackout = false
 journal.test.subscriptionPaid = true
 journal.test.notifyOnReview = ryan-dryad-testing@scherle.org
-#journal.test.notifyOnArchive = admin@datadryad.org, curator@datadryad.org
-#journal.test.notifyWeekly = admin@datadryad.org, curator@datadryad.org
+#journal.test.notifyOnArchive = automated-messages@datadryad.org
+#journal.test.notifyWeekly = automated-messages@datadryad.org
 
 # Test Blackout
 journal.testbo.fullname = Dryad Testing Blackout Journal
@@ -33,8 +33,8 @@ journal.testbo.allowReviewWorkflow = true
 journal.testbo.publicationBlackout = true
 journal.testbo.subscriptionPaid = true
 journal.testbo.notifyOnReview = dan.leehr@nescent.org
-#journal.testbo.notifyOnArchive = admin@datadryad.org, curator@datadryad.org
-#journal.testbo.notifyWeekly = admin@datadryad.org, curator@datadryad.org
+#journal.testbo.notifyOnArchive = automated-messages@datadryad.org
+#journal.testbo.notifyWeekly = automated-messages@datadryad.org
 
 
 # Test2
@@ -46,9 +46,9 @@ journal.testa.embargoAllowed = true
 journal.testa.allowReviewWorkflow = true
 journal.testa.publicationBlackout = false
 journal.testa.subscriptionPaid = true
-#journal.testa.notifyOnReview = admin@datadryad.org, curator@datadryad.org
-#journal.testa.notifyOnArchive = admin@datadryad.org, curator@datadryad.org
-#journal.testa.notifyWeekly = admin@datadryad.org, curator@datadryad.org
+#journal.testa.notifyOnReview = automated-messages@datadryad.org
+#journal.testa.notifyOnArchive = automated-messages@datadryad.org
+#journal.testa.notifyWeekly = automated-messages@datadryad.org
 
 # American Journal of Botany
 journal.amjbot.fullname = American Journal of Botany
@@ -60,9 +60,9 @@ journal.amjbot.allowReviewWorkflow = true
 journal.amjbot.publicationBlackout = false
 journal.amjbot.subscriptionPaid = true
 journal.amjbot.sponsorName = The Botanical Society of America
-#journal.amjbot.notifyOnReview = amcpherson@botany.org, rhund@botany.org, admin@datadryad.org, curator@datadryad.org
-#journal.amjbot.notifyOnArchive = amcpherson@botany.org, rhund@botany.org, admin@datadryad.org, curator@datadryad.org
-#journal.amjbot.notifyWeekly = amcpherson@botany.org, rhund@botany.org, admin@datadryad.org, curator@datadryad.org
+#journal.amjbot.notifyOnReview = amcpherson@botany.org, rhund@botany.org, automated-messages@datadryad.org
+#journal.amjbot.notifyOnArchive = amcpherson@botany.org, rhund@botany.org, automated-messages@datadryad.org
+#journal.amjbot.notifyWeekly = amcpherson@botany.org, rhund@botany.org, automated-messages@datadryad.org
 
 
 # American Naturalist
@@ -70,7 +70,7 @@ journal.amNat.fullname = The American Naturalist
 journal.amNat.metadataDir = /opt/dryad/submission/journalMetadata/amNat
 journal.amNat.parsingScheme = amNat
 journal.amNat.integrated=true
-#journal.amNat.notifyOnArchive=pmorse@press.uchicago.edu, admin@datadryad.org, curator@datadryad.org
+#journal.amNat.notifyOnArchive=pmorse@press.uchicago.edu, automated-messages@datadryad.org
 
 # Applications in Plant Sciences
 journal.apps.fullname = Applications in Plant Sciences
@@ -82,9 +82,9 @@ journal.apps.allowReviewWorkflow = true
 journal.apps.publicationBlackout = true
 journal.apps.subscriptionPaid = true
 journal.apps.sponsorName = The Botanical Society of America
-#journal.apps.notifyOnReview = apps@botany.org, bparada@botany.org, admin@datadryad.org, curator@datadryad.org
-#journal.apps.notifyOnArchive = apps@botany.org, bparada@botany.org, admin@datadryad.org, curator@datadryad.org
-#journal.apps.notifyWeekly = apps@botany.org, bparada@botany.org, admin@datadryad.org, curator@datadryad.org
+#journal.apps.notifyOnReview = apps@botany.org, bparada@botany.org, automated-messages@datadryad.org
+#journal.apps.notifyOnArchive = apps@botany.org, bparada@botany.org, automated-messages@datadryad.org
+#journal.apps.notifyWeekly = apps@botany.org, bparada@botany.org, automated-messages@datadryad.org
 
 
 # Biodiversity Data Journal
@@ -98,15 +98,15 @@ journal.BDJ.publicationBlackout = true
 journal.BDJ.subscriptionPaid = true
 journal.BDJ.sponsorName = Pensoft
 #journal.BDJ.notifyOnReview = bdj@pensoft.net
-#journal.BDJ.notifyOnArchive = bdj@pensoft.net, admin@datadryad.org, curator@datadryad.org
-#journal.BDJ.notifyWeekly = bdj@pensoft.net, info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+#journal.BDJ.notifyOnArchive = bdj@pensoft.net, automated-messages@datadryad.org
+#journal.BDJ.notifyWeekly = bdj@pensoft.net, info@pensoft.net, automated-messages@datadryad.org
 
 # Biological Journal of the Linnean Society 
 journal.BJLS.fullname = Biological Journal of the Linnean Society
 journal.BJLS.metadataDir = /opt/dryad/submission/journalMetadata/BJLS
 journal.BJLS.parsingScheme = manuscriptCentral
 journal.BJLS.integrated=true
-#journal.BJLS.notifyOnArchive=J.A.Allen@soton.ac.uk, samoore@wiley.com, admin@datadryad.org, curator@datadryad.org
+#journal.BJLS.notifyOnArchive=J.A.Allen@soton.ac.uk, samoore@wiley.com, automated-messages@datadryad.org
 
 # Biology Letters
 journal.BIOLETTS.fullname = Biology Letters
@@ -115,9 +115,9 @@ journal.BIOLETTS.parsingScheme = manuscriptCentral
 journal.BIOLETTS.integrated=true
 journal.BIOLETTS.allowReviewWorkflow=true
 journal.BIOLETTS.publicationBlackout=true
-#journal.BJLS.notifyOnArchive=bilogyletters@royalsociety.org, admin@datadryad.org, curator@datadryad.org
-#journal.BIOLETTS.notifyOnReview=bilogyletters@royalsociety.org, admin@datadryad.org, curator@datadryad.org
-#journal.BIOLETTS.notifyWeekly= biologyletters@royalsociety.org, admin@datadryad.org, curator@datadryad.org, pschaeffer@nescent.org, tjv@bio.unc.edu
+#journal.BJLS.notifyOnArchive=bilogyletters@royalsociety.org, automated-messages@datadryad.org
+#journal.BIOLETTS.notifyOnReview=bilogyletters@royalsociety.org, automated-messages@datadryad.org
+#journal.BIOLETTS.notifyWeekly= biologyletters@royalsociety.org, automated-messages@datadryad.org, pschaeffer@nescent.org, tjv@bio.unc.edu
 
 
 # biorisk
@@ -137,9 +137,9 @@ journal.BITR.allowReviewWorkflow = false
 journal.BITR.publicationBlackout = false
 journal.BITR.subscriptionPaid = true
 journal.BITR.sponsorName = Association for Tropical Biology and Conservation
-#journal.BITR.notifyOnReview = admin@datadryad.org, curator@datadryad.org
-#journal.BITR.notifyOnArchive = admin@datadryad.org, curator@datadryad.org
-#journal.BITR.notifyWeekly = admin@datadryad.org, curator@datadryad.org
+#journal.BITR.notifyOnReview = automated-messages@datadryad.org
+#journal.BITR.notifyOnArchive = automated-messages@datadryad.org
+#journal.BITR.notifyWeekly = automated-messages@datadryad.org
 
 # BMC Evolutionary Biology
 journal.BMCEvolBiol.fullname = BMC Evolutionary Biology
@@ -184,8 +184,8 @@ journal.bmjOpen.parsingScheme = manuscriptCentral
 journal.bmjOpen.embargoAllowed = false
 journal.bmjOpen.integrated=true
 journal.bmjOpen.allowReviewWorkflow=true
-#journal.bmjOpen.notifyOnReview=editorial.bmjopen@bmjgroup.com, admin@datadryad.org, curator@datadryad.org
-#journal.bmjOpen.notifyOnArchive=editorial.bmjopen@bmjgroup.com, admin@datadryad.org, curator@datadryad.org
+#journal.bmjOpen.notifyOnReview=editorial.bmjopen@bmjgroup.com, automated-messages@datadryad.org
+#journal.bmjOpen.notifyOnArchive=editorial.bmjopen@bmjgroup.com, automated-messages@datadryad.org
 
 # Deutsche Entomologische Zeitschrift
 journal.DEZ.fullname = Deutsche Entomologische Zeitschrift
@@ -198,8 +198,8 @@ journal.DEZ.publicationBlackout = true
 journal.DEZ.subscriptionPaid = true
 journal.DEZ.sponsorName = Pensoft
 #journal.DEZ.notifyOnReview = 
-#journal.DEZ.notifyOnArchive = layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-#journal.DEZ.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+#journal.DEZ.notifyOnArchive = layout@pensoft.net, automated-messages@datadryad.org
+#journal.DEZ.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org
 
 # Ecography
 journal.ECOG.fullname = Ecography
@@ -208,8 +208,8 @@ journal.ECOG.parsingScheme = manuscriptCentral
 journal.ECOG.embargoAllowed = true
 journal.ECOG.integrated = true
 journal.ECOG.allowReviewWorkflow = false
-#journal.ECOG.notifyOnArchive = ecograpy@ECOGosoffice.lu.se, curator@datadryad.org
-#journal.ECOG.notifyWeekly = ecograpy@ECOGosoffice.lu.se, curator@datadryad.org
+#journal.ECOG.notifyOnArchive = ecograpy@ECOGosoffice.lu.se, automated-messages@datadryad.org
+#journal.ECOG.notifyWeekly = ecograpy@ECOGosoffice.lu.se, automated-messages@datadryad.org
 journal.ECOG.publicationBlackout = false
 journal.ECOG.subscriptionPaid = true
 journal.ECOG.sponsorName = Nordic Society ECOG
@@ -223,9 +223,9 @@ journal.ecap.embargoAllowed = true
 journal.ecap.allowReviewWorkflow = false
 journal.ecap.publicationBlackout = false
 journal.ecap.subscriptionPaid = false
-#journal.ecap.notifyOnReview = admin@datadryad.org, curator@datadryad.org
-#journal.ecap.notifyOnArchive = admin@datadryad.org, curator@datadryad.org
-#journal.ecap.notifyWeekly = admin@datadryad.org, curator@datadryad.org
+#journal.ecap.notifyOnReview = automated-messages@datadryad.org
+#journal.ecap.notifyOnArchive = automated-messages@datadryad.org
+#journal.ecap.notifyWeekly = automated-messages@datadryad.org
 
 
 # Ecological Monographs
@@ -243,9 +243,9 @@ journal.ecol.embargoAllowed = true
 journal.ecol.allowReviewWorkflow = false
 journal.ecol.publicationBlackout = true
 journal.ecol.subscriptionPaid = false
-#journal.ecol.notifyOnReview = admin@datadryad.org, curator@datadryad.org
-#journal.ecol.notifyOnArchive = admin@datadryad.org, curator@datadryad.org
-#journal.ecol.notifyWeekly = admin@datadryad.org, curator@datadryad.org
+#journal.ecol.notifyOnReview = automated-messages@datadryad.org
+#journal.ecol.notifyOnArchive = automated-messages@datadryad.org
+#journal.ecol.notifyWeekly = automated-messages@datadryad.org
 
 
 # Ecology and Evolution
@@ -255,9 +255,9 @@ journal.ECE3.parsingScheme = manuscriptCentral
 journal.ECE3.integrated=true
 journal.ECE3.allowReviewWorkflow=false
 journal.ECE3.publicationBlackout=true
-#journal.ECE3.notifyOnArchive=ecoevo@wiley.com, ece@wiley.com, crouyang@wiley.com, admin@datadryad.org, curator@datadryad.org
-#journal.ECE3.notifyOnReview=ecoevo@wiley.com, admin@datadryad.org, curator@datadryad.org
-#journal.ECE3.notifyWeekly=ecoevo@wiley.com, kgreaney@wiley.com, crouyang@wiley.com, admin@datadryad.org, curator@datadryad.org
+#journal.ECE3.notifyOnArchive=ecoevo@wiley.com, ece@wiley.com, crouyang@wiley.com, automated-messages@datadryad.org
+#journal.ECE3.notifyOnReview=ecoevo@wiley.com, automated-messages@datadryad.org
+#journal.ECE3.notifyWeekly=ecoevo@wiley.com, kgreaney@wiley.com, crouyang@wiley.com, automated-messages@datadryad.org
 
 
 # Ecology Letters
@@ -267,8 +267,8 @@ journal.ECOLETS.parsingScheme = manuscriptCentral
 journal.ECOLETS.integrated=true
 journal.ECOLETS.publicationBlackout=true
 journal.ECOLETS.allowReviewWorkflow=false
-#journal.ECOLETS.notifyOnArchive = maholyoak@ucdavis.edu, ecolets@univ-montp2.fr, admin@datadryad.org, curator@datadryad.org
-#journal.ECOLETS.notifyWeekly = maholyoak@ucdavis.edu, admin@datadryad.org, curator@datadryad.org
+#journal.ECOLETS.notifyOnArchive = maholyoak@ucdavis.edu, ecolets@univ-montp2.fr, automated-messages@datadryad.org
+#journal.ECOLETS.notifyWeekly = maholyoak@ucdavis.edu, automated-messages@datadryad.org
 
 # Elementa
 journal.Elementa.fullname = Elementa
@@ -277,8 +277,8 @@ journal.Elementa.parsingScheme = manuscriptCentral
 journal.Elementa.integrated=true
 journal.Elementa.publicationBlackout=true
 journal.Elementa.allowReviewWorkflow=false
-#journal.Elementa.notifyOnArchive = lhladik@elementascience.org, mkurtz@elementascience.org, admin@datadryad.org, curator@datadryad.org
-#journal.Elementa.notifyWeekly = lhladik@elementascience.org, mkurtz@elementascience.org, admin@datadryad.org, curator@datadryad.org
+#journal.Elementa.notifyOnArchive = lhladik@elementascience.org, mkurtz@elementascience.org, automated-messages@datadryad.org
+#journal.Elementa.notifyWeekly = lhladik@elementascience.org, mkurtz@elementascience.org, automated-messages@datadryad.org
 
 
 # eLife
@@ -288,9 +288,9 @@ journal.eLife.parsingScheme = manuscriptCentral
 journal.eLife.integrated=true
 journal.eLife.publicationBlackout=true
 journal.eLife.allowReviewWorkflow=false
-#journal.eLife.notifyOnReview= admin@datadryad.org, curator@datadryad.org
-#journal.eLife.notifyOnArchive= admin@datadryad.org, curator@datadryad.org
-#journal.eLife.notifyWeekly= admin@datadryad.org, curator@datadryad.org
+#journal.eLife.notifyOnReview= automated-messages@datadryad.org
+#journal.eLife.notifyOnArchive= automated-messages@datadryad.org
+#journal.eLife.notifyWeekly= automated-messages@datadryad.org
 
 
 # Evolution
@@ -298,7 +298,7 @@ journal.evolution.fullname = Evolution
 journal.evolution.metadataDir = /opt/dryad/submission/journalMetadata/evolution
 journal.evolution.parsingScheme = manuscriptCentral
 journal.evolution.integrated=true
-#journal.evolution.notifyOnArchive=jmahar@wiley.com, admin@datadryad.org, curator@datadryad.org
+#journal.evolution.notifyOnArchive=jmahar@wiley.com, automated-messages@datadryad.org
 journal.evolution.publicationBlackout=true
 journal.evolution.subscriptionPaid = true
 
@@ -307,7 +307,7 @@ journal.EvolApp.fullname = Evolutionary Applications
 journal.EvolApp.metadataDir = /opt/dryad/submission/journalMetadata/EvolApp
 journal.EvolApp.parsingScheme = manuscriptCentral
 journal.EvolApp.integrated=true
-#journal.EvolApp.notifyOnArchive=sunderwood@wiley.com, evolappl@zoology.ubc.ca, admin@datadryad.org, curator@datadryad.org
+#journal.EvolApp.notifyOnArchive=sunderwood@wiley.com, evolappl@zoology.ubc.ca, automated-messages@datadryad.org
 
 # Frontiers in Ecology and the Environment
 journal.ecoFrontiers.fullname = Frontiers in Ecology and the Environment
@@ -328,9 +328,9 @@ journal.GMSGMS.fullname = GMS German Medical Science
 journal.GMSGMS.metadataDir = /opt/dryad/submission/journalMetadata/GMSGMS
 journal.GMSGMS.parsingScheme = manuscriptCentral
 journal.GMSGMS.integrated=true
-journal.GMSGMS.notifyOnReview=test@datadryad.org, admin@datadryad.org
-journal.GMSGMS.notifyOnArchive=test@datadryad.org, admin@datadryad.org
-journal.GMSGMS.notifyWeekly=test@datadryad.org, admin@datadryad.org
+journal.GMSGMS.notifyOnReview=test@datadryad.org, automated-messages@datadryad.org
+journal.GMSGMS.notifyOnArchive=test@datadryad.org, automated-messages@datadryad.org
+journal.GMSGMS.notifyWeekly=test@datadryad.org, automated-messages@datadryad.org
 journal.GMSGMS.publicationBlackout=false
 
 # GMS German Plastic, Reconstructive and Aesthetic Surgery
@@ -343,9 +343,9 @@ journal.GMSGPRAS.allowReviewWorkflow = true
 journal.GMSGPRAS.publicationBlackout = true
 journal.GMSGPRAS.subscriptionPaid = true
 journal.GMSGPRAS.sponsorName = German National Library of Medicine
-#journal.GMSGPRAS.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSGPRAS.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSGPRAS.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSGPRAS.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSGPRAS.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSGPRAS.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Health Technology Assessment
 journal.GMSHTA.fullname = GMS Health Technology Assessment
@@ -357,9 +357,9 @@ journal.GMSHTA.allowReviewWorkflow = true
 journal.GMSHTA.publicationBlackout = true
 journal.GMSHTA.subscriptionPaid = true
 journal.GMSHTA.sponsorName = German National Library of Medicine
-#journal.GMSHTA.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSHTA.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSHTA.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSHTA.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSHTA.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSHTA.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Hygiene and Infection Control
 journal.GMSHIC.fullname = GMS Hygiene and Infection Control
@@ -371,9 +371,9 @@ journal.GMSHIC.allowReviewWorkflow = true
 journal.GMSHIC.publicationBlackout = true
 journal.GMSHIC.subscriptionPaid = true
 journal.GMSHIC.sponsorName = German National Library of Medicine
-#journal.GMSHIC.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSHIC.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSHIC.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSHIC.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSHIC.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSHIC.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Infectious Diseases
 journal.GMSID.fullname = GMS Infectious Diseases
@@ -385,9 +385,9 @@ journal.GMSID.allowReviewWorkflow = true
 journal.GMSID.publicationBlackout = true
 journal.GMSID.subscriptionPaid = true
 journal.GMSID.sponsorName = German National Library of Medicine
-#journal.GMSID.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSID.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSID.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSID.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSID.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSID.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Interdisciplinary Plastic and Reconstructive Surgery DGPW
 journal.GMSIPRS.fullname = GMS Interdisciplinary Plastic and Reconstructive Surgery DGPW
@@ -399,9 +399,9 @@ journal.GMSIPRS.allowReviewWorkflow = true
 journal.GMSIPRS.publicationBlackout = true
 journal.GMSIPRS.subscriptionPaid = true
 journal.GMSIPRS.sponsorName = German National Library of Medicine
-#journal.GMSIPRS.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSIPRS.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSIPRS.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSIPRS.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSIPRS.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSIPRS.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Medizin - Bibliothek - Information
 journal.GMSMBI.fullname = GMS Medizin - Bibliothek - Information
@@ -413,9 +413,9 @@ journal.GMSMBI.allowReviewWorkflow = true
 journal.GMSMBI.publicationBlackout = true
 journal.GMSMBI.subscriptionPaid = true
 journal.GMSMBI.sponsorName = German National Library of Medicine
-#journal.GMSMBI.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSMBI.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSMBI.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSMBI.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSMBI.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSMBI.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Medizinische Informatik, Biometrie und Epidemiologie
 journal.GMSMIBE.fullname = GMS Medizinische Informatik, Biometrie und Epidemiologie
@@ -425,9 +425,9 @@ journal.GMSMIBE.integrated=true
 journal.GMSMIBE.embargoAllowed = false
 journal.GMSMIBE.allowReviewWorkflow=true
 journal.GMSMIBE.publicationBlackout=true
-#journal.GMSMIBE.notifyOnReview=gms@zbmed.de, curator@datadryad.org, admin@datadryad.org
-#journal.GMSMIBE.notifyOnArchive=gms@zbmed.de, curator@datadryad.org, admin@datadryad.org
-#journal.GMSMIBE.notifyWeekly=gms@zbmed.de, curator@datadryad.org, admin@datadryad.org
+#journal.GMSMIBE.notifyOnReview=gms@zbmed.de, automated-messages@datadryad.org, automated-messages@datadryad.org
+#journal.GMSMIBE.notifyOnArchive=gms@zbmed.de, automated-messages@datadryad.org, automated-messages@datadryad.org
+#journal.GMSMIBE.notifyWeekly=gms@zbmed.de, automated-messages@datadryad.org, automated-messages@datadryad.org
 
 # GMS Onkologische Rehabilitation und Sozialmedizin
 journal.GMSORS.fullname = GMS Onkologische Rehabilitation und Sozialmedizin
@@ -439,9 +439,9 @@ journal.GMSORS.allowReviewWorkflow = true
 journal.GMSORS.publicationBlackout = true
 journal.GMSORS.subscriptionPaid = true
 journal.GMSORS.sponsorName = German National Library of Medicine
-#journal.GMSORS.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSORS.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSORS.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSORS.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSORS.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSORS.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Zeitschrift für Medizinische Ausbildung
 journal.GMSZMA.fullname = GMS Zeitschrift für Medizinische Ausbildung
@@ -453,9 +453,9 @@ journal.GMSZMA.allowReviewWorkflow = true
 journal.GMSZMA.publicationBlackout = true
 journal.GMSZMA.subscriptionPaid = true
 journal.GMSZMA.sponsorName = German National Library of Medicine
-#journal.GMSZMA.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSZMA.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSZMA.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSZMA.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSZMA.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSZMA.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # GMS Zeitschrift zur Förderung der Qualitätssicherung in medizinischen Laboratorien
 journal.GMSLAB.fullname = GMS Zeitschrift zur Förderung der Qualitätssicherung in medizinischen Laboratorien
@@ -467,16 +467,16 @@ journal.GMSLAB.allowReviewWorkflow = true
 journal.GMSLAB.publicationBlackout = true
 journal.GMSLAB.subscriptionPaid = true
 journal.GMSLAB.sponsorName = German National Library of Medicine
-#journal.GMSLAB.notifyOnReview = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSLAB.notifyOnArchive = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
-#journal.GMSLAB.notifyWeekly = gms@zbmed.de, admin@datadryad.org, curator@datadryad.org
+#journal.GMSLAB.notifyOnReview = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSLAB.notifyOnArchive = gms@zbmed.de, automated-messages@datadryad.org
+#journal.GMSLAB.notifyWeekly = gms@zbmed.de, automated-messages@datadryad.org
 
 # Heredity
 journal.heredity.fullname = Heredity
 journal.heredity.metadataDir = /opt/dryad/submission/journalMetadata/heredity
 journal.heredity.parsingScheme = manuscriptCentral
 journal.heredity.integrated=true
-#journal.heredity.notifyOnArchive=heredity@sheffield.ac.uk, admin@datadryad.org, curator@datadryad.org
+#journal.heredity.notifyOnArchive=heredity@sheffield.ac.uk, automated-messages@datadryad.org
 #journal.heredity.notifyWeekly=R.Vickerstaff@nature.com, heredity@sheffield.ac.uk
 
 # Intl J of Myriapodology
@@ -500,8 +500,8 @@ journal.JAE.parsingScheme = manuscriptCentral
 journal.JAE.embargoAllowed = true
 journal.JAE.integrated=true
 journal.JAE.allowReviewWorkflow=false
-#journal.JAE.notifyOnArchive = managingeditor@journalofanimalecology.org, admin@journalofanimalecology.org, curator@datadryad.org
-#journal.JAE.notifyWeekly = managingeditor@journalofanimalecology.org, admin@journalofanimalecology.org, curator@datadryad.org
+#journal.JAE.notifyOnArchive = managingeditor@journalofanimalecology.org, admin@journalofanimalecology.org, automated-messages@datadryad.org
+#journal.JAE.notifyWeekly = managingeditor@journalofanimalecology.org, admin@journalofanimalecology.org, automated-messages@datadryad.org
 journal.JAE.publicationBlackout=true
 
 # Journal of Avian Biology
@@ -511,8 +511,8 @@ journal.JAV.parsingScheme = manuscriptCentral
 journal.JAV.embargoAllowed = true
 journal.JAV.integrated=true
 journal.JAV.allowReviewWorkflow=false
-#journal.JAV.notifyOnArchive = jab@oikosoffice.lu.se, curator@datadryad.org
-#journal.JAV.notifyWeekly = jab@oikosoffice.lu.se, curator@datadryad.org
+#journal.JAV.notifyOnArchive = jab@oikosoffice.lu.se, automated-messages@datadryad.org
+#journal.JAV.notifyWeekly = jab@oikosoffice.lu.se, automated-messages@datadryad.org
 journal.JAV.publicationBlackout=false
 journal.JAV.subscriptionPaid = true
 journal.JAV.sponsorName = Nordic Society Oikos
@@ -533,7 +533,7 @@ journal.JAPPL.parsingScheme = manuscriptCentral
 journal.JAPPL.integrated=true
 journal.JAPPL.publicationBlackout=true
 journal.JAPPL.allowReviewWorkflow=false
-#journal.JAPPL.notifyOnArchive = managingeditor@journalofappliedecology.org, admin@journalofappliedecology.org, admin@datadryad.org, curator@datadryad.org
+#journal.JAPPL.notifyOnArchive = managingeditor@journalofappliedecology.org, admin@journalofappliedecology.org, automated-messages@datadryad.org
 
 # Journal of Consumer Research
 journal.jcr.fullname = Journal of Consumer Research
@@ -557,7 +557,7 @@ journal.JECOL.parsingScheme = manuscriptCentral
 journal.JECOL.integrated=true
 journal.JECOL.publicationBlackout=true
 journal.JECOL.allowReviewWorkflow=false
-#journal.JECOL.notifyOnArchive = managingeditor@journalofecology.org, admin@journalofecology.org, admin@datadryad.org, curator@datadryad.org
+#journal.JECOL.notifyOnArchive = managingeditor@journalofecology.org, admin@journalofecology.org, automated-messages@datadryad.org
 
 
 # Journal of Evolutionary Biology
@@ -565,7 +565,7 @@ journal.EvolBiol.fullname = Journal of Evolutionary Biology
 journal.EvolBiol.metadataDir = /opt/dryad/submission/journalMetadata/EvolBiol
 journal.EvolBiol.parsingScheme = manuscriptCentral
 journal.EvolBiol.integrated=true
-#journal.EvolBiol.notifyOnArchive = S.Bennett@exeter.ac.uk, admin@datadryad.org, curator@datadryad.org
+#journal.EvolBiol.notifyOnArchive = S.Bennett@exeter.ac.uk, automated-messages@datadryad.org
 
 # Journal of Fish and Wildlife Management
 journal.jfwm.fullname = Journal of Fish and Wildlife Management
@@ -573,14 +573,14 @@ journal.jfwm.metadataDir = /opt/dryad/submission/journalMetadata/jfwm
 journal.jfwm.parsingScheme = ecoApp
 journal.jfwm.embargoAllowed = false
 journal.jfwm.integrated=true
-#journal.jfwm.notifyOnArchive = anne_post@fws.gov, lbuscher@allenpress.com, curator@datadryad.org
+#journal.jfwm.notifyOnArchive = anne_post@fws.gov, lbuscher@allenpress.com, automated-messages@datadryad.org
 
 # Journal of Heredity
 journal.jhered.fullname = Journal of Heredity
 journal.jhered.metadataDir = /opt/dryad/submission/journalMetadata/jhered
 journal.jhered.parsingScheme = manuscriptCentral
 journal.jhered.integrated=true
-#journal.jhered.notifyOnArchive = AGAJOH@oregonstate.edu, admin@datadryad.org, curator@datadryad.org
+#journal.jhered.notifyOnArchive = AGAJOH@oregonstate.edu, automated-messages@datadryad.org
 
 # Journal of Hymenoptera Research
 journal.jhr.fullname = Journal of Hymenoptera Research
@@ -593,8 +593,8 @@ journal.jhr.publicationBlackout = false
 journal.jhr.subscriptionPaid = true
 journal.jhr.sponsorName = Pensoft
 journal.jhr.notifyOnReview =
-#journal.jhr.notifyOnArchive = jhr@pensoft.net, admin@datadryad.org, curator@datadryad.org
-#journal.jhr.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+#journal.jhr.notifyOnArchive = jhr@pensoft.net, automated-messages@datadryad.org
+#journal.jhr.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org
 
 
 # Journal of Open Public Health Data
@@ -603,9 +603,9 @@ journal.JOPHD.metadataDir = /opt/dryad/submission/journalMetadata/JOPHD
 journal.JOPHD.parsingScheme = manuscriptCentral
 journal.JOPHD.integrated=true
 journal.JOPHD.allowReviewWorkflow=true
-#journal.JOPHD.notifyOnReview = editor.jophd@ubiquitypress.com, admin@datadryad.org, curator@datadryad.org
-#journal.JOPHD.notifyOnArchive = editor.jophd@ubiquitypress.com, admin@datadryad.org, curator@datadryad.org
-#journal.JOPHD.notifyWeekly = brian.hole@ubiquitypress.com, editor.jophd@ubiquitypress.com, admin@datadryad.org, curator@datadryad.org
+#journal.JOPHD.notifyOnReview = editor.jophd@ubiquitypress.com, automated-messages@datadryad.org
+#journal.JOPHD.notifyOnArchive = editor.jophd@ubiquitypress.com, automated-messages@datadryad.org
+#journal.JOPHD.notifyWeekly = brian.hole@ubiquitypress.com, editor.jophd@ubiquitypress.com, automated-messages@datadryad.org
 journal.JOPHD.publicationBlackout=false
 
 # Journal of Paleontology
@@ -620,9 +620,9 @@ journal.JPAKMED.metadataDir = /opt/dryad/submission/journalMetadata/JPAKMED
 journal.JPAKMED.parsingScheme = manuscriptCentral
 journal.JPAKMED.integrated=true
 journal.JPAKMED.allowReviewWorkflow=false
-#journal.JPAKMED.notifyOnReview = editor.jpms@gmail.com, admin@datadryad.org, curator@datadryad.org
-#journal.JPAKMED.notifyOnArchive = editor.jpms@gmail.com, admin@datadryad.org, curator@datadryad.org
-#journal.JPAKMED.notifyWeekly = editor.jpms@gmail.com, admin@datadryad.org, curator@datadryad.org
+#journal.JPAKMED.notifyOnReview = editor.jpms@gmail.com, automated-messages@datadryad.org
+#journal.JPAKMED.notifyOnArchive = editor.jpms@gmail.com, automated-messages@datadryad.org
+#journal.JPAKMED.notifyWeekly = editor.jpms@gmail.com, automated-messages@datadryad.org
 journal.JPAKMED.publicationBlackout=false
 
 
@@ -639,8 +639,8 @@ journal.MEE.parsingScheme = manuscriptCentral
 journal.MEE.integrated=true
 journal.MEE.allowReviewWorkflow=false
 journal.MEE.publicationBlackout=true
-#journal.MEE.notifyOnArchive = coordinator@methodsinecologyandevolution.org, admin@datadryad.org, curator@datadryad.org
-#journal.MEE.notifyWeekly = coordinator@methodsinecologyandevolution.org, admin@datadryad.org, curator@datadryad.org
+#journal.MEE.notifyOnArchive = coordinator@methodsinecologyandevolution.org, automated-messages@datadryad.org
+#journal.MEE.notifyWeekly = coordinator@methodsinecologyandevolution.org, automated-messages@datadryad.org
 
 # Molecular Ecology
 journal.MolEcol.fullname = Molecular Ecology
@@ -648,7 +648,7 @@ journal.MolEcol.metadataDir = /opt/dryad/submission/journalMetadata/MolEcol
 journal.MolEcol.parsingScheme = manuscriptCentral
 journal.MolEcol.integrated=true
 journal.MolEcol.allowReviewWorkflow=true
-#journal.MolEcol.notifyOnArchive = editorial.office@molecol.com, admin@datadryad.org, curator@datadryad.org
+#journal.MolEcol.notifyOnArchive = editorial.office@molecol.com, automated-messages@datadryad.org
 
 # Molecular Ecology Resources
 journal.MolEcolRes.fullname = Molecular Ecology Resources
@@ -656,7 +656,7 @@ journal.MolEcolRes.metadataDir = /opt/dryad/submission/journalMetadata/MolEcolRe
 journal.MolEcolRes.parsingScheme = manuscriptCentral
 journal.MolEcolRes.integrated=true
 journal.MolEcolRes.allowReviewWorkflow=true
-#journal.MolEcolRes.notifyOnArchive = editorial.office@molecol.com, admin@datadryad.org, curator@datadryad.org
+#journal.MolEcolRes.notifyOnArchive = editorial.office@molecol.com, automated-messages@datadryad.org
 
 # Molecular Phylogenetics and Evolution
 journal.mpe.fullname = Molecular Phylogenetics and Evolution
@@ -692,8 +692,8 @@ journal.NJB.parsingScheme = manuscriptCentral
 journal.NJB.embargoAllowed = true
 journal.NJB.integrated = true
 journal.NJB.allowReviewWorkflow = false
-#journal.NJB.notifyOnArchive = njb@oikosoffice.lu.se, curator@datadryad.org
-#journal.NJB.notifyWeekly = njb@oikosoffice.lu.se, curator@datadryad.org
+#journal.NJB.notifyOnArchive = njb@oikosoffice.lu.se, automated-messages@datadryad.org
+#journal.NJB.notifyWeekly = njb@oikosoffice.lu.se, automated-messages@datadryad.org
 journal.NJB.publicationBlackout = false
 journal.NJB.subscriptionPaid = true
 journal.NJB.sponsorName = Nordic Society Oikos
@@ -709,8 +709,8 @@ journal.NL.publicationBlackout = true
 journal.NL.subscriptionPaid = true
 journal.NL.sponsorName = Pensoft
 #journal.NL.notifyOnReview = 
-#journal.NL.notifyOnArchive = layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-#journal.NLE.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+#journal.NL.notifyOnArchive = layout@pensoft.net, automated-messages@datadryad.org
+#journal.NLE.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org
 
 # Oikos
 journal.OIK.fullname = Oikos
@@ -719,8 +719,8 @@ journal.OIK.parsingScheme = manuscriptCentral
 journal.OIK.embargoAllowed = true
 journal.OIK.integrated = true
 journal.OIK.allowReviewWorkflow = false
-#journal.OIK.notifyOnArchive = oikos@oikosoffice.lu.se, curator@datadryad.org
-#journal.OIK.notifyWeekly = oikos@oikosoffice.lu.se, curator@datadryad.org
+#journal.OIK.notifyOnArchive = oikos@oikosoffice.lu.se, automated-messages@datadryad.org
+#journal.OIK.notifyWeekly = oikos@oikosoffice.lu.se, automated-messages@datadryad.org
 journal.OIK.publicationBlackout =false
 journal.OIK.subscriptionPaid = true
 journal.OIK.sponsorName = Nordic Society Oikos
@@ -741,9 +741,9 @@ journal.PALA.embargoAllowed = false
 journal.PALA.allowReviewWorkflow=true
 journal.PALA.publicationBlackout=true
 journal.PALA.subscriptionPaid = true
-#journal.PALA.notifyOnReview=editor@sallyandnik.co.uk, admin@datadryad.org, curator@datadryad.org
-#journal.PALA.notifyOnArchive = editor@sallyandnik.co.uk, admin@datadryad.org, curator@datadryad.org
-#journal.PALA.notifyWeekly=a.smith@nhm.ac.uk, admin@datadryad.org, curator@datadryad.org
+#journal.PALA.notifyOnReview=editor@sallyandnik.co.uk, automated-messages@datadryad.org
+#journal.PALA.notifyOnArchive = editor@sallyandnik.co.uk, automated-messages@datadryad.org
+#journal.PALA.notifyWeekly=a.smith@nhm.ac.uk, automated-messages@datadryad.org
 
 # Papers in Palaeontology
 journal.PP.fullname = Papers in Palaeontology
@@ -754,9 +754,9 @@ journal.PP.embargoAllowed = false
 journal.PP.allowReviewWorkflow=true
 journal.PP.publicationBlackout=false
 journal.PP.subscriptionPaid = true
-#journal.PP.notifyOnReview=editor@palass.org, admin@datadryad.org, curator@datadryad.org
-#journal.PP.notifyOnArchive = editor@palass.org, admin@datadryad.org, curator@datadryad.org
-#journal.PP.notifyWeekly=a.smith@nhm.ac.uk, admin@datadryad.org, curator@datadryad.org
+#journal.PP.notifyOnReview=editor@palass.org, automated-messages@datadryad.org
+#journal.PP.notifyOnArchive = editor@palass.org, automated-messages@datadryad.org
+#journal.PP.notifyWeekly=a.smith@nhm.ac.uk, automated-messages@datadryad.org
 
 # phytokeys
 journal.phytokeys.fullname = PhytoKeys
@@ -779,11 +779,11 @@ journal.pbiology.integrated = true
 journal.pbiology.embargoAllowed = false
 journal.pbiology.allowReviewWorkflow = true
 journal.pbiology.publicationBlackout = true
-#journal.pbiology.notifyOnReview=tbloom@plos.org, admin@datadryad.org, curator@datadryad.org
-#journal.pbiology.notifyOnArchive = tbloom@plos.org, mbrown@plos.org, admin@datadryad.org, curator@datadryad.org
+#journal.pbiology.notifyOnReview=tbloom@plos.org, automated-messages@datadryad.org
+#journal.pbiology.notifyOnArchive = tbloom@plos.org, mbrown@plos.org, automated-messages@datadryad.org
 # dleehr - For API Testing 2014-10-29, prior to launch
-journal.pbiology.notifyOnReview = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
-journal.pbiology.notifyOnArchive = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pbiology.notifyOnReview = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pbiology.notifyOnArchive = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
 
 # PLoS Biology (TESTING CONFIG ONLY)
 journal.pbiologyTest.fullname = PLOS PBIOLOGY Test Site
@@ -801,8 +801,8 @@ journal.pcompbiol.embargoAllowed = false
 journal.pcompbiol.allowReviewWorkflow = true
 journal.pcompbiol.publicationBlackout = true
 # dleehr - For API Testing 2014-10-29, prior to launch
-journal.pcompbiol.notifyOnReview = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
-journal.pcompbiol.notifyOnArchive = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pcompbiol.notifyOnReview = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pcompbiol.notifyOnArchive = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
 
 # PLOS Genetics
 journal.pgenetics.fullname = PLOS Genetics
@@ -812,12 +812,12 @@ journal.pgenetics.integrated = true
 journal.pgenetics.embargoAllowed = false
 journal.pgenetics.allowReviewWorkflow = true
 journal.pgenetics.publicationBlackout = true
-#journal.pgenetics.notifyOnReview= rdickin@plos.org, plosgenetics@plos.org, admin@datadryad.org, curator@datadryad.org
-#journal.pgenetics.notifyOnArchive = rdickin@plos.org, plosgenetics@plos.org, admin@datadryad.org, curator@datadryad.org
-#journal.pgenetics.notifyWeekly = plosgenetics@plos.org, admin@datadryad.org, curator@datadryad.org
+#journal.pgenetics.notifyOnReview= rdickin@plos.org, plosgenetics@plos.org, automated-messages@datadryad.org
+#journal.pgenetics.notifyOnArchive = rdickin@plos.org, plosgenetics@plos.org, automated-messages@datadryad.org
+#journal.pgenetics.notifyWeekly = plosgenetics@plos.org, automated-messages@datadryad.org
 # dleehr - For API Testing 2014-10-29, prior to launch
-journal.pgenetics.notifyOnReview = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
-journal.pgenetics.notifyOnArchive = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pgenetics.notifyOnReview = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pgenetics.notifyOnArchive = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
 
 # PLoS Genetics Test
 journal.pgeneticsTest.fullname = PLOS PGENETICS Test Site
@@ -837,8 +837,8 @@ journal.pmedicine.embargoAllowed = false
 journal.pmedicine.allowReviewWorkflow = true
 journal.pmedicine.publicationBlackout = true
 # dleehr - For API Testing 2014-10-29, prior to launch
-journal.pmedicine.notifyOnReview = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
-journal.pmedicine.notifyOnArchive = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pmedicine.notifyOnReview = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pmedicine.notifyOnArchive = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
 
 # PLOS Neglected Tropical Diseases
 journal.pntd.fullname = PLOS Neglected Tropical Diseases
@@ -849,8 +849,8 @@ journal.pntd.embargoAllowed = false
 journal.pntd.allowReviewWorkflow = true
 journal.pntd.publicationBlackout = true
 # dleehr - For API Testing 2014-10-29, prior to launch
-journal.pntd.notifyOnReview = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
-journal.pntd.notifyOnArchive = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pntd.notifyOnReview = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pntd.notifyOnArchive = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
 
 # PLOS ONE
 journal.pone.fullname = PLOS ONE
@@ -861,8 +861,8 @@ journal.pone.embargoAllowed = false
 journal.pone.allowReviewWorkflow = true
 journal.pone.publicationBlackout = true
 # dleehr - For API Testing 2014-10-29, prior to launch
-journal.pone.notifyOnReview = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
-journal.pone.notifyOnArchive = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pone.notifyOnReview = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.pone.notifyOnArchive = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
 
 # PLOS Pathogens
 journal.ppathogens.fullname = PLOS Pathogens
@@ -873,8 +873,8 @@ journal.ppathogens.embargoAllowed = false
 journal.ppathogens.allowReviewWorkflow = true
 journal.ppathogens.publicationBlackout = true
 # dleehr - For API Testing 2014-10-29, prior to launch
-journal.ppathogens.notifyOnReview = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
-journal.ppathogens.notifyOnArchive = admin@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.ppathogens.notifyOnReview = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
+journal.ppathogens.notifyOnArchive = automated-messages@datadryad.org, dan.leehr@nescent.org, edupin@plos.org
 
 # RSOS
 journal.RSOS.fullname = Royal Society Open Science
@@ -887,8 +887,8 @@ journal.RSOS.publicationBlackout = false
 journal.RSOS.subscriptionPaid = true
 journal.RSOS.sponsorName = The Royal Society
 #journal.RSOS.notifyOnReview = 
-#journal.RSOS.notifyOnArchive = openscience@royalsociety.org, admin@datadryad.org, curator@datadryad.org
-#journal.RSOS.notifyWeekly = openscience@royalsociety.org, admin@datadryad.org, curator@datadryad.org
+#journal.RSOS.notifyOnArchive = openscience@royalsociety.org, automated-messages@datadryad.org
+#journal.RSOS.notifyWeekly = openscience@royalsociety.org, automated-messages@datadryad.org
 
 # Proceedings of the Royal Society B: Biological Sciences
 journal.RSPB.fullname = Proceedings of the Royal Society B
@@ -914,9 +914,9 @@ journal.SDATA.allowReviewWorkflow = true
 journal.SDATA.publicationBlackout = true
 journal.SDATA.subscriptionPaid = true
 journal.SDATA.sponsorName = Nature Publishing Group
-#journal.SDATA.notifyOnReview = Andrew.Hufton@nature.com, admin@datadryad.org, curator@datadryad.org
-#journal.SDATA.notifyOnArchive = Andrew.Hufton@nature.com, admin@datadryad.org, curator@datadryad.org
-#journal.SDATA.notifyWeekly = Andrew.Hufton@nature.com, admin@datadryad.org, curator@datadryad.org
+#journal.SDATA.notifyOnReview = Andrew.Hufton@nature.com, automated-messages@datadryad.org
+#journal.SDATA.notifyOnArchive = Andrew.Hufton@nature.com, automated-messages@datadryad.org
+#journal.SDATA.notifyWeekly = Andrew.Hufton@nature.com, automated-messages@datadryad.org
 
 
 # Subterranean Biology
@@ -927,9 +927,9 @@ journal.subtbiol.integrated= true
 journal.subtbiol.embargoAllowed = false
 journal.subtbiol.allowReviewWorkflow = true
 journal.subtbiol.publicationBlackout = true
-#journal.subtbiol.notifyOnReview = subtbiol@pensoft.net, admin@datadryad.org, curator@datadryad.org
-#journal.subtbiol.notifyOnArchive = subtbiol@pensoft.net, admin@datadryad.org, curator@datadryad.org
-#journal.subtbiol.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+#journal.subtbiol.notifyOnReview = subtbiol@pensoft.net, automated-messages@datadryad.org
+#journal.subtbiol.notifyOnArchive = subtbiol@pensoft.net, automated-messages@datadryad.org
+#journal.subtbiol.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org
 
 # Systematic Biology
 journal.SystBiol.fullname = Systematic Biology
@@ -938,8 +938,8 @@ journal.SystBiol.parsingScheme = manuscriptCentral
 journal.SystBiol.integrated= true
 journal.SystBiol.embargoAllowed = false
 journal.SystBiol.allowReviewWorkflow=true
-journal.SystBiol.notifyOnReview=admin@datadryad.org,test-sysbioreview@scherle.org
-#journal.SystBiol.notifyOnArchive =ron.debry@uc.edu, sysbio@oxfordjournals.org, Caitlyn.Haase@oup.com, Cathy.Kennedy@oup.com, admin@datadryad.org, curator@datadryad.org
+journal.SystBiol.notifyOnReview=automated-messages@datadryad.org,test-sysbioreview@scherle.org
+#journal.SystBiol.notifyOnArchive =ron.debry@uc.edu, sysbio@oxfordjournals.org, Caitlyn.Haase@oup.com, Cathy.Kennedy@oup.com, automated-messages@datadryad.org
 
 # Systematic Botany
 journal.SYSBOT.fullname = Systematic Botany
@@ -951,8 +951,8 @@ journal.SYSBOT.allowReviewWorkflow = false
 journal.SYSBOT.publicationBlackout = true
 journal.SYSBOT.subscriptionPaid = true
 journal.SYSBOT.sponsorName = American Society of Plant Taxonomists
-#journal.SYSBOT.notifyOnReview = systbot@gmail.com, curator@datadryad.org
-#journal.SYSBOT.notifyOnArchive = systematicbotanyme@gmail.com, curator@datadryad.org
+#journal.SYSBOT.notifyOnReview = systbot@gmail.com, automated-messages@datadryad.org
+#journal.SYSBOT.notifyOnArchive = systematicbotanyme@gmail.com, automated-messages@datadryad.org
 #journal.SYSBOT.notifyWeekly = systbot@gmail.com
 
 
@@ -974,5 +974,5 @@ journal.ZSE.publicationBlackout = true
 journal.ZSE.subscriptionPaid = true
 journal.ZSE.sponsorName = Pensoft
 #journal.ZSE.notifyOnReview = 
-#journal.ZSE.notifyOnArchive = layout@pensoft.net, admin@datadryad.org, curator@datadryad.org
-#journal.ZSE.notifyWeekly = info@pensoft.net, admin@datadryad.org, curator@datadryad.org
+#journal.ZSE.notifyOnArchive = layout@pensoft.net, automated-messages@datadryad.org
+#journal.ZSE.notifyWeekly = info@pensoft.net, automated-messages@datadryad.org


### PR DESCRIPTION
Instead of directing all notifications to admin@datadryad.org and
curator@datadryad.org, send them to the automated-notifications list.
Any Dryad staff who want to receive these notifications can sign up
for the list, or just check the archives of the list on Google.
