### PR TITLE
Remove outdatted exemption for Duke Accessibility

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/static/robots.txt
+++ b/dspace/modules/xmlui/src/main/webapp/static/robots.txt
@@ -1,7 +1,3 @@
-# Special exception for the Duke Accessibility Management group
-user-agent: Win32
-allow: /
-
 # For our non-production servers, we do not allow any indexing.
 # Settings for the production servers are in robots.txt.production
 User-agent: *


### PR DESCRIPTION
This exemption was only needed when the Accessibility group at Duke was analyzing changes to our website. Their work was completed long ago, so our dev/staging servers should fully discourage spider activity.
