### PR TITLE
Limit REST API results

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/workflow/DryadWorkflowUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/DryadWorkflowUtils.java
@@ -188,19 +188,7 @@ public class DryadWorkflowUtils {
                     }
                 }
             } else {
-                // now the minority case (as we clean up the data)
-                String[] parts = metadata.value.split("\\s+|\\.");
-                String author = parts[parts.length - 1].replace("\\s+|\\.", "");
-                char ch;
-
-                authorString.append(author).append(" ");
-
-                for (int index = 0; index < parts.length - 1; index++) {
-                    if (parts[index].length() > 0) {
-                        ch = parts[index].replace("\\s+|\\.", "").charAt(0);
-                        authorString.append(ch);
-                    }
-                }
+                authorString.append(metadata.value);
             }
             authorString.append("@");
 

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/resources/v1/ManuscriptResource.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/resources/v1/ManuscriptResource.java
@@ -46,7 +46,7 @@ public class ManuscriptResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getManuscripts(@PathParam(Organization.ORGANIZATION_CODE) String organizationCode, @QueryParam("search") String searchParam, @QueryParam("results") Integer resultParam) {
+    public Response getManuscripts(@PathParam(Organization.ORGANIZATION_CODE) String organizationCode, @QueryParam("search") String searchParam, @QueryParam("count") Integer resultParam) {
         try {
             // Returning a list requires POJO turned on
             StoragePath path = new StoragePath();

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/resources/v1/ManuscriptResource.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/resources/v1/ManuscriptResource.java
@@ -10,6 +10,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -45,12 +46,12 @@ public class ManuscriptResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getManuscripts(@PathParam(Organization.ORGANIZATION_CODE) String organizationCode) {
+    public Response getManuscripts(@PathParam(Organization.ORGANIZATION_CODE) String organizationCode, @QueryParam("results") Integer resultParam) {
         try {
             // Returning a list requires POJO turned on
             StoragePath path = new StoragePath();
             path.addPathElement(Organization.ORGANIZATION_CODE, organizationCode);
-            return Response.ok(manuscriptStorage.getAll(path)).build();
+            return Response.ok(manuscriptStorage.getResults(path, resultParam)).build();
         } catch (StorageException ex) {
             log.error("Exception getting manuscripts", ex);
             ErrorsResponse error = ResponseFactory.makeError(ex.getMessage(), "Unable to list manuscripts", uriInfo, Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/resources/v1/ManuscriptResource.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/resources/v1/ManuscriptResource.java
@@ -46,12 +46,12 @@ public class ManuscriptResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getManuscripts(@PathParam(Organization.ORGANIZATION_CODE) String organizationCode, @QueryParam("results") Integer resultParam) {
+    public Response getManuscripts(@PathParam(Organization.ORGANIZATION_CODE) String organizationCode, @QueryParam("search") String searchParam, @QueryParam("results") Integer resultParam) {
         try {
             // Returning a list requires POJO turned on
             StoragePath path = new StoragePath();
             path.addPathElement(Organization.ORGANIZATION_CODE, organizationCode);
-            return Response.ok(manuscriptStorage.getResults(path, resultParam)).build();
+            return Response.ok(manuscriptStorage.getResults(path, searchParam, resultParam)).build();
         } catch (StorageException ex) {
             log.error("Exception getting manuscripts", ex);
             ErrorsResponse error = ResponseFactory.makeError(ex.getMessage(), "Unable to list manuscripts", uriInfo, Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/AbstractStorage.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/AbstractStorage.java
@@ -15,7 +15,6 @@ public abstract class AbstractStorage<T> implements StorageInterface<T> {
     protected abstract void updateObject(StoragePath path, T object) throws StorageException;
     protected abstract T readObject(StoragePath path) throws StorageException;
     protected abstract void deleteObject(StoragePath path) throws StorageException;
-    protected abstract void addAll(StoragePath path, List<T> objects) throws StorageException;
     protected abstract void addResults(StoragePath path, List<T> objects, Integer limit) throws StorageException;
 
     final void checkPath(StoragePath path, List<String> expectedKeyPath) throws StorageException {
@@ -61,7 +60,7 @@ public abstract class AbstractStorage<T> implements StorageInterface<T> {
     @Override
     public List<T> getAll(StoragePath path) throws StorageException {
         List<T> objects = new ArrayList<T>();
-        addAll(path, objects);
+        addResults(path, objects, null);
         return objects;
     }
 

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/AbstractStorage.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/AbstractStorage.java
@@ -15,7 +15,7 @@ public abstract class AbstractStorage<T> implements StorageInterface<T> {
     protected abstract void updateObject(StoragePath path, T object) throws StorageException;
     protected abstract T readObject(StoragePath path) throws StorageException;
     protected abstract void deleteObject(StoragePath path) throws StorageException;
-    protected abstract void addResults(StoragePath path, List<T> objects, Integer limit) throws StorageException;
+    protected abstract void addResults(StoragePath path, List<T> objects, String searchParam, Integer limit) throws StorageException;
 
     final void checkPath(StoragePath path, List<String> expectedKeyPath) throws StorageException {
         if(path == null) {
@@ -60,14 +60,14 @@ public abstract class AbstractStorage<T> implements StorageInterface<T> {
     @Override
     public List<T> getAll(StoragePath path) throws StorageException {
         List<T> objects = new ArrayList<T>();
-        addResults(path, objects, null);
+        addResults(path, objects, null, null);
         return objects;
     }
 
     @Override
-    public List<T> getResults(StoragePath path, Integer limit) throws StorageException {
+    public List<T> getResults(StoragePath path, String searchParam, Integer limit) throws StorageException {
         List<T> objects = new ArrayList<T>();
-        addResults(path, objects, limit);
+        addResults(path, objects, searchParam, limit);
         return objects;
     }
 

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/AbstractStorage.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/AbstractStorage.java
@@ -2,6 +2,7 @@
  */
 package org.datadryad.rest.storage;
 
+import java.lang.Integer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,6 +16,7 @@ public abstract class AbstractStorage<T> implements StorageInterface<T> {
     protected abstract T readObject(StoragePath path) throws StorageException;
     protected abstract void deleteObject(StoragePath path) throws StorageException;
     protected abstract void addAll(StoragePath path, List<T> objects) throws StorageException;
+    protected abstract void addResults(StoragePath path, List<T> objects, Integer limit) throws StorageException;
 
     final void checkPath(StoragePath path, List<String> expectedKeyPath) throws StorageException {
         if(path == null) {
@@ -60,6 +62,13 @@ public abstract class AbstractStorage<T> implements StorageInterface<T> {
     public List<T> getAll(StoragePath path) throws StorageException {
         List<T> objects = new ArrayList<T>();
         addAll(path, objects);
+        return objects;
+    }
+
+    @Override
+    public List<T> getResults(StoragePath path, Integer limit) throws StorageException {
+        List<T> objects = new ArrayList<T>();
+        addResults(path, objects, limit);
         return objects;
     }
 

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/StorageInterface.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/StorageInterface.java
@@ -2,6 +2,7 @@
  */
 package org.datadryad.rest.storage;
 
+import java.lang.Integer;
 import java.util.List;
 
 /**
@@ -11,6 +12,7 @@ import java.util.List;
 public interface StorageInterface<T> {
     public void create(StoragePath path, T t) throws StorageException;
     public List<T> getAll(StoragePath path) throws StorageException;
+    public List<T> getResults(StoragePath path, Integer limit) throws StorageException;
     public T findByPath(StoragePath path) throws StorageException;
     public void update(StoragePath path, T object) throws StorageException;
     public void deleteByPath(StoragePath path) throws StorageException;

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/StorageInterface.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/StorageInterface.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface StorageInterface<T> {
     public void create(StoragePath path, T t) throws StorageException;
     public List<T> getAll(StoragePath path) throws StorageException;
-    public List<T> getResults(StoragePath path, Integer limit) throws StorageException;
+    public List<T> getResults(StoragePath path, String searchParam, Integer limit) throws StorageException;
     public T findByPath(StoragePath path) throws StorageException;
     public void update(StoragePath path, T object) throws StorageException;
     public void deleteByPath(StoragePath path) throws StorageException;

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/ManuscriptJSONStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/ManuscriptJSONStorageImpl.java
@@ -99,6 +99,25 @@ public class ManuscriptJSONStorageImpl extends AbstractManuscriptStorage {
     }
 
     @Override
+    protected void addResults(StoragePath path, List<Manuscript> manuscripts, Integer limit) throws StorageException {
+        File subdirectory = getSubdirectory(path);
+        File[] files = subdirectory.listFiles(new FilenameFilter() {
+
+            @Override
+            public boolean accept(File file, String string) {
+                return string.endsWith(FILE_EXTENSION);
+            }
+        });
+        try {
+            for(File file : files) {
+                manuscripts.add((Manuscript)reader.readValue(file));
+            }
+        } catch (IOException ex) {
+            throw new StorageException("IO Exception reading files", ex);
+        }
+    }
+
+    @Override
     protected void createObject(StoragePath path, Manuscript manuscript) throws StorageException {
         File subdirectory = getSubdirectory(path);
         String baseFileName = getBaseFileName(manuscript);

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/ManuscriptJSONStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/ManuscriptJSONStorageImpl.java
@@ -80,25 +80,6 @@ public class ManuscriptJSONStorageImpl extends AbstractManuscriptStorage {
     }
 
     @Override
-    protected void addAll(StoragePath path, List<Manuscript> manuscripts) throws StorageException {
-        File subdirectory = getSubdirectory(path);
-        File[] files = subdirectory.listFiles(new FilenameFilter() {
-
-            @Override
-            public boolean accept(File file, String string) {
-                return string.endsWith(FILE_EXTENSION);
-            }
-        });
-        try {
-            for(File file : files) {
-                manuscripts.add((Manuscript)reader.readValue(file));
-            }
-        } catch (IOException ex) {
-            throw new StorageException("IO Exception reading files", ex);
-        }
-    }
-
-    @Override
     protected void addResults(StoragePath path, List<Manuscript> manuscripts, Integer limit) throws StorageException {
         File subdirectory = getSubdirectory(path);
         File[] files = subdirectory.listFiles(new FilenameFilter() {

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/ManuscriptJSONStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/ManuscriptJSONStorageImpl.java
@@ -80,7 +80,7 @@ public class ManuscriptJSONStorageImpl extends AbstractManuscriptStorage {
     }
 
     @Override
-    protected void addResults(StoragePath path, List<Manuscript> manuscripts, Integer limit) throws StorageException {
+    protected void addResults(StoragePath path, List<Manuscript> manuscripts, String searchParam, Integer limit) throws StorageException {
         File subdirectory = getSubdirectory(path);
         File[] files = subdirectory.listFiles(new FilenameFilter() {
 

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/OrganizationJSONStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/OrganizationJSONStorageImpl.java
@@ -83,7 +83,7 @@ public class OrganizationJSONStorageImpl extends AbstractOrganizationStorage {
     }
 
     @Override
-    protected void addResults(StoragePath path, List<Organization> organizations, Integer limit) throws StorageException {
+    protected void addResults(StoragePath path, List<Organization> organizations, String searchParam, Integer limit) throws StorageException {
         File[] files = this.storageDirectory.listFiles(new FilenameFilter() {
 
             @Override

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/OrganizationJSONStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/OrganizationJSONStorageImpl.java
@@ -101,6 +101,24 @@ public class OrganizationJSONStorageImpl extends AbstractOrganizationStorage {
     }
 
     @Override
+    protected void addResults(StoragePath path, List<Organization> organizations, Integer limit) throws StorageException {
+        File[] files = this.storageDirectory.listFiles(new FilenameFilter() {
+
+            @Override
+            public boolean accept(File file, String string) {
+                return string.endsWith(FILE_EXTENSION);
+            }
+        });
+        try {
+            for(File file : files) {
+                organizations.add((Organization)reader.readValue(file));
+            }
+        } catch (IOException ex) {
+            throw new StorageException("IO Exception reading files", ex);
+        }
+    }
+
+    @Override
     protected void createObject(StoragePath path, Organization organization) throws StorageException {
         String baseFileName = getBaseFileName(organization);
         File outputFile = buildFile(this.storageDirectory, baseFileName);

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/OrganizationJSONStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/json/OrganizationJSONStorageImpl.java
@@ -83,24 +83,6 @@ public class OrganizationJSONStorageImpl extends AbstractOrganizationStorage {
     }
 
     @Override
-    protected void addAll(StoragePath path, List<Organization> organizations) throws StorageException {
-        File[] files = this.storageDirectory.listFiles(new FilenameFilter() {
-
-            @Override
-            public boolean accept(File file, String string) {
-                return string.endsWith(FILE_EXTENSION);
-            }
-        });
-        try {
-            for(File file : files) {
-                organizations.add((Organization)reader.readValue(file));
-            }
-        } catch (IOException ex) {
-            throw new StorageException("IO Exception reading files", ex);
-        }
-    }
-
-    @Override
     protected void addResults(StoragePath path, List<Organization> organizations, Integer limit) throws StorageException {
         File[] files = this.storageDirectory.listFiles(new FilenameFilter() {
 

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
@@ -4,6 +4,7 @@ package org.datadryad.rest.storage.rdbms;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.Integer;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +44,7 @@ public class ManuscriptDatabaseStorageImpl extends AbstractManuscriptStorage {
     // active is stored as String because DatabaseManager doesn't support Boolean
     static final String COLUMN_ACTIVE = "active";
     static final String COLUMN_JSON_DATA = "json_data";
+    static final int DEFAULT_LIMIT = 1000;
 
     static final List<String> MANUSCRIPT_COLUMNS = Arrays.asList(
             COLUMN_ID,
@@ -180,14 +182,16 @@ public class ManuscriptDatabaseStorageImpl extends AbstractManuscriptStorage {
         }
     }
 
-    private static List<Manuscript> getManuscripts(Context context, String organizationCode) throws SQLException, IOException {
+    private static List<Manuscript> getManuscripts(Context context, String organizationCode, int limit) throws SQLException, IOException {
         List<Manuscript> manuscripts = new ArrayList<Manuscript>();
         Integer organizationId = getOrganizationInternalId(context, organizationCode);
+
         if(organizationId == NOT_FOUND) {
             return manuscripts;
         } else {
-            String query = "SELECT * FROM MANUSCRIPT WHERE organization_id = ? AND active = ?";
-            TableRowIterator rows = DatabaseManager.queryTable(context, MANUSCRIPT_TABLE, query, organizationId, ACTIVE_TRUE);
+            log.info ("returning "+limit+ " results");
+            String query = "SELECT * FROM MANUSCRIPT WHERE organization_id = ? AND active = ? ORDER BY manuscript_id DESC LIMIT ? ";
+            TableRowIterator rows = DatabaseManager.queryTable(context, MANUSCRIPT_TABLE, query, organizationId, ACTIVE_TRUE, limit);
             while(rows.hasNext()) {
                 TableRow row = rows.next();
                 manuscripts.add(manuscriptFromTableRow(row));
@@ -257,7 +261,25 @@ public class ManuscriptDatabaseStorageImpl extends AbstractManuscriptStorage {
         String organizationCode = getOrganizationCode(path);
         try {
             Context context = getContext();
-            manuscripts.addAll(getManuscripts(context, organizationCode));
+            manuscripts.addAll(getManuscripts(context, organizationCode, DEFAULT_LIMIT));
+            completeContext(context);
+        } catch (SQLException ex) {
+            throw new StorageException("Exception finding manuscripts", ex);
+        } catch (IOException ex) {
+            throw new StorageException("Exception reading manuscripts", ex);
+        }
+    }
+
+    @Override
+    protected void addResults(StoragePath path, List<Manuscript> manuscripts, Integer limit) throws StorageException {
+        String organizationCode = getOrganizationCode(path);
+        int limitInt = DEFAULT_LIMIT;
+        if (limit != null) {
+            limitInt = limit.intValue();
+        }
+        try {
+            Context context = getContext();
+            manuscripts.addAll(getManuscripts(context, organizationCode, limitInt));
             completeContext(context);
         } catch (SQLException ex) {
             throw new StorageException("Exception finding manuscripts", ex);

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
@@ -200,6 +200,25 @@ public class ManuscriptDatabaseStorageImpl extends AbstractManuscriptStorage {
         }
     }
 
+    private static List<Manuscript> getManuscriptsMatchingQuery(Context context, String organizationCode, String searchParam, int limit) throws SQLException, IOException {
+        List<Manuscript> manuscripts = new ArrayList<Manuscript>();
+        Integer organizationId = getOrganizationInternalId(context, organizationCode);
+
+        if(organizationId == NOT_FOUND) {
+            return manuscripts;
+        } else {
+            String searchWords[] = searchParam.split("\\s", 2);
+            String queryParam = "%" + searchWords[0] + "%";
+            String query = "SELECT * FROM MANUSCRIPT WHERE organization_id = ? AND active = ? AND json_data like ? ORDER BY manuscript_id DESC LIMIT ? ";
+            TableRowIterator rows = DatabaseManager.queryTable(context, MANUSCRIPT_TABLE, query, organizationId, ACTIVE_TRUE, queryParam, limit);
+            while(rows.hasNext()) {
+                TableRow row = rows.next();
+                manuscripts.add(manuscriptFromTableRow(row));
+            }
+            return manuscripts;
+        }
+    }
+
     private static void insertManuscript(Context context, Manuscript manuscript, String organizationCode) throws SQLException, IOException {
         Integer organizationId = getOrganizationInternalId(context, organizationCode);
         TableRow row = tableRowFromManuscript(manuscript, organizationId);

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
@@ -256,6 +256,11 @@ public class ManuscriptDatabaseStorageImpl extends AbstractManuscriptStorage {
         }
     }
 
+    protected void addAll(StoragePath path, List<Manuscript> manuscripts) throws StorageException {
+        addResults(path, manuscripts, null);
+    }
+
+    // This call is always limited to the default limit of entries, so as not to tie up the connection pool.
     @Override
     protected void addResults(StoragePath path, List<Manuscript> manuscripts, Integer limit) throws StorageException {
         String organizationCode = getOrganizationCode(path);

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
@@ -257,20 +257,6 @@ public class ManuscriptDatabaseStorageImpl extends AbstractManuscriptStorage {
     }
 
     @Override
-    protected void addAll(StoragePath path, List<Manuscript> manuscripts) throws StorageException {
-        String organizationCode = getOrganizationCode(path);
-        try {
-            Context context = getContext();
-            manuscripts.addAll(getManuscripts(context, organizationCode, DEFAULT_LIMIT));
-            completeContext(context);
-        } catch (SQLException ex) {
-            throw new StorageException("Exception finding manuscripts", ex);
-        } catch (IOException ex) {
-            throw new StorageException("Exception reading manuscripts", ex);
-        }
-    }
-
-    @Override
     protected void addResults(StoragePath path, List<Manuscript> manuscripts, Integer limit) throws StorageException {
         String organizationCode = getOrganizationCode(path);
         int limitInt = DEFAULT_LIMIT;

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/OrganizationDatabaseStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/OrganizationDatabaseStorageImpl.java
@@ -3,6 +3,7 @@
 package org.datadryad.rest.storage.rdbms;
 
 import java.io.File;
+import java.lang.Integer;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -158,6 +159,17 @@ public class OrganizationDatabaseStorageImpl extends AbstractOrganizationStorage
 
     @Override
     protected void addAll(StoragePath path, List<Organization> organizations) throws StorageException {
+        try {
+            Context context = getContext();
+            organizations.addAll(getOrganizations(context));
+            completeContext(context);
+        } catch (SQLException ex) {
+            throw new StorageException("Exception reading organizations", ex);
+        }
+    }
+
+    @Override
+    protected void addResults(StoragePath path, List<Organization> organizations, Integer limit) throws StorageException {
         try {
             Context context = getContext();
             organizations.addAll(getOrganizations(context));

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/OrganizationDatabaseStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/OrganizationDatabaseStorageImpl.java
@@ -159,11 +159,11 @@ public class OrganizationDatabaseStorageImpl extends AbstractOrganizationStorage
 
     protected void addAll(StoragePath path, List<Organization> organizations) throws StorageException {
         // passing in a limit of null to addResults should return all records
-        addResults(path, organizations, null);
+        addResults(path, organizations, null, null);
     }
 
     @Override
-    protected void addResults(StoragePath path, List<Organization> organizations, Integer limit) throws StorageException {
+    protected void addResults(StoragePath path, List<Organization> organizations, String searchParam, Integer limit) throws StorageException {
         try {
             Context context = getContext();
             organizations.addAll(getOrganizations(context));

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/OrganizationDatabaseStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/OrganizationDatabaseStorageImpl.java
@@ -157,6 +157,11 @@ public class OrganizationDatabaseStorageImpl extends AbstractOrganizationStorage
         }
     }
 
+    protected void addAll(StoragePath path, List<Organization> organizations) throws StorageException {
+        // passing in a limit of null to addResults should return all records
+        addResults(path, organizations, null);
+    }
+
     @Override
     protected void addResults(StoragePath path, List<Organization> organizations, Integer limit) throws StorageException {
         try {

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/OrganizationDatabaseStorageImpl.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/storage/rdbms/OrganizationDatabaseStorageImpl.java
@@ -158,17 +158,6 @@ public class OrganizationDatabaseStorageImpl extends AbstractOrganizationStorage
     }
 
     @Override
-    protected void addAll(StoragePath path, List<Organization> organizations) throws StorageException {
-        try {
-            Context context = getContext();
-            organizations.addAll(getOrganizations(context));
-            completeContext(context);
-        } catch (SQLException ex) {
-            throw new StorageException("Exception reading organizations", ex);
-        }
-    }
-
-    @Override
     protected void addResults(StoragePath path, List<Organization> organizations, Integer limit) throws StorageException {
         try {
             Context context = getContext();


### PR DESCRIPTION
Sets a default limit of 1000 records for manuscript GET calls, but allows a query parameter to specify a different number.
