### PR TITLE
Trello 315: fix tooltips on /feedback and /membership pages

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -24,7 +24,7 @@
                 xmlns:dc="http://purl.org/dc/elements/1.1/"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:confman="org.dspace.core.ConfigurationManager"
-                exclude-result-prefixes="i18n dri mets xlink xsl dim xhtml mods dc">
+                exclude-result-prefixes="dri mets xlink xsl dim xhtml mods dc">
 
     <xsl:import href="../dri2xhtml-alt/dri2xhtml.xsl"/>
     <xsl:import href="lib/xsl/core/global-variables.xsl"/>
@@ -1075,23 +1075,27 @@ parameter that is being used (see variable defined above) -->
         </span>
     </xsl:template>
     <xsl:template match="dri:help">
-        <xsl:if
-                test="not(ancestor::dri:div[@id='aspect.submission.StepTransformer.div.submit-describe-publication' or @id= 'aspect.submission.StepTransformer.div.submit-describe-dataset' or @id= 'aspect.submission.StepTransformer.div.submit-select-publication' or @id= 'aspect.dryadfeedback.MembershipApplicationForm.div.membership-form' or @id= 'aspect.artifactbrowser.FeedbackForm.div.feedback-form'])">
-            <!--Only create the <span> if there is content in the <dri:help> node-->
-            <xsl:if test="./text() or ./node()">
-                <span>
-                    <xsl:attribute name="class">
-                        <xsl:text>field-help</xsl:text>
-                    </xsl:attribute>
-                    <xsl:if test="ancestor::dri:field[@rend='hidden']">
+        <xsl:choose>
+            <!-- only display <help> in tooltip for feedback form -->
+            <xsl:when test="ancestor::dri:div[@id='aspect.artifactbrowser.FeedbackForm.div.feedback-form']"/>
+            
+            <xsl:when test="not(ancestor::dri:div[@id='aspect.submission.StepTransformer.div.submit-describe-publication' or @id= 'aspect.submission.StepTransformer.div.submit-describe-dataset' or @id= 'aspect.submission.StepTransformer.div.submit-select-publication' or @id= 'aspect.dryadfeedback.MembershipApplicationForm.div.membership-form' or @id= 'aspect.artifactbrowser.FeedbackForm.div.feedback-form'])">
+                <!--Only create the <span> if there is content in the <dri:help> node-->
+                <xsl:if test="./text() or ./node()">
+                    <span>
                         <xsl:attribute name="class">
-                            <xsl:text>hidden</xsl:text>
+                            <xsl:text>field-help</xsl:text>
                         </xsl:attribute>
-                    </xsl:if>
-                    <xsl:apply-templates/>
-                </span>
-            </xsl:if>
-        </xsl:if>
+                        <xsl:if test="ancestor::dri:field[@rend='hidden']">
+                            <xsl:attribute name="class">
+                                <xsl:text>hidden</xsl:text>
+                            </xsl:attribute>
+                        </xsl:if>
+                        <xsl:apply-templates/>
+                    </span>
+                </xsl:if>
+            </xsl:when>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="/dri:document/dri:body/dri:div/dri:div/dri:list[@n='most_recent' or @n='link-to-button']">

--- a/dspace/modules/xmlui/src/main/webapp/themes/dri2xhtml-alt/core/forms.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/dri2xhtml-alt/core/forms.xsl
@@ -28,7 +28,7 @@
 	xmlns:dc="http://purl.org/dc/elements/1.1/"
 	xmlns:xalan="http://xml.apache.org/xalan"
 	xmlns="http://www.w3.org/1999/xhtml"
-	exclude-result-prefixes="i18n dri mets xlink xsl dim xhtml mods dc xalan">
+	exclude-result-prefixes="dri mets xlink xsl dim xhtml mods dc xalan">
 
     <xsl:output indent="yes"/>
 
@@ -192,7 +192,7 @@
     <xsl:template name="pick-label">
         <xsl:choose>
             <xsl:when test="dri:field/dri:label">
-                <xsl:variable name="help" select="string(./dri:field/dri:help)"/>
+                <xsl:variable name="help" select="./dri:field/dri:help"/>
                 <label class="ds-form-label">
                         <xsl:choose>
                                 <xsl:when test="./dri:field/@id">
@@ -208,31 +208,56 @@
                         <xsl:choose>
                             <!-- skip the first help on the forgot-email page -->
                             <xsl:when test="./dri:field[@id='aspect.eperson.StartForgotPassword.field.email']"/>
