### PR TITLE
Email redirect

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -111,7 +111,7 @@ mail.admin = ${default.mail.admin}
 alert.recipient = ${mail.admin}
 
 # Recipient for new user registration emails
-registration.notify = ${mail.admin}
+registration.notify = ${default.automated_email.recipient}
 
 # Recipient for mailing list subscription emails
 subscribe_mailinglist.recipient = ${default.subscribe_mailinglist.recipient}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -111,7 +111,10 @@ mail.admin = ${default.mail.admin}
 alert.recipient = ${mail.admin}
 
 # Recipient for new user registration emails
-registration.notify = ${default.automated_email.recipient}
+registration.notify = ${default.automated.email.recipient}
+
+# Recipient for general automated emails
+automated.email.recipient = ${default.automated.email.recipient}
 
 # Recipient for mailing list subscription emails
 subscribe_mailinglist.recipient = ${default.subscribe_mailinglist.recipient}


### PR DESCRIPTION
Redirect some of the automated system messages to go to a specific email address, rather than users in certain roles.

To use, add a configuration to the maven settings.xml file like:

``` xml
<default.automated.email.recipient>some-email@somewhere.org</default.automated.email.recipient>
```

To test, create a new EPerson and use that EPerson to submit a data package for curation. The email notifications of these activities should go to the email set in the maven file.
