### PR TITLE
Change symlinks into actual files

### DIFF
--- a/test/config/emails
+++ b/test/config/emails
@@ -1,1 +1,0 @@
-../../dspace/config/emails

--- a/test/config/emails/bagit_error
+++ b/test/config/emails/bagit_error
@@ -1,0 +1,19 @@
+# Email sent to DSpace admin when a bagit export fails to complete
+#
+# Parameters: {0} the export error
+#             {1} the email address of the person requesting the item
+#             {2} the item that did not export correctly
+#             {3} the location of the files created by the disseminator
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad - Problem with the bagit exporter
+A bagit export was not successfully completed, due to the following reason:
+
+{0}
+ 
+The item was requested by {1}
+ 
+The item in question is {2}
+ 
+The location of the work products is {3}

--- a/test/config/emails/bagit_notify
+++ b/test/config/emails/bagit_notify
@@ -1,0 +1,21 @@
+# Email sent to user when s/he selects to also upload data to a remote repo
+#
+# Parameters: {0} the remote repository to which s/he has uploaded data
+#             {1} the URL the user needs to log into to complete the upload
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Your Dryad Submission to {0}
+
+Thank you for your recent deposit to the Dryad repository. During your
+submission, you chose to also automatically upload your data to {0}.
+
+This upload has been completed.  To finish the {0} submission you
+will need to log in to {0} and complete the process.  You can do
+this by visiting:
+
+{1}
+
+Thanks.
+
+Dryad

--- a/test/config/emails/change_password
+++ b/test/config/emails/change_password
@@ -1,0 +1,14 @@
+# Email sent to DSpace users when they forget their password.
+#
+# Parameters: {0} is expanded to a special URL
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Change Password Request
+Dryad has received a request to reset your password.  If you did not initiate this request, or if you require any other assistance with your account, please notify help@datadryad.org.  Otherwise, click the link below to change your password:
+
+  {0}
+
+If you need assistance with your account, please email help@datadryad.org
+
+The Dryad Team

--- a/test/config/emails/datacite_error
+++ b/test/config/emails/datacite_error
@@ -1,0 +1,15 @@
+# Email sent to DSpace admin when a datacite update fails to complete
+#
+# Parameters: {0} registration/update
+#             {1} the exception
+#             {2} the item in question
+
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad - Problem with the datacite EZID
+A Datacite EZID {0} was not successfully completed, due to the following reason:
+
+{1}
+
+The item in question is: {2}

--- a/test/config/emails/export_error
+++ b/test/config/emails/export_error
@@ -1,0 +1,19 @@
+# Email sent to DSpace users when they successfully export an item or collection.
+#
+# Parameters: {0} the export error
+#             {1} the URL to the feedback page
+#             
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad - The item export you requested was not completed.
+The item export you requested was not completed, due to the following reason:
+ {0}
+
+For more information you may contact your system administrator:
+ {1}
+
+
+
+The Dryad Team
+

--- a/test/config/emails/export_success
+++ b/test/config/emails/export_success
@@ -1,0 +1,18 @@
+# Email sent to DSpace users when they successfully export an item or collection.
+#
+# Parameters: {0} is expanded to a special URL
+#             {1} configurable time (hours) an export file will be kept
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad - Item export requested is ready for download
+The item export you requested from the repository is now ready for download.
+
+You may download the compressed file using the following link:
+{0}
+
+This file will remain available for at least {1} hours.  
+
+
+The Dryad Team
+

--- a/test/config/emails/feedback
+++ b/test/config/emails/feedback
@@ -1,0 +1,26 @@
+# E-mail sent with the information filled out in a feedback form.
+#
+# Parameters: {0} current date
+#             {1} email address that the user provided
+#             {2} logged in as
+#             {3} page that the user was on when they selected feedback
+#             {4} User-Agent HTTP Header
+#             {5} Session Id
+#             {6} The user's comments
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Feedback Form Information
+
+Comments:
+
+{6}
+
+
+Date: {0}
+Email: {1}
+Logged In As: {2}
+Referring Page: {3}
+User Agent: {4}
+Session: {5}
+

--- a/test/config/emails/flowtask_notify
+++ b/test/config/emails/flowtask_notify
@@ -1,0 +1,23 @@
+# Workflow curation task notification email message
+#
+# {0}  Title of submission
+# {1}  Name of collection
+# {2}  Submitter's name
+# {3}  Name of task operating
+# {4}  Task result
+# {5}  Workflow action taken
+#
+Subject: DSpace: Curation Task Report
+
+Title:         {0}
+Collection:    {1}
+Submitted by:  {2}
+
+Curation task {3} has been performed
+with the following result:
+
+{4}
+
+Action taken on the submission: {5}
+
+DSpace