-                            <!-- put all help text in the hover-over field for these items -->
-                            <xsl:when test="$n = 'dc_subject'
-                                         or $n = 'dwc_ScientificName'
-                                         or $n = 'dc_coverage_spatial'
-                                         or $n = 'dc_coverage_temporal'
-                            ">
-                                <xsl:text> </xsl:text>
-                                <img class="label-mark" src="/themes/Mirage/images/help.jpg">
-                                    <xsl:attribute name="title">
-                                        <xsl:value-of select="$help"/>
-                                    </xsl:attribute>
-                                </img>
-                            </xsl:when>
-                            <!-- for other fields, display subsequent sentences in hover text -->
-                            <xsl:otherwise>
-                                <div class="help-title">
-                                    <xsl:value-of select="substring-before($help,'.')"/>.
-                                    <xsl:if test="string-length(substring-after($help,'.'))>0">
+                            
+                            <!-- handle helptext on submission forms -->
+                            <xsl:when test="ancestor::dri:div[contains(@id,'aspect.submission')]">
+                                <xsl:choose>
+                                    <!-- put all help text in the hover-over field for these items -->
+                                    <xsl:when test="$n = 'dc_subject'
+                                                 or $n = 'dwc_ScientificName'
+                                                 or $n = 'dc_coverage_spatial'
+                                                 or $n = 'dc_coverage_temporal'
+                                    ">
+                                        <xsl:text> </xsl:text>
                                         <img class="label-mark" src="/themes/Mirage/images/help.jpg">
                                             <xsl:attribute name="title">
-                                                <xsl:value-of select="substring-after($help,'.')"/>
+                                                <xsl:value-of select="$help"/>
                                             </xsl:attribute>
                                         </img>
-                                    </xsl:if>
-                                </div>                                
+                                    </xsl:when>
+                                    <!-- for other fields, display subsequent sentences in hover text -->
+                                    <xsl:otherwise>
+                                        <div class="help-title">
+                                            <xsl:value-of select="substring-before($help,'.')"/>.
+                                            <xsl:if test="string-length(substring-after($help,'.'))>0">
+                                                <img class="label-mark" src="/themes/Mirage/images/help.jpg">
+                                                    <xsl:attribute name="title">
+                                                        <xsl:value-of select="substring-after($help,'.')"/>
+                                                    </xsl:attribute>
+                                                </img>
+                                            </xsl:if>
+                                        </div>                                
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <span class="help-title">
+                                    <img class="label-mark" src="/themes/Mirage/images/help.jpg">
+                                        <xsl:choose>
+                                            <xsl:when test="$help/i18n:text">
+                                                <xsl:attribute name="title">
+                                                    <xsl:value-of select="$help/i18n:text"/>
+                                                </xsl:attribute>
+                                                <xsl:attribute name="i18n:attr">title</xsl:attribute>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:attribute name="title">
+                                                    <xsl:value-of select="$help"/>
+                                                </xsl:attribute>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
+                                    </img>
+                                </span>
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:if>
@@ -270,7 +295,8 @@
                                         </xsl:choose>
                                     <xsl:apply-templates select="preceding-sibling::*[1][local-name()='label']"/>&#160;
                                     <xsl:if test="string-length($help)>0">
-                                        <div class="help-title"><xsl:value-of select="substring-before($help,'.')"/>.
+                                        <div class="help-title">
+                                            <xsl:value-of select="substring-before($help,'.')"/>.
                                             <xsl:if test="string-length(substring-after($help,'.'))>0">
                                         <img class="label-mark" src="/themes/Mirage/images/help.jpg">
                                             <xsl:attribute name="title">
@@ -315,7 +341,8 @@
         </xsl:choose>
         <xsl:apply-templates />
         <xsl:if test="string-length($help)>0">
-            <div class="help-title"><xsl:value-of select="substring-before($help,'.')"/>.
+            <div class="help-title">
+                <xsl:value-of select="substring-before($help,'.')"/>.
                 <xsl:if test="string-length(substring-after($help,'.'))>0">
                     <img class="label-mark" src="/themes/Mirage/images/help.jpg">
                         <xsl:attribute name="title">
@@ -1209,6 +1236,12 @@
         <xsl:choose>
             <!-- don't output the help text in this mode for the forgot-email page -->
             <xsl:when test="(string(parent::dri:field/@id)='aspect.eperson.StartForgotPassword.field.email')"/>
+            
+            <!-- membership form : do not repeat help text -->
+            <xsl:when test="ancestor::dri:div[@id='aspect.dryadfeedback.MembershipApplicationForm.div.membership-form']"/>
+
+            <!-- feedback form : do not repeat help text -->
+            <xsl:when test="ancestor::dri:div[@id='aspect.artifactbrowser.FeedbackForm.div.feedback-form']"/>
             
             <!--Only create the <span> if there is content in the <dri:help> node-->
             <xsl:when test="./text() or ./node()">


### PR DESCRIPTION
Fixes broken tooltips on /feedback and /membership pages, where the xmlui messages had been broken by a December update made for Submission page tooltips. See these pages on prod for broken tooltips, like `xmlui. (?)`:
 
https://datadryad.org/feedback
https://datadryad.org/membership

Does not change behavior on submission pages (handle/10255/2/submit/), where tooltips part of help text is displayed on the form and part in the tooltip text.