### PR TITLE
atmire-0000 intellij build fix

### DIFF
--- a/dspace/modules/journal-submit/pom.xml
+++ b/dspace/modules/journal-submit/pom.xml
@@ -5,7 +5,6 @@
 	<artifactId>journal-submit</artifactId>
 	<packaging>war</packaging>
 	<name>Dryad Journal Submission :: Web Application</name>
-	<version>0.0.1</version>
 	<description>Dryad Journal Submission Web Application</description>
 
 	<parent>


### PR DESCRIPTION
This is a small fix to the Intellij build that clears a dependency resolution issue in the UI. The problem is that journal-submit inherits a dependencyManagement section from modules/pom.xml that sets version numbering based on the original poms version number. We recommend keeping  version numbering consistent across the entire build.