### PR TITLE
trello-41: journal landing pages

### DIFF
--- a/selenium/src/test/java/JournalLandingPageTests.java
+++ b/selenium/src/test/java/JournalLandingPageTests.java
@@ -1,0 +1,91 @@
+
+package test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import static junit.framework.Assert.assertTrue;
+import java.util.Arrays;
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class JournalLandingPageTests extends PagesBase {
+
+    private final static String goodPage = "/journal/Evolution";
+    private final static String badPage = "/journal/__asdf--asdfasdfa";
+    
+    private final static long clickWait = 250; // ms after tab click
+    private final static long pageLoadWait = 250;
+    
+    // minimal set of banner paragraphs
+    private List<String> bannerParaXpaths = Arrays.asList(
+        "//p[@id='aspect_journal_landing_Banner_p_journal-landing-banner-spo']",
+        "//p[@id='aspect_journal_landing_Banner_p_journal-landing-banner-int']",
+        "//p[@id='aspect_journal_landing_Banner_p_journal-landing-banner-aut']",
+        "//p[@id='aspect_journal_landing_Banner_p_journal-landing-banner-dat']",
+        "//p[@id='aspect_journal_landing_Banner_p_journal-landing-banner-met']",
+        "//p[@id='aspect_journal_landing_Banner_p_journal-landing-banner-pac']"
+    );
+    private String searchFormXpath = "//form[@id='aspect_journal_landing_JournalSearch_div_journal-landing-search']";
+    private String searchInputXpath = "//input[@id='aspect_journal_landing_JournalSearch_field_query']";
+    
+    private int buttonMin = 1;
+    private int buttonMax = 4;
+    private String tabButtonFmt = "//a[@href='#aspect_journal_landing_JournalStats_div_journal-landing-stats-%d']";
+    private String tabDivFmt = "//div[@id='aspect_journal_landing_JournalStats_div_journal-landing-stats-%d']";
+    
+    private String searchText = "test text for Evolution search";
+    private String searchResultsPageTitle = "Search Results - Dryad";
+    private String searchUrlPath = "/discover?";
+    
+    // confirm minimal content for page banner
+    public void testBannerLoaded() throws Exception {
+        String pageUrl = baseUrl + goodPage;
+        driver.get(pageUrl);
+        sleepMS(pageLoadWait);
+        assertTrue(xpathsPresent(bannerParaXpaths));
+        driver.close();
+    }
+
+    // cycle through the tab buttons and confirm panel contents visibility
+    public void testBrowseButtons() throws Exception {
+        String pageUrl = baseUrl + goodPage;
+        driver.get(pageUrl);
+        for (int i = buttonMin; i <= buttonMax; ++i) {
+            driver.findElement(By.xpath(String.format(tabButtonFmt, i))).click();
+            sleepMS(clickWait);
+            assertTrue(driver.findElement(By.xpath(String.format(tabDivFmt, i))).isDisplayed());
+        }
+        driver.close();
+    }
+    
+    // confirm that the search page loads when the search form is submitted
+    public void testSearchForm() throws Exception {
+        String pageUrl = baseUrl + goodPage;
+        driver.get(pageUrl);
+        sleepMS(pageLoadWait);
+        WebElement form = driver.findElement(By.xpath(searchFormXpath));
+        WebElement input = driver.findElement(By.xpath(searchInputXpath));
+        assertTrue(input.isDisplayed());
+        input.sendKeys(searchText);
+        form.submit();
+        assertTrue(driver.getTitle().equals(searchResultsPageTitle));
+        String expectedUrlBasePath = baseUrl + searchUrlPath;
+        String actualUrlAll = driver.getCurrentUrl();
+        assertTrue(actualUrlAll.length() >= expectedUrlBasePath.length());
+        assertTrue(actualUrlAll.substring(0, expectedUrlBasePath.length()).equals(expectedUrlBasePath));        
+        driver.close();
+    }    
+    
+    // confirm 404 for non-existant journal
+    // NOTE: http request w/out selenium webdriver, but does require a 
+    // running Dryad application
+    public void test404() throws Exception {
+        String badPageUrl = baseUrl + badPage;
+        URL url = new URL(badPageUrl);
+        HttpURLConnection huc = (HttpURLConnection) url.openConnection();
+        huc.connect();
+        assertTrue(huc.getResponseCode() == 404);
+    }
+    
+}


### PR DESCRIPTION
This pull request implements public journal landing pages, and incorporates all feedback given on the landing page prototype.

There are both junit and selenium tests included. The junit tests (dspace/modules/journal-landing/journal-landing-webapp/src/test/java/org/datadryad/api/DryadJournalTest.java) run as part of the Travis build, and the selenium tests may be run from the `dryad-repo` directory using this command:
```
~/dryad-repo/selenium $ mvn package -DseleniumTestURL="http://192.168.111.223:9999" -Dtest=JournalLandingPageTests
``` 
PR #887 (rnathanday:journal-landing-new-metadata-fields) adds two journal metadata fields (journal.description, journal.memberName) that are used on a landing page, so that PR is a dependency of this one, although not a hard dependency as missing metadatavalues are not an error.

Documentation available in the wiki:
http://wiki.datadryad.org/Journal_Landing_Pages
http://wiki.datadryad.org/Journal_Landing_Pages_build
http://wiki.datadryad.org/Journal_Landing_Page_Mockups