--- a/test/config/emails/harvesting_error
+++ b/test/config/emails/harvesting_error
@@ -1,0 +1,20 @@
+# E-mail sent to designated address when a harvest process fails
+#
+# Parameters: {0} Collection id
+#             {1} Date & time
+#             {2} Status flag
+#             {3} Exception message
+#             {4} Exception stack trace
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad: Harvesting Error
+Collection {0} failed on harvest:
+
+Date:       	{1}
+Status Flag: 	{2}
+
+{3}
+
+Exception:
+{4}

--- a/test/config/emails/internal_error
+++ b/test/config/emails/internal_error
@@ -1,0 +1,24 @@
+# E-mail sent to designated address when an internal server error occurs
+#
+# Parameters: {0} DSpace server URL
+#             {1} Date & time
+#             {2} Session ID
+#             {3} URL + HTTP parameters, if any
+#             {4} Exception stack trace
+#             {5} User details
+#             {6} IP address
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad: Internal Server Error
+An internal server error occurred on {0}:
+
+Date:       {1}
+Session ID: {2}
+User:       {5}
+IP address: {6}
+
+{3}
+
+Exception:
+{4}

--- a/test/config/emails/journal_submit_error
+++ b/test/config/emails/journal_submit_error
@@ -1,0 +1,15 @@
+# Email sent when there is a problem with the journal submission process
+#
+# Parameters: {0} the exception message that was caught at point of error
+#             {1} the location of the journal-submit logs (for more details)
+#             
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+# This email goes to the DSpace ${mail.admin} email account
+#
+Subject: Journal-Submit Problem
+Journal submit failed to complete, due to the following reason:
+ {0}
+
+ Check the logs at '{1}' for more details

--- a/test/config/emails/membership_application
+++ b/test/config/emails/membership_application
@@ -1,0 +1,43 @@
+# Dryad Membership Application
+# {0}   Submission Date
+# {1}   Organization Name
+# {2}   Organization Legalname (if different)
+# {3}   Organization Type
+# {4}   Organization annual revenue
+# {5}   Organization annual revenue currency
+# {6}   Billing Contact Name
+# {7}   Billing Contact Email
+# {8}   Billing address
+# {9}   Publications
+# {10}   Membership Year Start
+# {11}   Membership Year Duration (yearsa)
+# {12}   Dryad Representative Name
+# {13}  Dryad Representative Email
+# {14}  Comments
+# {15}  User Agent
+# {16}  Session ID
+#
+Subject: Dryad: Membership Application Submitted
+
+A new Dryad Membership Application has been submitted:
+
+Submission Date:				{0}
+Organization Name:				{1}
+Organization Legal Name:		{2}
+Organization Type:				{3}
+Organization Annual revenue:	{4} 
+Organization Annual revenue currency: {5}
+Billing Contact Name:			{6}
+Billing Contact Email:			{7}
+Billing address:				{8}
+Publications:					{9}
+Membership Term:				{10}, {11}
+Dryad Representative Name:		{12}
+Dryad Representative Email:		{13}
+Comments:						{14}
+User Agent:						{15}
+Session ID:						{16}
+
+Thanks,
+
+The Dryad Team

--- a/test/config/emails/payment_approved
+++ b/test/config/emails/payment_approved
@@ -1,0 +1,26 @@
+# Approved email message
+#
+# {0}  Title of submission
+# {1}  Submitter
+# {2}  Shopping Cart Contents
+#
+Subject: Dryad: Payment Receipt
+
+Receipt for Data Publishing Charges
+Dryad Digital Repository
+datadryad.org
+
+Thank you for your online payment of the Dryad Data Publishing Charge for the data submission described below:
+
+Received from: {1}
+
+Dryad submission: {0}
+
+Payment details:
+
+{2}
+
+Your data are now securely and permanently archived at datadryad.org.  
+
+The Dryad Team
+datadryad.org

--- a/test/config/emails/payment_error
+++ b/test/config/emails/payment_error
@@ -1,0 +1,18 @@
+# Error email message
+#
+# Title of submission: {0}
+# Submitter: {1}
+# Error: {2}
+# Shopping cart contents: {3}
+#
+Subject: Dryad: Error Receipt
+
+There was a problem with the payment processing step in Dryad.
+
+Title of submission: {0}
+Submitter: {1}
+Error: {2}
+
+Shopping Cart Contents
+
+{3}

