### PR TITLE
Correct reading of arguments from the command line

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -73,10 +73,10 @@ public class AssociationAnywhere {
 
         }
         else if(line.hasOption("d")){
-            deductCredit(line.getOptionValue("d"));
+            deductCredit(line.getOptionValue("i"));
         }
         else if(line.hasOption("l")){
-            System.out.print(printDocument(loadCustomerInfo(line.getOptionValue("l"))));
+            System.out.print(printDocument(loadCustomerInfo(line.getOptionValue("i"))));
         }
         else if(line.hasOption("i")){
             //load credit


### PR DESCRIPTION
This reverts commit 992b140d329e2b4160f4c72bb3adc1212a0c7b4e. I had changed the parsing for command-line arguments to AssociationAnywhere, but I didn't realize the implications of how some of the arguments were processed. It was better in the original implementation.
