### PR TITLE
Update DryadJournalSubmission.testing.properties

### DIFF
--- a/dspace/config/DryadJournalSubmission.testing.properties
+++ b/dspace/config/DryadJournalSubmission.testing.properties
@@ -6,7 +6,7 @@
 # receive email about test submissions.
 #
 
-journal.order=test, testbo, AMJBOT, amNat, APPS, BEHECO, BDJ, BJJ, BJR,  BJLS, BIOLETTS, biorisk, BITR, BMCEcol, BMCEvolBiol, BMCTEST, bmjOpen, compcytogen, ECOG, ecoMono, ECE3, ECOLETS, evolution, EvolApp, ecap, ecoFrontiers, ecol, Elementa, EBPM, EvolBiol, FE, GMSGMS, GMSGPRAS, GMSHTA, GMSHIC, GMSID, GMSIPRS, GMSMBI, GMSMIBE, GMSORS, GMSZMA, GMSLAB, heredity, ijm, JAE, JAV, JECOL, JAPPL, jcr, jfwm, jhered, jhr, JOPHD, jpaleo, JPAKMED, mbe, MEE, MolEcol, MolEcolRes, mpe, mycokeys, natureconservation, neobiota, NJB, NL, OIK, PALA, PP, paleobiology, phytokeys, plantSciB, pbiology, pbiologyTest, pcompbiol, pgenetics, pgeneticsTest, pmedicine, pntd, pone, ppathogens, RSOS, RSPB, SDATA, subtbiol, SYSBOT, SystBiol, ZooKeys, ZSE
+journal.order=test, testbo, AMJBOT, amNat, APPS, BEHECO, BDJ, BJJ, BJR,  BJLS, BIOLETTS, biorisk, BITR, BMCEcol, BMCEvolBiol, BMCTEST, bmjOpen, compcytogen, ECOG, ecoMono, ECE3, ECOLETS, evolution, EvolApp, ecap, ecoFrontiers, ecol, Elementa, EBPM, EvolBiol, FE, GMSGMS, GMSGPRAS, GMSHTA, GMSHIC, GMSID, GMSIPRS, GMSMBI, GMSMIBE, GMSORS, GMSZMA, GMSLAB, heredity, ijm, JAE, JAV, JECOL, JAPPL, jcr, jfwm, jhered, jhr, JOPHD, jpaleo, JPAKMED, mbe, MEE, MolEcol, MolEcolRes, mpe, mycokeys, natureconservation, neobiota, NJB, NL, OIK, PALA, PP, paleobiology, PBZ, phytokeys, plantSciB, pbiology, pbiologyTest, pcompbiol, pgenetics, pgeneticsTest, pmedicine, pntd, pone, ppathogens, RSOS, RSPB, SDATA, subtbiol, SYSBOT, SystBiol, ZooKeys, ZSE
 
 
 
@@ -57,7 +57,7 @@ journal.AMJBOT.parsingScheme = amNat
 journal.AMJBOT.integrated = true
 journal.AMJBOT.embargoAllowed = false
 journal.AMJBOT.allowReviewWorkflow = true
-journal.AMJBOT.publicationBlackout = false
+journal.AMJBOT.publicationBlackout = true
 journal.AMJBOT.subscriptionPaid = true
 journal.AMJBOT.sponsorName = Botanical Society of America
 #journal.AMJBOT.notifyOnReview = amcpherson@botany.org, rhund@botany.org, automated-messages@datadryad.org
@@ -92,7 +92,7 @@ journal.BEHECO.parsingScheme = manuscriptCentral
 journal.BEHECO.integrated = true
 journal.BEHECO.embargoAllowed = true
 journal.BEHECO.allowReviewWorkflow = false
-journal.BEHECO.publicationBlackout = true
+journal.BEHECO.publicationBlackout = false
 journal.BEHECO.subscriptionPaid = true
 journal.BEHECO.sponsorName = International Society for Behavioral Ecology
 #journal.BEHECO.notifyOnReview =
@@ -169,7 +169,7 @@ journal.BITR.parsingScheme = manuscriptCentral
 journal.BITR.integrated = true
 journal.BITR.embargoAllowed = true
 journal.BITR.allowReviewWorkflow = false
-journal.BITR.publicationBlackout = false
+journal.BITR.publicationBlackout = true
 journal.BITR.subscriptionPaid = true
 journal.BITR.sponsorName = Association for Tropical Biology and Conservation
 #journal.BITR.notifyOnReview = wendy.martin@env.ethz.ch, embruna@ufl.edu, automated-messages@datadryad.org
@@ -794,6 +794,20 @@ journal.PP.subscriptionPaid = true
 #journal.PP.notifyOnReview=editor@palass.org, automated-messages@datadryad.org
 #journal.PP.notifyOnArchive = editor@palass.org, automated-messages@datadryad.org
 #journal.PP.notifyWeekly=a.smith@nhm.ac.uk, automated-messages@datadryad.org
+
+# Physiological and Biochemical Zoology
+journal.PBZ.fullname = Physiological and Biochemical Zoology
+journal.PBZ.metadataDir = /opt/dryad/submission/journalMetadata/PBZ
+journal.PBZ.parsingScheme = amNat
+journal.PBZ.integrated = true
+journal.PBZ.embargoAllowed = true
+journal.PBZ.allowReviewWorkflow = true
+journal.PBZ.publicationBlackout = true
+journal.PBZ.subscriptionPaid = true
+journal.PBZ.sponsorName = 
+#journal.PBZ.notifyOnReview = wendy.martin@env.ethz.ch, embruna@ufl.edu, automated-messages@datadryad.org
+#journal.PBZ.notifyOnArchive = wendy.martin@env.ethz.ch, embruna@ufl.edu, automated-messages@datadryad.org
+#journal.PBZ.notifyWeekly = wendy.martin@env.ethz.ch, embruna@ufl.edu, automated-messages@datadryad.org
 
 # phytokeys
 journal.phytokeys.fullname = PhytoKeys


### PR DESCRIPTION
Added Physiological and Biochemical Zoology and updated pub blackout for American Journal of Botany (AMJBOT),  Biotropica (BITR), Applications in Plant Sciences (APPS) and Behavioral Ecology (BEHECO).
