### PR TITLE
Use config file for recipients of DOI registration errors

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -122,6 +122,9 @@ subscribe_mailinglist.recipient = ${default.subscribe_mailinglist.recipient}
 # Recipient for Membership Application emails
 membership.recipient = ${default.membership.recipient}
 
+# Recipient for curation error emails
+curator_errors.recipient = ${default.curator_errors.recipient}
+
 # Set the default mail character set. This may be over ridden by providing a line
 # inside the email template "charset: <encoding>", otherwise this default is used.
 mail.charset = UTF8

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
@@ -617,13 +617,13 @@ public class CDLDataCiteService {
     }
 
     public void emailException(String error, String item, String operation) throws IOException {
-        String admin = ConfigurationManager.getProperty("mail.admin");
+        String recipient = ConfigurationManager.getProperty("curator_errors.recipient");
         Locale locale = I18nUtil.getDefaultLocale();
         String emailFile = I18nUtil.getEmailFilename(locale, "datacite_error");
         Email email = ConfigurationManager.getEmail(emailFile);
 
         // Write our stack trace to a string for output
-        email.addRecipient(admin);
+        email.addRecipient(recipient);
 
         // Add details to display in the email message
         email.addArgument(operation);


### PR DESCRIPTION
When an error occurs during DOI registration, an email is sent. This changes the recipient from being the Dryad admins to a value that is seperately configurable.

This code requires a new setting in the maven settings.xml -- default.curator_errors.recipient. I have already added the proper setting on the Dryad dev and production servers.