--- a/test/config/emails/payment_needs_reauthorization
+++ b/test/config/emails/payment_needs_reauthorization
@@ -1,0 +1,17 @@
+# Failed payment needs reauthorization message
+#
+# {0}  Title of submission
+# {1}  Submitter's name
+#
+Subject: Dryad: Payment needs reauthorization
+
+Dryad submission: {0}
+Submitter: {1}
+
+Thank you for your submission to Dryad.  Your data package has been curated and approved, but there was an issue processing the Dryad Data Publishing Charge.
+
+To complete the transaction, please go to https://datadryad.org/submissions, open your submission, and enter new
+payment information. Once the transaction is completed, your data will be securely and permanently archived in Dryad.
+
+The Dryad Team
+datadryad.org

--- a/test/config/emails/payment_rejected
+++ b/test/config/emails/payment_rejected
@@ -1,0 +1,26 @@
+# Rejection email message
+#
+# Title of submission: {0}
+# Submitter: {1}
+# Shopping cart contents: {2}
+#
+Subject: Dryad: Your Payment Was Rejected
+
+You submitted the following data package to Dryad: 
+{0}
+
+Submitter: {1}
+
+Shopping Cart Contents
+
+{2}
+
+The payment information that you previously entered is no longer
+valid. Please login to Dryad and provide current payment information.
+
+You can access the in-progress submission from your "My Submissions"
+page: 
+http://datadryad.org/submissions
+
+The Dryad Team
+datadryad.org

--- a/test/config/emails/payment_waived
+++ b/test/config/emails/payment_waived
@@ -1,0 +1,19 @@
+# Waived Payment email message
+#
+# {0}  Title of submission
+# {1}  Submitter
+# {2}  Shopping Cart Contents
+#
+Subject: Dryad: Waived Payment Receipt
+
+This is your receipt for data archiving with Dryad.
+
+Dryad submission: {0}
+Submitter: {1}
+
+Shopping Cart Contents
+
+{2}
+
+The Dryad Team
+datadryad.org

--- a/test/config/emails/register
+++ b/test/config/emails/register
@@ -1,0 +1,15 @@
+# E-mail sent to DSpace users when they register for an account
+#
+# Parameters: {0} is expanded to a special registration URL
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad Account Registration
+
+Thank you for registering for an account at datadryad.org.  To complete registration for your account, please click the link below:
+
+ {0}
+
+If you need assistance with your account, please email help@datadryad.org.  For more information about using or submitting data, please see http://datadryad.org/pages/faq.
+
+The Dryad Team

--- a/test/config/emails/registration_notify
+++ b/test/config/emails/registration_notify
@@ -1,0 +1,17 @@
+# Registration notification email
+#
+# Parameters: {0} The name of the DSpace instance
+#             {1} The URL of the DSpace instance 
+#             {2} Name:
+#             {3} Email:
+#             {4} Registration Date:
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad: Registration Notification
+
+A new user has registered on {0} at {1}:
+
+Name:                   {2}
+Email:                  {3}
+Date:                   {4}

--- a/test/config/emails/submit_archive
+++ b/test/config/emails/submit_archive
@@ -1,0 +1,21 @@
+# Item Archived email message
+#
+# {0}  Title of submission
+# {1}  Name of collection
+# {2}  handle 
+#
+Subject: DSpace: Submission Approved and Archived 
+
+You submitted: {0}
+
+To collection: {1}
+
+Your submission has been accepted and archived in DSpace,
+and it has been assigned the following identifier:
+{2}
+
+Please use this identifier when citing your submission.
+
+Many thanks!
+
+DSpace

--- a/test/config/emails/submit_article_reject
+++ b/test/config/emails/submit_article_reject
@@ -1,0 +1,22 @@
+# Rejection email message
+# This message is sent to the submitter when Dryad receives
+# notification that their article has been rejected by the journal.
+#
+# {0}  Title of submission
+# {1}  Name(s) of the data file(s)
+# {2}  Name of the rejector (may be blank due to automated script action)
+# {3}  Reason for the rejection
+# {4}  Link to 'My DSpace' page
+#
+Subject: Dryad: Data package returned
+
+You submitted a data package to Dryad titled: {0}
+with the following data files:
+{1}
+
+The journal has notified Dryad that the associated article is no longer under review. Therefore, the Dryad data package has been returned to your personal workspace, and will not be reviewed by the Dryad curators. This data package will be available in your workspace for a period of one year.
+
+Your submission has not been deleted.  You can access it from your
+"My Submissions" page at http://datadryad.org/submissions
+
+The Dryad Team

