### PR TITLE
Only define solr.authority.server once in dspace.cfg.

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1610,7 +1610,7 @@ org.dspace.content.authority.SolrAuthority = SolrAuthorityType
 
 
 # Configuration settings for ORCID based authority control, uncomment the lines below to enable configuration
-solr.authority.server=${solr.server}/authority
+solr.authority.server=${default.solr.authority.server}
 choices.plugin.dc.contributor.author = SolrAuthorAuthority
 choices.presentation.dc.contributor.author = authorLookup
 authority.controlled.dc.contributor.author = true
@@ -2603,7 +2603,6 @@ solr.log.dataonemn.server = ${default.solr.log.dataonemn.server}
 
 # LOCAL AUTHORITY CONTROLLED FIELD: solr is populated by the class LocalIndexer that refers to every single field reported below.
 # URL to reach SOLR
-solr.authority.server=${default.solr.authority.server}
 solr.authority.indexes=prism.publicationName
 
 


### PR DESCRIPTION
It was defined twice, once to a nonexistent maven variable.