### PR TITLE
max length for version reason is 255.

### DIFF
--- a/dspace/modules/versioning/versioning-webapp/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionItemForm.java
+++ b/dspace/modules/versioning/versioning-webapp/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionItemForm.java
@@ -81,6 +81,7 @@ public class VersionItemForm extends AbstractDSpaceTransformer {
         Composite addComposite = fields.addItem().addComposite("summary");
         addComposite.setLabel(T_summary);
         TextArea addValue = addComposite.addTextArea("summary");
+        addValue.setMaxLength(255);
         if (errors.contains("version_reason")) {
             addValue.addError(T_reason);
         }


### PR DESCRIPTION
Single-line code change to fix an item on https://trello.com/c/wxjkkTvj/320-bug-s-versioning-bugs and https://nescent.fogbugz.com/default.asp?5149.

Test by deploying, versioning a package, then trying to paste a big chunk into the box:

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt pharetra turpis quis dapibus. Ut varius eros a velit sagittis consequat. Ut ut ornare magna. Aenean volutpat ex ac placerat lobortis. Sed rutrum commodo sapien, a maximus lectus dapibus non. Praesent mi magna, scelerisque ac velit quis, dignissim gravida arcu.
```

It should cut off at `a maximus lectus d`.
