### PR TITLE
Repurposing parts of "be part of Dryad" on homepage (to be replaced by Twitter feed)

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -248,7 +248,7 @@
                             <a href="/pages/membershipOverview">
                                 <img alt="" src="/themes/Mirage/images/watering-can.png" />
                                 <p style="width: 450px; color: #363; font-size: 90%; top: 0px; right: 10px; line-height: 1.2em; position: absolute; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);"> 
-                                    Help grow open data at Dryad:<br />Become an organizational member
+                                    Help grow open data at Dryad: Become an organizational member
                                 </p>
                                 <p style="drop-shadow: 4px 4px; position: absolute; right: 40px; bottom: 80px; font-size: 70%; text-align: right; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);">Learn more &#187;</p>
                             </a>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -244,11 +244,11 @@
                                 <img src="/themes/Mirage/images/membershipMeeting2015_carousel.jpg" alt="Dryad Community Meeting, 27 May 2015, Washington DC" />
                            </a>
                        </div>
-						<div><span class="publication-date">2013-03-01</span>
-                            <a href="/pages/pricing">
+						<div><span class="publication-date">2015-03-23</span>
+                            <a href="/pages/membershipOverview">
                                 <img alt="" src="/themes/Mirage/images/watering-can.png" />
                                 <p style="width: 450px; color: #363; font-size: 90%; top: 0px; right: 10px; line-height: 1.2em; position: absolute; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);"> 
-                                    Data Publishing Charges help sustain open data at Dryad
+                                    Help grow open data at Dryad: Become an organizational member
                                 </p>
                                 <p style="drop-shadow: 4px 4px; position: absolute; right: 40px; bottom: 80px; font-size: 70%; text-align: right; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);">Learn more &#187;</p>
                             </a>
@@ -585,13 +585,8 @@
         </h1>
         <div id="ds_connect_with_dryad" class="ds-static-div primary" style="font-size: 14px;">
             <p style="margin-bottom: 0;">
-                Learn more about:
+                Orgnanizations can be part of Dryad by becoming a <a href="/pages/membershipOverview">member</a>, choosing a <a href="/pages/payment">payment plan</a>, <a href="/pages/submissionIntegration">integrating a journal</a>, or all of the above.
             </p>
-            <ul style="list-style: none; margin-left: 1em;">
-                <li><a href="/pages/membershipOverview">Membership</a></li>
-                <li><a href="/pages/submissionIntegration">Submission integration</a></li>
-                <li><a href="/pages/payment">Payment plans</a></li>
-            </ul> 
         </div>      
 	  </div>
     </xsl:template>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -248,7 +248,7 @@
                             <a href="/pages/membershipOverview">
                                 <img alt="" src="/themes/Mirage/images/watering-can.png" />
                                 <p style="width: 450px; color: #363; font-size: 90%; top: 0px; right: 10px; line-height: 1.2em; position: absolute; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);"> 
-                                    Help grow open data at Dryad: Become an organizational member
+                                    Help grow open data at Dryad:<br />Become an organizational member
                                 </p>
                                 <p style="drop-shadow: 4px 4px; position: absolute; right: 40px; bottom: 80px; font-size: 70%; text-align: right; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);">Learn more &#187;</p>
                             </a>
@@ -585,7 +585,12 @@
         </h1>
         <div id="ds_connect_with_dryad" class="ds-static-div primary" style="font-size: 14px;">
             <p style="margin-bottom: 0;">
-                Orgnanizations can be part of Dryad by becoming a <a href="/pages/membershipOverview">member</a>, choosing a <a href="/pages/payment">payment plan</a>, <a href="/pages/submissionIntegration">integrating a journal</a>, or all of the above.
+                We encourage organizations to: 
+				<ul>
+				<li><a href="/pages/membershipOverview">become a member</a></li>
+				<li><a href="/pages/payment">sponsor data publishing fees</a></li> 
+				<li><a href="/pages/submissionIntegration">integrate your journal(s)</a>, or</li>
+				<li>all of the above!</li>
             </p>
         </div>      
 	  </div>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -585,10 +585,11 @@
             <p style="margin-bottom: 0;">
                 We encourage organizations to:</p>
 				<ul style="list-style: none; margin-left: 1em;">
