### PR TITLE
Versioning should not create new open carts

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/orcid/model/BioName.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/model/BioName.java
@@ -28,7 +28,7 @@ public class BioName {
         otherNames = new ArrayList<String>();
     }
 
-    BioName(String givenNames, String familyName, String creditName, List<String> otherNames) {
+    public BioName(String givenNames, String familyName, String creditName, List<String> otherNames) {
         this.givenNames = givenNames;
         this.familyName = familyName;
         this.creditName = creditName;

--- a/dspace/modules/api/src/main/java/org/dspace/curate/OdinsHamr.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/OdinsHamr.java
@@ -16,13 +16,13 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import org.dspace.content.DCValue;
@@ -34,6 +34,9 @@ import org.dspace.identifier.IdentifierService;
 import org.dspace.identifier.IdentifierNotFoundException;
 import org.dspace.identifier.IdentifierNotResolvableException;
 import org.dspace.utils.DSpace;
+import org.dspace.authority.orcid.xml.XMLtoBio;
+import org.dspace.authority.orcid.model.Bio;
+import org.dspace.authority.orcid.model.BioName;
 
 import org.apache.log4j.Logger;
 
@@ -56,20 +59,20 @@ public class OdinsHamr extends AbstractCurationTask {
     DocumentBuilder docb = null;
     static long total = 0;
     private Context context;
-    
+
     @Override 
     public void init(Curator curator, String taskId) throws IOException {
         super.init(curator, taskId);
 	
         identifierService = new DSpace().getSingletonService(IdentifierService.class);            
 	
-	// init xml processing
-	try {
-	    dbf = DocumentBuilderFactory.newInstance();
-	    docb = dbf.newDocumentBuilder();
-	} catch (ParserConfigurationException e) {
-	    throw new IOException("unable to initiate xml processor", e);
-	}
+	    // init xml processing
+        try {
+            dbf = DocumentBuilderFactory.newInstance();
+            docb = dbf.newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            throw new IOException("unable to initiate xml processor", e);
+        }
     }
     
     /**
@@ -83,194 +86,189 @@ public class OdinsHamr extends AbstractCurationTask {
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException {
-	log.info("performing ODIN's Hamr task " + total++ );
+        log.info("performing ODIN's Hamr task " + total++ );
 
-	String handle = "\"[no handle found]\"";
-	String itemDOI = "\"[no item DOI found]\"";
-	String articleDOI = "";
-	
-	try {
-	    context = new Context();
-        } catch (SQLException e) {
-	    log.fatal("Unable to open database connection", e);
-	    return Curator.CURATE_FAIL;
-	}
-	
-	if (dso.getType() == Constants.COLLECTION) {
-	    // output headers for the CSV file that will be created by processing all items in this collection
-	    report("itemDOI, articleDOI, orcidID, orcidName, dspaceORCID, dspaceName");
-	} else if (dso.getType() == Constants.ITEM) {
-            Item item = (Item)dso;
+        String handle = "\"[no handle found]\"";
+        String itemDOI = "\"[no item DOI found]\"";
+        String articleDOI = "";
 
-	    try {
-		handle = item.getHandle();
-		log.info("handle = " + handle);
-		
-		if (handle == null) {
-		    // this item is still in workflow - no handle assigned
-		    context.abort(); 
-		    return Curator.CURATE_SKIP;
-		}
-		
-		// item DOI
-		DCValue[] vals = item.getMetadata("dc.identifier");
-		if (vals.length == 0) {
-		    setResult("Object has no dc.identifier available " + handle);
-		    log.error("Skipping -- no dc.identifier available for " + handle);
-		    context.abort(); 
-		    return Curator.CURATE_SKIP;
-		} else {
-		    for(int i = 0; i < vals.length; i++) {
-			if (vals[i].value.startsWith("doi:")) {
-			    itemDOI = vals[i].value;
-			}
-		    }
-		}
-		log.debug("itemDOI = " + itemDOI);
-
-		// article DOI
-		vals = item.getMetadata("dc.relation.isreferencedby");
-		if (vals.length == 0) {
-		    log.debug("Object has no articleDOI (dc.relation.isreferencedby) " + handle);
-		    articleDOI = "";
-		} else {
-		    articleDOI = vals[0].value;
-		}
-		log.debug("articleDOI = " + articleDOI);
-
-
-		// DSpace names
-		List<OrcidName> dspaceNames = new ArrayList<OrcidName>();
-		vals = item.getMetadata("dc.contributor.author");
-		if (vals.length == 0) {
-		    log.error("Object has no dc.contributor.author available in DSpace" + handle);
-		} else {
-		    for(int i = 0; i < vals.length; i++) {
-			dspaceNames.add(new OrcidName("",vals[i].value));
-		    }
-		}
-
-		// ORCID names
-		List<OrcidName> orcidNames = new ArrayList<OrcidName>();
-		orcidNames.addAll(retrieveOrcidNames(itemDOI));
-		
-		if(articleDOI != null && articleDOI.length() > 0) {
-		    List<OrcidName> orcidNamesArticle = retrieveOrcidNames(articleDOI);
-		    for(OrcidName orcidName:orcidNamesArticle) {
-			if(!containsName(orcidNames, orcidName.getName())) {
-			    orcidNames.add(orcidName);
-			}
-		    }
-		}
-		
-		// reconcile names between DSpace and ORCID
-		HashMap<OrcidName,OrcidName> mappedNames = doHamrMatch(dspaceNames, orcidNames);
-		
-		// output the resultant mappings
-		Iterator nameIt = mappedNames.entrySet().iterator();
-		while(nameIt.hasNext()) {
-		    Map.Entry pairs = (Map.Entry)nameIt.next();
-		    OrcidName mappedOrcidEntry = (OrcidName)pairs.getKey();
-		    OrcidName mappedDSpaceEntry = (OrcidName)pairs.getValue();
-		    report(itemDOI + ", " + articleDOI + ", " + mappedOrcidEntry.getOrcid() + ", \"" + mappedOrcidEntry.getName() + "\", " +
-			   mappedDSpaceEntry.getOrcid() + ", \"" + mappedDSpaceEntry.getName() + "\", " + hamrScore(mappedDSpaceEntry,mappedOrcidEntry));
-		
-		    setResult("Last processed item = " + handle + " -- " + itemDOI);
-		}
-		
-		log.info(handle + " done.");
-	    } catch (Exception e) {
-		log.fatal("Skipping -- Exception in processing " + handle, e);
-		setResult("Object has a fatal error: " + handle + "\n" + e.getMessage());
-		report("Object has a fatal error: " + handle + "\n" + e.getMessage());
-		
-		context.abort();
-		return Curator.CURATE_SKIP;
-	    }
-	} else {
-	    log.info("Skipping -- non-item DSpace object");
-	    setResult("Object skipped (not an item)");
-	    context.abort();
-	    return Curator.CURATE_SKIP;
+        try {
+            context = new Context();
+            } catch (SQLException e) {
+            log.fatal("Unable to open database connection", e);
+            return Curator.CURATE_FAIL;
         }
 
-	try { 
-	    context.complete();
-        } catch (SQLException e) {
-	    log.fatal("Unable to close database connection", e);
-	}
+        if (dso.getType() == Constants.COLLECTION) {
+            // output headers for the CSV file that will be created by processing all items in this collection
+            report("itemDOI, articleDOI, orcidID, orcidName, dspaceORCID, dspaceName");
+        } else if (dso.getType() == Constants.ITEM) {
+            Item item = (Item)dso;
 
-	log.info("ODIN's Hamr complete");
-	return Curator.CURATE_SUCCESS;
+            try {
+                handle = item.getHandle();
+                log.info("handle = " + handle);
+
+                if (handle == null) {
+                    // this item is still in workflow - no handle assigned
+                    context.abort();
+                    return Curator.CURATE_SKIP;
+                }
+
+                // item DOI
+                DCValue[] vals = item.getMetadata("dc.identifier");
+                if (vals.length == 0) {
+                    setResult("Object has no dc.identifier available " + handle);
+                    log.error("Skipping -- no dc.identifier available for " + handle);
+                    context.abort();
+                    return Curator.CURATE_SKIP;
+                } else {
+                    for(int i = 0; i < vals.length; i++) {
+                        if (vals[i].value.startsWith("doi:")) {
+                            itemDOI = vals[i].value;
+                        }
+                    }
+                }
+                log.debug("itemDOI = " + itemDOI);
+
+                // article DOI
+                vals = item.getMetadata("dc.relation.isreferencedby");
+                if (vals.length == 0) {
+                    log.debug("Object has no articleDOI (dc.relation.isreferencedby) " + handle);
+                    articleDOI = "";
+                } else {
+                    articleDOI = vals[0].value;
+                }
+                    log.debug("articleDOI = " + articleDOI);
+
+
+                // DSpace names
+                List<Bio> dspaceBios = new ArrayList<Bio>();
+                vals = item.getMetadata("dc.contributor.author");
+                if (vals.length == 0) {
+                    log.error("Object has no dc.contributor.author available in DSpace" + handle);
+                } else {
+                    for(int i = 0; i < vals.length; i++) {
+                        dspaceBios.add(createBio("", vals[i].value));
+                    }
+                }
+
+                // ORCID names
+                List<Bio> orcidBios = retrieveOrcids(itemDOI);
+
+                if(articleDOI != null && articleDOI.length() > 0) {
+                    List<Bio> articleBios = retrieveOrcids(articleDOI);
+                    for(Bio bio : articleBios) {
+                        if(!containsName(orcidBios, bio)) {
+                            orcidBios.add(bio);
+                        }
+                    }
+                }
+
+                // reconcile names between DSpace and ORCID
+                HashMap<Bio,Bio> mappedNames = doHamrMatch(dspaceBios, orcidBios);
+
+                // output the resultant mappings
+                Iterator nameIt = mappedNames.entrySet().iterator();
+                while(nameIt.hasNext()) {
+                    Map.Entry pairs = (Map.Entry)nameIt.next();
+                    Bio mappedOrcidEntry = (Bio)pairs.getValue();
+                    Bio mappedDSpaceEntry = (Bio)pairs.getKey();
+                    report(itemDOI + ", " + articleDOI + ", " + mappedOrcidEntry.getOrcid() + ", \"" + getName(mappedOrcidEntry) + "\", " +
+                       mappedDSpaceEntry.getOrcid() + ", \"" + getName(mappedDSpaceEntry) + "\", " + hamrScore(mappedDSpaceEntry,mappedOrcidEntry));
+
+                    setResult("Last processed item = " + handle + " -- " + itemDOI);
+                }
+
+                log.info(handle + " done.");
+            } catch (Exception e) {
+                log.fatal("Skipping -- Exception in processing " + handle, e);
+                setResult("Object has a fatal error: " + handle + "\n" + e.getMessage());
+                report("Object has a fatal error: " + handle + "\n" + e.getMessage());
+
+                context.abort();
+                return Curator.CURATE_SKIP;
+            }
+        } else {
+            log.info("Skipping -- non-item DSpace object");
+            setResult("Object skipped (not an item)");
+            context.abort();
+            return Curator.CURATE_SKIP;
+            }
+
+        try {
+            context.complete();
+            } catch (SQLException e) {
+            log.fatal("Unable to close database connection", e);
+        }
+
+        log.info("ODIN's Hamr complete");
+        return Curator.CURATE_SUCCESS;
 	}
 
     /**
        Computes a minimum between three integers.
     **/
     private static int minimum(int a, int b, int c) {
-	return Math.min(Math.min(a, b), c);
+	    return Math.min(Math.min(a, b), c);
     }
 
     /**
        Levenshtein distance algorithm, borrowed from
        http://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance
     **/
-    public static int computeLevenshteinDistance(CharSequence str1,
-						 CharSequence str2) {
-	int[][] distance = new int[str1.length() + 1][str2.length() + 1];
+    public static int computeLevenshteinDistance(CharSequence str1, CharSequence str2) {
+        int[][] distance = new int[str1.length() + 1][str2.length() + 1];
 
-	for (int i = 0; i <= str1.length(); i++)
-	    distance[i][0] = i;
-	for (int j = 1; j <= str2.length(); j++)
-	    distance[0][j] = j;
+        for (int i = 0; i <= str1.length(); i++)
+            distance[i][0] = i;
+        for (int j = 1; j <= str2.length(); j++)
+            distance[0][j] = j;
 
-	for (int i = 1; i <= str1.length(); i++)
-	    for (int j = 1; j <= str2.length(); j++)
-		distance[i][j] = minimum(
-					 distance[i - 1][j] + 1,
-					 distance[i][j - 1] + 1,
-					                                                 distance[i - 1][j - 1]
-					 + ((str1.charAt(i - 1) == str2.charAt(j - 1)) ? 0
-					    : 1));
+        for (int i = 1; i <= str1.length(); i++)
+            for (int j = 1; j <= str2.length(); j++)
+            distance[i][j] = minimum(
+                         distance[i - 1][j] + 1,
+                         distance[i][j - 1] + 1,
+                         distance[i - 1][j - 1] + ((str1.charAt(i - 1) == str2.charAt(j - 1)) ? 0 : 1));
 
-	return distance[str1.length()][str2.length()];
+        return distance[str1.length()][str2.length()];
     }
     
     /**
        Scores the correspondence between two author names.
     **/
-    private double hamrScore(OrcidName name1, OrcidName name2) {
-	// if the orcid ID's match, the names are a perfect match
-	if(name1.getOrcid() != null && name1.getOrcid().equals(name2.getOrcid())) {
-	    return 1.0;
-	}
+    private double hamrScore(Bio bio1, Bio bio2) {
+        // if the orcid ID's match, the names are a perfect match
+        if(bio1.getOrcid() != null && bio1.getOrcid().equals(bio2.getOrcid())) {
+            return 1.0;
+        }
 
-	int maxlen = Math.max(name1.getName().length(), name2.getName().length());
-	int editlen = computeLevenshteinDistance(name1.getName(), name2.getName());
+        int maxlen = Math.max(getName(bio1).length(), getName(bio2).length());
+        int editlen = computeLevenshteinDistance(getName(bio1), getName(bio2));
 
-	return (double)(maxlen-editlen)/(double)maxlen;	
+        return (double)(maxlen-editlen)/(double)maxlen;
     }
     
     /**
-       Matches two lists of OrcidNames using the Hamr algorithm.
+       Matches two lists of Orcid names using the Hamr algorithm.
     **/
-    private HashMap<OrcidName,OrcidName> doHamrMatch(List<OrcidName>dspaceNames, List<OrcidName>orcidNames) {
-	HashMap<OrcidName,OrcidName> matchedNames = new HashMap<OrcidName,OrcidName>();
+    private HashMap<Bio,Bio> doHamrMatch(List<Bio>dspaceBios, List<Bio>orcidBios) {
+	HashMap<Bio,Bio> matchedNames = new HashMap<Bio,Bio>();
 
-	// for each dspaceName, find the best possible match in the orcidName list, provided the score is over the threshhold
-	for(OrcidName dspaceName:dspaceNames) {
+	// for each dspaceName, find the best possible match in the orcidBios list, provided the score is over the threshhold
+	for(Bio dspaceBio:dspaceBios) {
 	    double currentScore = 0.0;
-	    OrcidName currentMatch = null;
-	    for(OrcidName orcidName:orcidNames) {
-		double strength = hamrScore(dspaceName, orcidName);
-
-		if(strength > currentScore && strength > MATCH_THRESHHOLD) {
-		    currentScore = strength;
-		    currentMatch = orcidName;
-		}
+	    Bio currentMatch = null;
+	    for(Bio orcidBio:orcidBios) {
+            double strength = hamrScore(dspaceBio, orcidBio);
+            if(strength > currentScore && strength > MATCH_THRESHHOLD) {
+                currentScore = strength;
+                currentMatch = orcidBio;
+            }
 	    }
 	    if(currentScore > 0.0) {
-		matchedNames.put(dspaceName, currentMatch);
+		    matchedNames.put(dspaceBio, currentMatch);
 	    }
 	}
 
@@ -278,94 +276,63 @@ public class OdinsHamr extends AbstractCurationTask {
     }
     
     /**
-       Reports whether a given targetName appears in a list of OrcidNames.
+       Reports whether a given targetName appears in a list of Orcid Bios.
     **/
-    private boolean containsName(List<OrcidName> theList, String targetName) {
-	if(theList != null) {
-	    for(OrcidName aName:theList) {
-		if(aName.getName().equals(targetName)) {
-		    return true;
-		}
-	    }
-	}
-	return false;
+    private boolean containsName(List<Bio> bioList, Bio targetBio) {
+        if(bioList != null) {
+            for(Bio bio:bioList) {
+                if(getName(bio).equals(getName(targetBio))) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
-    /**
-       Retrieve the text of a named sub-element of the given node.
-    **/
-    private String retrieveXMLChild(Node aNode, String elemName) {
-	NodeList subNodes = aNode.getChildNodes();
-	for(int i = 0; i < subNodes.getLength(); i++) {
-	    Node subNode = subNodes.item(i);
-	    String subNodeName = subNode.getNodeName();
-	    if(subNodeName != null && subNodeName.equals(elemName)) {
-		return subNode.getTextContent();
-	    } else {
-		String subResult = retrieveXMLChild(subNode, elemName);
-		if(subResult != null) {
-		    return subResult;
-		}
-		// if subResult is null, the for loop continues to other nodes
-	    }
-	}
-	return null;
+    private Bio createBio (String orcid, String dryadName) {
+        Bio bio = new Bio();
+        bio.setOrcid(orcid);
+
+        // Create a Pattern object
+        Pattern lastfirst = Pattern.compile("(.*),\\s*(.*)");
+
+        // Now create matcher object.
+        Matcher m = lastfirst.matcher(dryadName);
+        if (m.find()) {
+            bio.setName(new BioName(m.group(2), m.group(1), "", null));
+        } else {
+            log.error("Name " + dryadName + " is not in lastname, firstname format.");
+        }
+        return bio;
     }
-    
+
     /**
        Retrieve a list of names associated with this DOI in ORCID.
        The DOI may represent a Dryad item, or any other work.
     **/
-    private List<OrcidName> retrieveOrcidNames(String aDOI) {
-	List<OrcidName> orcidNames = new ArrayList<OrcidName>();
+    private List<Bio> retrieveOrcids(String aDOI) {
+        List<Bio> orcidBios = new ArrayList<Bio>();
 
-	if(aDOI.startsWith("doi:")) {
-	    aDOI = aDOI.substring("doi:".length());
-	}
-	try {
-	    URL orcidQuery = new URL(ORCID_QUERY_BASE + "%22" + aDOI + "%22");
-	    Document orcidDoc = docb.parse(orcidQuery.openStream());
-	    NodeList nl = orcidDoc.getElementsByTagName("orcid-profile");
-	    // for each returned ORCID profile...
-	    for(int i = 0; i < nl.getLength(); i++) {
-		Node profile = nl.item(i);
-		String theOrcid = retrieveXMLChild(profile, "orcid");
-		String givenName = retrieveXMLChild(profile, "given-names");
-		String familyName = retrieveXMLChild(profile, "family-name");
-		orcidNames.add(new OrcidName(theOrcid, familyName +  ", " + givenName));
-	    }
-	} catch (MalformedURLException e) {
-	    log.error("cannot make a valid URL for aDOI="  + aDOI, e);
-	} catch (IOException e) {
-	    log.error("IO problem for aDOI="  + aDOI, e);
-	} catch (SAXException e) {
-	    log.error("error processing XML for aDOI="  + aDOI, e);
-	}
+        if(aDOI.startsWith("doi:")) {
+            aDOI = aDOI.substring("doi:".length());
+        }
+        try {
+            URL orcidQuery = new URL(ORCID_QUERY_BASE + "%22" + aDOI + "%22");
+            Document orcidDoc = docb.parse(orcidQuery.openStream());
+            XMLtoBio converter = new XMLtoBio();
+            return orcidBios = converter.convert(orcidDoc);
+        } catch (MalformedURLException e) {
+            log.error("cannot make a valid URL for aDOI="  + aDOI, e);
+        } catch (IOException e) {
+            log.error("IO problem for aDOI="  + aDOI, e);
+        } catch (SAXException e) {
+            log.error("error processing XML for aDOI="  + aDOI, e);
+        }
 
-	return orcidNames;
+        return orcidBios;
     }
 
-    
-    class OrcidName extends Object {
-	private String orcid = "";
-	private String name = "";
-	
-	public OrcidName(String orcid, String name) {
-	    this.orcid = orcid;
-	    this.name = name;
-	}
-
-	public String getName() {
-	    return name;
-	}
-
-	public String getOrcid() {
-	    return orcid;
-	}
-
-	public String toString() {
-	    return name;
-	}
+    private String getName(Bio bio) {
+        return bio.getName().getFamilyName() + ", " + bio.getName().getGivenNames();
     }
-    
 }

--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/PaymentSystemImpl.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/PaymentSystemImpl.java
@@ -206,6 +206,15 @@ public class PaymentSystemImpl implements PaymentSystemService {
             if(shoppingCarts.size()>0)
             {
                 return shoppingCarts.get(0);
+            } else {
+                // if the original item doesn't have a shopping cart,
+                // this item must've been created before the payment system was in place.
+                // We should create a completed placeholder cart for the original item, but make sure it is marked
+                // that it was created for versioning and should not be re-charged.
+                ShoppingCart versionCart = createNewShoppingCart(context,itemId,context.getCurrentUser().getID(),"",ShoppingCart.CURRENCY_US,ShoppingCart.STATUS_COMPLETED);
+                versionCart.setNote("cart created for versioning; do not charge");
+                versionCart.update();
+                return versionCart;
             }
 
         }


### PR DESCRIPTION
Fixes https://trello.com/c/FLbyGElK/39-recurring-when-versioning-older-items-curators-are-asked-to-enter-payment-information

To test: 
* create a new package in your VM, take it through to archiving.
* delete the shopping cart associated with it (to simulate a package that existed before the cart system)
* version the package, take it through to archiving.

The original item should now have an associated cart that is marked as "completed" and has a note "cart created for versioning; do not charge".