--- a/test/config/emails/submit_datapackage_archive
+++ b/test/config/emails/submit_datapackage_archive
@@ -1,0 +1,51 @@
+# Data package Archived email message
+# This message is sent to a submitter when the Dryad curator
+# has approved the submission, and the data package is moved into
+# the main Dryad archive.
+# 
+# {0}  Title of data package
+# {1}  The doi identifier of the data package
+# {2}  The title(s) of the data file(s)
+# {3}  The doi's of the data files
+# {4}  The submitters full name
+# {5}  The manuscript identifier (or "none available" if the metadata doesn't contain one)
+#
+Subject: Dryad submission approved {1}
+
+Dear {4},
+
+Thank you for your submission to the Dryad repository. Your data package has been approved, and the DOI is now fully registered with the DOI system.
+
+Title: {0}
+DOI: {1}
+Journal manuscript number: {5}
+
+
+CITING YOUR DRYAD DATA
+
+Ensure that readers can find your data!
+
+We recommend that the article include a link to the Dryad data as follows (subsitute your DOI suffix for the xxxxx):
+
+Data available from the Dryad Digital Repository: http://dx.doi.org/10.5061/dryad.xxxxx 
+
+Your journal may follow the CrossRef recommendation that the data package be cited in the article Reference list. If so, the citation should include the Dryad package DOI, e.g.: 
+
+Author(s) (Year). Data from [title]. Dryad Digital Repository. {1}
+
+
+To view your Dryad entry, you may visit the repository at http://datadryad.org
+
+Check out the information for depositors at http://datadryad.org/pages/faq
+- How do I refer to my Dryad data in my article?
+- How can I see how often my data package is viewed and downloaded?
+- How can I add my data package to a Data section on my CV?
+- If my data files are embargoed, when will they be released?
+- and more!
+
+Thanks again for taking this important step to preserve and share your research data.
+
+We welcome your feedback! Contact us at help@datadryad.org.
+
+The Dryad Team
+datadryad.org 

--- a/test/config/emails/submit_datapackage_blackout
+++ b/test/config/emails/submit_datapackage_blackout
@@ -1,0 +1,49 @@
+# Data package Approved into Blackout email message
+# This message is sent to a submitter when the Dryad curator
+# has approved a submission and sent it to blackout.
+# 
+# {0}  Title of data package
+# {1}  The doi identifier of the data package
+# {2}  The title(s) of the data file(s)
+# {3}  The doi's of the data files
+# {4}  The submitters full name
+# {5}  The manuscript identifier (or "none available" if the metadata doesn't contain one)
+#
+Subject: Dryad submission approved pending publication {1}
+
+Dear {4},
+
+Thank you for your submission to the Dryad repository. Your data package has been approved, and will be available in the repository once the associated article has been published. 
+
+Title: {0}
+DOI: {1}
+Journal manuscript number: {5}
+
+You will receive another email when your data package is released. If you did not request a data embargo, your file(s) will be available for download after the article is published.
+
+
+CITING YOUR DRYAD DATA
+
+Ensure that readers can find your data!
+
+We recommend that the article include a link to the Dryad data as follows (subsitute your DOI suffix for the xxxxx):
+
+Data available from the Dryad Digital Repository: http://dx.doi.org/10.5061/dryad.xxxxx 
+
+Your journal may follow the CrossRef recommendation that the data package be cited in the article Reference list. If so, the citation should include the Dryad package DOI, e.g.: 
+
+Author(s) (Year). Data from [title]. Dryad Digital Repository. {1}
+
+
+Check out the information for depositors at http://datadryad.org/pages/faq
+- How do I refer to my Dryad data in my article?
+- How can I see how often my data package is viewed and downloaded?
+- How can I add my data package to a Data section on my CV?
+- If my data files are embargoed, when will they be released?
+- and more!
+
+Thanks again for taking this important step to preserve and share your research data.
+We welcome your feedback! Contact us at help@datadryad.org.
+
+The Dryad Team
+datadryad.org 

