### PR TITLE
Replace "Be part of Dryad" with twitter feed

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -317,41 +317,13 @@
 
             <!-- START CONNECT  -->
             <div class="home-col-2" style="clear: right;">
-                <h1 class="ds-div-head ds_connect_with_dryad_head" id="ds_connect_with_dryad_head">Be part of Dryad
+                <h1 class="ds-div-head ds_connect_with_dryad_head" id="ds_connect_with_dryad_head">Tweets from Dryad
                 </h1>
 
                 <div id="ds_connect_with_dryad" class="ds-static-div primary" style="height: 475px; font-size: 14px;">
                     <div id="connect-illustrated-prose">
-                        <p>
-                            <img src="/themes/Mirage/images/seed-2.png" style="float: left; margin-left: -8px;" 
-                                 alt="Dryad's data packages are like seeds."
-                                 title="Dryad's data packages are like seeds." />
-                            Publishers, societies, universities, libraries,
-                            funders, and other stakeholder organizations are
-                            invited to become <a href="/pages/membershipOverview">members</a>.
-                            Tap into an active knowledge-sharing network,
-                            receive discounts on submission fees, and help
-                            shape Dryad's future.
-                            <img src="/themes/Mirage/images/seed-3.png" style="float: right; margin-right: -8px;" 
-                                 alt="Researchers use Dryad data in their new work."
-                                 title="Researchers use Dryad data in their new work."/>
-                        </p>
-                        <p>
-                            <a href="/pages/journalIntegration">Submission integration</a> 
-                            is a free service that allows publishers to
-                            coordinate manuscript and data submissions.
-                            It makes submitting data easy for researchers; makes linking
-                            articles and data easy for journals; and enables
-                            confidential review of data prior to publication.
-                        </p>
-                        <p>
-                            <img src="/themes/Mirage/images/seed-1.png" style="float: left; margin-left: -8px;" 
-                                 alt="New data is added to Dryad, and the cycle continues."
-                                 title="New data is added to Dryad, and the cycle continues."/>
-                            Submission fees support the cost of keeping Dryad's content free to use.
-                            Flexible <a href="/pages/pricing">pricing plans</a> 
-                            provide volume discounts.
-                        </p>
+		      <a class="twitter-timeline" href="https://twitter.com/datadryad" data-widget-id="572434627277901824">Tweets by @datadryad</a>
+		      <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>	
                     </div>
                 </div>
             </div>
@@ -576,7 +548,7 @@
     <xsl:template match="dri:options/dri:list[@n='DryadConnect']" priority="3">
       <div class="NOT-simple-box">
         <!-- START CONNECT  -->
-        <h1 class="ds-div-head ds_connect_with_dryad_head" id="ds_connect_with_dryad_head">Be part of Dryad
+        <h1 class="ds-div-head ds_connect_with_dryad_head" id="ds_connect_with_dryad_head">Tweets from Dryad
         </h1>
         <div id="ds_connect_with_dryad" class="ds-static-div primary" style="font-size: 14px;">
             <p style="margin-bottom: 0;">


### PR DESCRIPTION
On the homepage, replace the "Be part of Dryad" section with a feed of twitter content.

This needs to be reviewed by Elizabeth (and perhaps others). Before final integration, the "Be part of Dryad" content needs to be placed on a new page.
