### PR TITLE
git ignore DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ META-INF/
 *.properties
 !build.properties
 notes.txt
+
+## ignore OSX system files
+.DS_Store
+


### PR DESCRIPTION
git should not report that the OSX .DS_Store files are untracked