--- a/test/config/emails/submit_datapackage_blackout_archive
+++ b/test/config/emails/submit_datapackage_blackout_archive
@@ -1,0 +1,53 @@
+# Data package Archived after blackout email message
+# This message is sent to a submitter when the Dryad curator
+# has approved a submission that was previously in publication blackout
+# and the submission is now in the main Dryad archive.
+# 
+# {0}  Title of data package
+# {1}  The doi identifier of the data package
+# {2}  The title(s) of the data file(s)
+# {3}  The doi's of the data files
+# {4}  The submitters full name
+# {5}  The manuscript identifier (or "none available" if the metadata doesn't contain one)
+#
+Subject: Dryad submission approved {1}
+
+Dear {4},
+
+Your submission to the Dryad repository has been approved, and is available now that the associated article has been published. If you did not request a data embargo, your file(s) are now available for download.
+
+Title: {0}
+DOI: {1}
+Journal manuscript number: {5}
+
+
+
+CITING YOUR DRYAD DATA
+
+Ensure that readers can find your data!
+
+We recommend that the article include a link to the Dryad data as follows (subsitute your DOI suffix for the xxxxx):
+
+Data available from the Dryad Digital Repository: http://dx.doi.org/10.5061/dryad.xxxxx 
+
+Your journal may follow the CrossRef recommendation that the data package be cited in the article Reference list. If so, the citation should include the Dryad package DOI, e.g.: 
+
+Author(s) (Year). Data from [title]. Dryad Digital Repository. {1}
+
+
+
+To view your Dryad entry, you may visit the repository at http://datadryad.org
+
+Check out the information for depositors at http://datadryad.org/pages/faq
+- How do I refer to my Dryad data in my article?
+- How can I see how often my data package is viewed and downloaded?
+- How can I add my data package to a Data section on my CV?
+- If my data files are embargoed, when will they be released?
+- and more!
+
+Thanks again for taking this important step to preserve and share your research data.
+
+We welcome your feedback! Contact us at help@datadryad.org.
+
+The Dryad Team
+datadryad.org 

--- a/test/config/emails/submit_datapackage_confirm
+++ b/test/config/emails/submit_datapackage_confirm
@@ -1,0 +1,30 @@
+# Data package confirmation email message
+# This message is a confirmation sent to a submitter to indicate that a data package has 
+# been received by Dryad. The message is sent when a submission is moved to the DSpace workflow
+# without going through the review stage. Submissions that go to the review stage receive 
+# a similar message, submit_datapackage_review.
+#
+#
+# {0}  Title of data package
+# {1}  The doi identifier of the data package
+# {2}  The title(s) of the data file(s)
+#
+Subject: Dryad submission now in curation
+
+Your submission to the Dryad repository titled "{0}" is now being processed by the curatorial team. They will contact you with an update within two business days.
+
+YOUR DRYAD DOI
+
+Your data package has been assigned a unique identifier, called a DOI. This DOI is provisional for now, but may be included in the article manuscript. It will be fully registered with the DOI system when your submission has been approved by Dryad curation staff.
+
+Data package title: {0}
+Provisional DOI: {1}
+Data files: {2}
+
+PAYMENT
+
+If you were asked to enter a credit card number, your card has been verified, but will be not be charged until the curatorial team accepts your submission. You will receive a confirmation and a receipt when your card is charged.
+
+Please email us at help@datadryad.org if you have any questions or concerns.
+
+The Dryad Team

--- a/test/config/emails/submit_datapackage_reject
+++ b/test/config/emails/submit_datapackage_reject
@@ -1,0 +1,27 @@
+# Rejection email message
+# This message is sent to a submitter when the Dryad curator
+# has rejected a data package. The data package is placed back
+# in the submitter's workspace.
+#
+# {0}  Title of submission
+# {2}  Name(s) of the data file(s)
+# {2}  Name of the rejector
+# {3}  Reason for the rejection
+# {4}  Link to 'My DSpace' page
+#
+Subject: Your submission to Dryad 
+
+You previously submitted a data package to Dryad titled: {0}
+
+This data package contained the following data files:
+{1}
+
+This submission has been returned to your working space by Dryad curator {2}
+with the following explanation:
+
+{3}
+
+You can view, modify, and resubmit the data from your
+"My Submissions" page at http://datadryad.org/submissions
+
+The Dryad Team