-				<li><a href="/pages/membershipOverview">become a member</a></li>
-				<li><a href="/pages/payment">sponsor data publishing fees</a></li> 
-				<li><a href="/pages/submissionIntegration">integrate your journal(s)</a>, or</li>
+				<li><a href="/pages/membershipOverview">become a member</a>,</li>
+				<li><a href="/pages/payment">sponsor data publishing fees</a>,</li> 
+				<li><a href="/pages/submissionIntegration">integrate your journal(s)</a>, OR</li>
 				<li>all of the above!</li>
+			</ul>
         </div>      
 	  </div>
     </xsl:template>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -585,10 +585,10 @@
             <p style="margin-bottom: 0;">
                 We encourage organizations to:</p>
 				<ul style="list-style: none; margin-left: 1em;">
-				<li><a href="/pages/membershipOverview">become a member</a></li>
-				<li><a href="/pages/payment">sponsor data publishing fees</a></li> 
-				<li><a href="/pages/submissionIntegration">integrate your journal</a>, or</li>
-				<li>all of the above</li>
+				<li><a href="/pages/membershipOverview">Become a member</a></li>
+				<li><a href="/pages/payment">Sponsor data publishing fees</a></li> 
+				<li><a href="/pages/submissionIntegration">Integrate your journal(s)</a>, or</li>
+				<li>All of the above</li>
 			</ul>
         </div>      
 	  </div>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -585,10 +585,10 @@
             <p style="margin-bottom: 0;">
                 We encourage organizations to:</p>
 				<ul style="list-style: none; margin-left: 1em;">
-				<li><a href="/pages/membershipOverview">become a member</a>,</li>
-				<li><a href="/pages/payment">sponsor data publishing fees</a>,</li> 
-				<li><a href="/pages/submissionIntegration">integrate your journal(s)</a>, OR</li>
-				<li>all of the above!</li>
+				<li><a href="/pages/membershipOverview">become a member</a></li>
+				<li><a href="/pages/payment">sponsor data publishing fees</a></li> 
+				<li><a href="/pages/submissionIntegration">integrate your journal</a>, or</li>
+				<li>all of the above</li>
 			</ul>
         </div>      
 	  </div>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -247,9 +247,7 @@
 						<div><span class="publication-date">2015-03-23</span>
                             <a href="/pages/membershipOverview">
                                 <img alt="" src="/themes/Mirage/images/watering-can.png" />
-                                <p style="width: 450px; color: #363; font-size: 90%; top: 0px; right: 10px; line-height: 1.2em; position: absolute; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);"> 
-                                    Help grow open data at Dryad: Become an organizational member
-                                </p>
+                                <p style="width: 450px; color: #363; font-size: 90%; top: 0px; right: 10px; line-height: 1.2em; position: absolute; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);">Help grow open data at Dryad:<br />Become an organizational member</p>
                                 <p style="drop-shadow: 4px 4px; position: absolute; right: 40px; bottom: 80px; font-size: 70%; text-align: right; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);">Learn more &#187;</p>
                             </a>
                         </div>
@@ -585,13 +583,12 @@
         </h1>
         <div id="ds_connect_with_dryad" class="ds-static-div primary" style="font-size: 14px;">
             <p style="margin-bottom: 0;">
-                We encourage organizations to: 
-				<ul>
+                We encourage organizations to:</p>
+				<ul style="list-style: none; margin-left: 1em;">
 				<li><a href="/pages/membershipOverview">become a member</a></li>
 				<li><a href="/pages/payment">sponsor data publishing fees</a></li> 
 				<li><a href="/pages/submissionIntegration">integrate your journal(s)</a>, or</li>
 				<li>all of the above!</li>
