### PR TITLE
add padding to version history header

### DIFF
--- a/dspace/modules/versioning/versioning-webapp/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionHistoryForm.java
+++ b/dspace/modules/versioning/versioning-webapp/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionHistoryForm.java
@@ -132,6 +132,7 @@ public class VersionHistoryForm extends AbstractDSpaceTransformer {
         Table table = main.addTable("versionhistory", 1, 1);
         
         Row header = table.addRow(Row.ROLE_HEADER);
+        header.addCell();
         header.addCell().addContent(T_column1);
         header.addCell().addContent(T_column2);
         //header.addCell().addContent(T_column3);


### PR DESCRIPTION
Added an empty cell to the header of the version history page so that it aligns correctly. Test by finding a versioned package and going to "Show modification history." The header elements should align with the columns now.