--- a/test/config/emails/submit_datapackage_review
+++ b/test/config/emails/submit_datapackage_review
@@ -1,0 +1,66 @@
+# Data file review email message
+# Sent when a datapackage is submitted, but the associated journal 
+# article is listed as "in review". Submissions that go to the curation stage receive 
+# a similar message, submit_datapackage_confirm.
+#
+# {0}  Title of submission
+# {1}  Doi of the data package
+# {2}  Title of the data package
+# {3}  Submitter name/email
+# {4}  Url for the review
+# {5}  The manuscript identifier (or "none available" if the metadata doesn't contain one)
+# {6}  The journal name (or "not available" if the metadata doesn't contain one)
+
+Subject: Dryad: Data package received for review {1}
+
+Dryad has received the following data package:
+Title:        {0}
+Journal manuscript number: {5}
+Journal: {6}
+Submitted by: {3}
+Data file(s):
+{2}
+
+Thank you for submitting your data package to Dryad for journal review. Please read the following information carefully, so you will know what to expect during the rest of the data archiving process.
+
+YOUR DRYAD DOI
+
+Your data package has been assigned a unique identifier, called a DOI. This DOI is provisional for now, but may be included in the article manuscript. It will be fully registered with the DOI system when your submission has been approved by Dryad curation staff.
+
+{1}
+
+
+REVIEWER ACCESS TO YOUR DRYAD DATA
+
+Journal editors and anonymous peer reviewers may view the submission for review purposes using the following url:
+{4}
+
+This url will be functional only temporarily. If/when your publication is accepted, your Dryad submission will move out of review and into our queue for curation and archiving.
+
+
+MODIFYING YOUR DRYAD SUBMISSION
+
+Should you need to modify your data package while it is in review, you may access it at https://datadryad.org/submissions.
+
+Do not create multiple Dryad submissions associated with the same publication, as this causes confusion for both reviewers and Dryad curators, who may not know which version is most recent/correct.
+
+The actions you can perform while a submission is in review are limited. Dryad does not allow files to be deleted while an article is under review. We only allow additions during this time. This restriction ensures that all reviewers see the files that were originally submitted.
+
+To add new or corrected files:
+  - Log into your Dryad account and click on the "My Submissions" link in the menu. 
+  - Select the appropriate data package. At the bottom of the page for this package, you will see an option to "Add new data file".
+  - After you have finished adding data files, please send an email to help@datadryad.org (including your Dryad DOI) to indicate which files should be retained during the final curation process.
+  - If/when your article has been accepted for publication, Dryad curators will remove any files that you have indicated are duplicate or superseded.
+
+If/when your publication is accepted, your Dryad submission will automatically move out of review and into our queue for curation and archiving, and will no longer be accessible for modification.
+
+
+PAYMENT
+
+If you were asked to enter a credit card number, your card has been verified, but will be not be charged unless/until your article is accepted and the curatorial team approves your submission. You will receive a confirmation and a receipt when your card is charged.
+
+Please email us at help@datadryad.org if you have questions.
+
+Many thanks!
+
+-The Dryad Team

--- a/test/config/emails/submit_datapackage_task
+++ b/test/config/emails/submit_datapackage_task
@@ -1,0 +1,27 @@
+# Workflow task email message for a data package
+# This is sent to curators when a new submission enters the 
+# workflow stage (i.e., it is ready for curation)
+# NOTE: This submission may have come through the 
+#       review stage, or the article may have been 
+#	accepted at the time of data submission.
+#
+# {0}  Title of submission
+# {1}  Title of the data file(s)
+# {2}  submitter's name
+# {3}  Description of task
+# {4}  link to 'my DSpace' page
+#
+Subject: Dryad: New data package ready for curation
+
+A new data package has been submitted to Dryad:
+Package title:        {0}
+Data file(s):
+{1}
+
+Submitted by: {2}
+
+{3}
+
+To claim this task, please visit your "My Dryad"
+page:  {4}
+

--- a/test/config/emails/submit_reject
+++ b/test/config/emails/submit_reject
@@ -1,0 +1,23 @@
+# Rejection email message
+#
+# {0}  Title of submission
+# {1}  Name of collection
+# {2}  Name of the rejector
+# {3}  Reason for the rejection
+# {4}  Link to 'My DSpace' page
+#
+Subject: DSpace: Submission Rejected
+
+You submitted: {0}
+
+To collection: {1}
+
+Your submission has been rejected by {2}
+with the following explanation:
+
+{3}
+
+Your submission has not been deleted.  You can access it from your
+"My DSpace" page: {4}
+
+DSpace

--- a/test/config/emails/submit_task
+++ b/test/config/emails/submit_task
@@ -1,0 +1,24 @@
+# Workflow task email message
+#
+# {0}  Title of submission
+# {1}  Name of collection
+# {2}  submitter's name
+# {3}  Description of task
+# {4}  link to 'my DSpace' page 
+#
+Subject: DSpace: You have a new task
+
+A new item has been submitted:
+
+Title:        {0}
+Collection:   {1}
+Submitted by: {2}
+
+{3}
+
+To claim this task, please visit your "My DSpace"
+page:  {4}
+
+Many thanks!
+
+DSpace

--- a/test/config/emails/subscribe_mailinglist
+++ b/test/config/emails/subscribe_mailinglist
@@ -1,0 +1,9 @@
+# E-mail sent to mailman when users request to subscribe to the
+# Dryad-announcement mailing list
+#
+# Parameters: {0} is the email address that should be subscribed to the list
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: subscribe address={0}
+
+Please subscribe {0} to the dryad-announce mailing list. Thanks!

--- a/test/config/emails/subscription
+++ b/test/config/emails/subscription
@@ -1,0 +1,12 @@
+# E-mail sent to DSpace users when new items appear in collections they are
+# subscribed to
+#
+# Parameters: {0} is the details of the new collections and items
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Dryad Subscription
+New items are available in the collections you have subscribed to:
+
+{0}
+
+The Dryad Team