-            </p>
         </div>      
 	  </div>
     </xsl:template>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
@@ -14,7 +14,7 @@
   <div id="ds-body">
     <h1 class="ds-div-head">Payment plans and Data Publishing Charges<a id="pricing">&#160;</a></h1>
     <div class="ds-static-div primary">
-        <p><strong>Dryad is a <strong>nonprofit</strong> organization that provides <strong>long-term access</strong> 
+        <p>Dryad is a <strong>nonprofit</strong> organization that provides <strong>long-term access</strong> 
         to its contents at <strong>no cost</strong> to researchers, educators or students, irrespective of 
         nationality or institutional affiliation. Dryad is able to provide free access to data due to
         financial support from members and data submitters.</p>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
@@ -53,8 +53,8 @@
                 <option value="JPY">JPY¥</option>
             </select>
         </div>
-        <p>Organizations (including publishers, scientific societies, libraries, funders, and others) are encouraged to <strong>cover the costs of data publishing on behalf of their community of researchers</strong>. For instance, a society or publisher may sponsor the DPCs for all the authors of its journals. To do this, 
-            Dryad offers a variety of flexible payment plans that provide for volume discounts. (Sustainer and Supporter-level <a href="/pages/membershipOverview#becomeAMember">members</a> receive additional discounts).</p>
+        <p>Organizations (including publishers, scientific societies, libraries, funders, and others) are encouraged to <strong>cover the costs of data publishing on behalf of their community of researchers</strong>. For instance, a society or publisher may sponsor the DPCs for all the authors of its journals.</p>
+		<p>To do this, Dryad offers a variety of flexible payment plans that provide for volume discounts. (Sustainer and Supporter-level <a href="/pages/membershipOverview#becomeAMember">members</a> receive additional discounts).</p>
         <p>Use our online <a href="/pages/paymentPlanComparisonTool">payment plan comparison tool</a> to compare the annual 
             cost of Dryad's plan options.</p>
         

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
@@ -53,13 +53,8 @@
                 <option value="JPY">JPY¥</option>
             </select>
         </div>
-        <p>Organizations (including publishers, scientific societies, libraries, funders, and others) can <strong>be a part of 
-            Dryad by <a href="/pages/membershipOverview#becomeAMember">becoming a member</a>, participating in a payment plan,
-            or both</strong>. Membership is open to any organization supporting the mission of Dryad. Members have a voice in 
-            the governance of Dryad, and Sustainer and Supporter-level members receive discounts on DPCs (see chart below).</p> 
-        <p>Organizations are encouraged to <strong>cover the costs of data publishing on behalf of their community of researchers</strong>.
-            For instance, a society or publisher may sponsor the DPCs for all the authors of its journals. To do this, 
-            Dryad offers a variety of flexible payment plans that provide for volume discounts.</p>
+        <p>Organizations (including publishers, scientific societies, libraries, funders, and others) are encouraged to <strong>cover the costs of data publishing on behalf of their community of researchers</strong>. For instance, a society or publisher may sponsor the DPCs for all the authors of its journals. To do this, 
+            Dryad offers a variety of flexible payment plans that provide for volume discounts. (Sustainer and Supporter-level <a href="/pages/membershipOverview#becomeAMember">members</a> receive additional discounts).</p>
         <p>Use our online <a href="/pages/paymentPlanComparisonTool">payment plan comparison tool</a> to compare the annual 
             cost of Dryad's plan options.</p>
         

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
@@ -14,7 +14,7 @@
   <div id="ds-body">
     <h1 class="ds-div-head">Payment plans and Data Publishing Charges<a id="pricing">&#160;</a></h1>
     <div class="ds-static-div primary">
-        <p>Dryad is a <strong>nonprofit</strong> organization that provides <strong>long-term access</strong> 
+        <p><img title="Dryad's data packages are like seeds." alt="Dryad's data packages are like seeds." style="float: left; margin-left: -7px; padding: 2px 7px;" src="/themes/Mirage/images/seed-2.png" /><strong>Dryad is a <strong>nonprofit</strong> organization that provides <strong>long-term access</strong> 
         to its contents at <strong>no cost</strong> to researchers, educators or students, irrespective of 
         nationality or institutional affiliation. Dryad is able to provide free access to data due to
         financial support from members and data submitters.</p>
@@ -53,7 +53,7 @@
                 <option value="JPY">JPY¥</option>
             </select>
         </div>
-        <p>Organizations (including publishers, scientific societies, libraries, funders, and others) are encouraged to <strong>cover the costs of data publishing on behalf of their community of researchers</strong>. For instance, a society or publisher may sponsor the DPCs for all the authors of its journals. To do this, 
+        <p>Organizations (including publishers, scientific societies, libraries, funders, and others) are encouraged to <strong>cover the costs of data publishing on behalf of their community of researchers</strong>.For instance, a society or publisher may sponsor the DPCs for all the authors of its journals. To do this, 
             Dryad offers a variety of flexible payment plans that provide for volume discounts. (Sustainer and Supporter-level <a href="/pages/membershipOverview#becomeAMember">members</a> receive additional discounts).</p>
         <p>Use our online <a href="/pages/paymentPlanComparisonTool">payment plan comparison tool</a> to compare the annual 
             cost of Dryad's plan options.</p>
@@ -119,7 +119,7 @@
         </a>             
       </p>
     </div>  
-    <div>Last revised: 2015-02-18</div>
+    <div>Last revised: 2015-03-23</div>
   </div>
  </body>
 </html>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
@@ -53,7 +53,7 @@
                 <option value="JPY">JPY¥</option>
             </select>
         </div>
-        <p>Organizations (including publishers, scientific societies, libraries, funders, and others) are encouraged to <strong>cover the costs of data publishing on behalf of their community of researchers</strong>.For instance, a society or publisher may sponsor the DPCs for all the authors of its journals. To do this, 
+        <p>Organizations (including publishers, scientific societies, libraries, funders, and others) are encouraged to <strong>cover the costs of data publishing on behalf of their community of researchers</strong>. For instance, a society or publisher may sponsor the DPCs for all the authors of its journals. To do this, 
             Dryad offers a variety of flexible payment plans that provide for volume discounts. (Sustainer and Supporter-level <a href="/pages/membershipOverview#becomeAMember">members</a> receive additional discounts).</p>
         <p>Use our online <a href="/pages/paymentPlanComparisonTool">payment plan comparison tool</a> to compare the annual 
             cost of Dryad's plan options.</p>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/payment.xhtml
@@ -14,7 +14,7 @@
   <div id="ds-body">
     <h1 class="ds-div-head">Payment plans and Data Publishing Charges<a id="pricing">&#160;</a></h1>
     <div class="ds-static-div primary">
-        <p><img title="Dryad's data packages are like seeds." alt="Dryad's data packages are like seeds." style="float: left; margin-left: -7px; padding: 2px 7px;" src="/themes/Mirage/images/seed-2.png" /><strong>Dryad is a <strong>nonprofit</strong> organization that provides <strong>long-term access</strong> 
+        <p><strong>Dryad is a <strong>nonprofit</strong> organization that provides <strong>long-term access</strong> 
         to its contents at <strong>no cost</strong> to researchers, educators or students, irrespective of 
         nationality or institutional affiliation. Dryad is able to provide free access to data due to
         financial support from members and data submitters.</p>


### PR DESCRIPTION
Rather than replicating this content exactly as-is, we opted to convert the DPC carousel slide to be about membership and to clarify the "Be part of Dryad" sidebar box used on various pages.