--- a/test/config/emails/suggest
+++ b/test/config/emails/suggest
@@ -1,0 +1,26 @@
+# E-mail sent with the information filled out in a suggest form.
+#
+# Parameters: {0} recipient name
+#             {1} sender name
+#             {2} repository name
+#             {3} item title
+#             {4} item handle URI
+#             {5} item local URL - may be used in lieu of {4} if not using handle server
+#             {6} collection name
+#             {7} sender message 
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: An item of interest from Dryad
+
+Hello {0}:
+
+{1} requested we send you this email regarding an item available in {2}.
+
+Title: {3}
+Location: {5}
+In Collection: {6}
+Personal Message: {7}
+
+The Dryad repository system captures, stores, indexes, preserves, and distributes digital material.
+For more information, visit www.datadryad.org
+

--- a/test/config/workflow-actions.xml
+++ b/test/config/workflow-actions.xml
@@ -1,1 +1,110 @@
-../../dspace/config/workflow-actions.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+    xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+    <bean id="completePaymentActionAPI" class="org.dspace.workflow.actions.processingaction.CompletePaymentAction"/>
+    <bean id="finalPaymentActionAPI" class="org.dspace.workflow.actions.processingaction.FinalPaymentAction"/>
+    <bean id="dryadAcceptRejectEditActionAPI" class="org.dspace.workflow.actions.processingaction.EditMetadataAction" scope="prototype"/>
+    <bean id="reviewActionAPI" class="org.dspace.workflow.actions.processingaction.DryadReviewAction"/>
+    <bean id="pendingDeleteAPI" class="org.dspace.workflow.actions.processingaction.DryadPendingDeleteAction"/>
+    <bean id="requiresReviewActionAPI" class="org.dspace.workflow.actions.processingaction.ReviewRequiredAction"/>
+    <bean id="assignOriginalSubmitterActionAPI" class="org.dspace.workflow.actions.userassignment.AssignOriginalSubmitterAction" scope="prototype"/>
+    <bean id="noUserSelectionActionAPI" class="org.dspace.workflow.actions.userassignment.NoUserSelectionAction" scope="prototype"/>
+    <bean id="claimActionAPI" class="org.dspace.workflow.actions.userassignment.ClaimAction" scope="prototype"/>
+
+    <bean id="registerPendingPublicationActionAPI" class="org.dspace.workflow.actions.processingaction.RegisterPendingPublicationAction" scope="prototype"/>
+    <bean id="afterPublicationActionAPI" class="org.dspace.workflow.actions.processingaction.AfterPublicationAction" scope="prototype"/>
+
+    <bean id="reAuthorizationPaymentActionAPI" class="org.dspace.workflow.actions.processingaction.ReAuthorizationPaymentAction" scope="prototype"/>
+
+    <bean id="dryadAcceptEditRejectAction" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="dryadAcceptEditRejectAction"/>
+
+        <property name="processingAction" ref="dryadAcceptRejectEditActionAPI"/>
+        <property name="requiresUI" value="true"/>
+    </bean>
+
+    <bean id="reviewAction" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="reviewAction"/>
+
+        <property name="processingAction" ref="reviewActionAPI"/>
+        <property name="requiresUI" value="true"/>
+    </bean>
+    <bean id="finalPaymentAction" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="finalPaymentAction"/>
+
+        <property name="processingAction" ref="finalPaymentActionAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
+
+    <bean id="completePaymentAction" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="completePaymentAction"/>
+
+        <property name="processingAction" ref="completePaymentActionAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
+
+    <bean id="pendingdelete" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="pendingdelete"/>
+
+        <property name="processingAction" ref="pendingDeleteAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
+
+    <bean id="requiresReviewAction" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="requiresReviewAction"/>
+
+        <property name="processingAction" ref="requiresReviewActionAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
+
+    <bean id="registerPendingPublicationAction" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="registerPendingPublicationAction"/>
+
+        <property name="processingAction" ref="registerPendingPublicationActionAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
+
+    <bean id="afterPublicationAction" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="afterPublicationAction"/>
+
+        <property name="processingAction" ref="afterPublicationActionAPI"/>
+        <property name="requiresUI" value="true"/>
+    </bean>
+
+    <!--User selection actions-->
+    <bean id="assignOriginalSubmitterAction" class="org.dspace.workflow.actions.UserSelectionActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="assignOriginalSubmitterAction"/>
+
+        <property name="processingAction" ref="assignOriginalSubmitterActionAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
+
+    <bean id="noUserSelectionAction" class="org.dspace.workflow.actions.UserSelectionActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="noUserSelectionAction"/>
+
+        <property name="processingAction" ref="noUserSelectionActionAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
+
+    <bean id="claimAction" class="org.dspace.workflow.actions.UserSelectionActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="claimAction"/>
+
+        <property name="processingAction" ref="claimActionAPI"/>
+        <property name="requiresUI" value="true"/>
+    </bean>
+
+    <bean id="reAuthorizationPaymentAction" class="org.dspace.workflow.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="reAuthorizationPaymentAction"/>
+
+        <property name="processingAction" ref="reAuthorizationPaymentActionAPI"/>
+        <property name="requiresUI" value="true"/>
+    </bean>
+
+
+
+
+</beans>

--- a/test/config/workflow.xml
+++ b/test/config/workflow.xml
@@ -1,1 +1,82 @@
-../../dspace/config/workflow.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<wf-config>
+    <workflow-map>
+        <name-map collection="default" workflow="default"/>
+    </workflow-map>
+
+    <workflow start="requiresReviewStep" id="default">
+        <roles>
+            <role id="curator" name="Curator" />
+            <!--TODO: rename the group if needed-->
+            <role id="editors" name="Editors" />
+        </roles>
+
+        <step id="requiresReviewStep" nextStep="reviewStep" userSelectionMethod="noUserSelectionAction">
+            <alternativeOutcome>
+                <step status="1">dryadAcceptEditReject</step>
+            </alternativeOutcome>
+            <action id="requiresReviewAction"/>
+        </step>
+
+        <step id="reviewStep" nextStep="dryadAcceptEditReject" userSelectionMethod="assignOriginalSubmitterAction">
+            <alternativeOutcome>
+                <step status="1">pendingdelete</step>
+            </alternativeOutcome>
+            <action id="reviewAction"/>
+        </step>
+
+        <!-- Editor has the option of sending item to blackout.  Item will still go through finalPaymentAction -->
+              
+        <step id="dryadAcceptEditReject" nextStep="finalPaymentStep" userSelectionMethod="claimAction" role="editors">
+            <action id="dryadAcceptEditRejectAction"/>
+            <alternativeOutcome>
+                <!-- if outcome of dryadAcceptEditRejectAction is 1, curator has selected blackout -->
+                <step status="1">pendingPublicationFinalPaymentStep</step>
+            </alternativeOutcome>
+        </step>
+
+        <!-- Approve and archive selected -->
+        <step id="finalPaymentStep" nextStep="completePaymentStep" userSelectionMethod="noUserSelectionAction">
+            <action id="finalPaymentAction"/>
+            <alternativeOutcome>
+                <step status="1">reAuthorizationPaymentStep</step>
+            </alternativeOutcome>
+        </step>
+        
+        <step id="reAuthorizationPaymentStep" nextStep="completePaymentStep" userSelectionMethod="assignOriginalSubmitterAction">
+            <action id="reAuthorizationPaymentAction"/>
+        </step>
+        
+        <!-- Blackout selected.  Use the same payment auth actions but different steps for blackout -->
+        <step id="pendingPublicationFinalPaymentStep" nextStep="registerPendingPublicationStep" userSelectionMethod="noUserSelectionAction">
+            <action id="finalPaymentAction"/>
+            <alternativeOutcome>
+                <step status="1">pendingPublicationReAuthorizationPaymentStep</step>
+            </alternativeOutcome>
+        </step>
+
+        <step id="pendingPublicationReAuthorizationPaymentStep" nextStep="registerPendingPublicationStep" userSelectionMethod="assignOriginalSubmitterAction">
+            <action id="reAuthorizationPaymentAction"/>
+        </step>
+
+        <!-- Register an identifier and then send to pendingPublicationStep -->
+        <step id="registerPendingPublicationStep" nextStep="pendingPublicationStep" userSelectionMethod="noUserSelectionAction" role="curator">
+            <action id="registerPendingPublicationAction"/>
+        </step>
+        
+        <!-- Parked after registration, waiting for a curator to claim -->
+        <step id="pendingPublicationStep" nextStep="completePaymentStep" userSelectionMethod="claimAction" role="curator">
+            <action id="afterPublicationAction"/>
+        </step>
+
+
+        <step id="pendingdelete"  userSelectionMethod="noUserSelectionAction">
+            <action id="pendingdelete"/>
+        </step>
+
+        <!-- Approve and archive selected -->
+        <step id="completePaymentStep" userSelectionMethod="noUserSelectionAction">
+            <action id="completePaymentAction"/>
+        </step>
+    </workflow>
+</wf-config>


### PR DESCRIPTION
We originally created the test directory using symlinks, so the files
only needed to be in one place at a time. However, the symlinks fail
to work when the source directory and installation directory have
different structures. It is more straightforward to maintain copies of
these files in the test config.
