### PR TITLE
Change "reject" to "return"

### DIFF
--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/i18n/messages.xml
@@ -722,17 +722,17 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Once you've edited the item, use this option to commit the item to the archive.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Commit to archive</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Reject item</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Return item to submitter</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Select this option to change the item's metadata.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edit metadata</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Return the task to the pool so that another user may perform the task.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Return task to pool</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
-	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Please enter your reason for returning the submission into the box below, indicating whether the submitter may fix a problem and resubmit.</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Reason</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">The reason field is required</message>
-	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Reject item</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Return item to submitter</message>
 
 
 
@@ -1454,8 +1454,8 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administrators</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Workflow steps</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Accept/Reject Step</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Accept/Reject/Edit Metadata Step</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Accept/Return Step</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Accept/Return/Edit Metadata Step</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Edit Metadata Step</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Submitters</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Default read access</message>

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/i18n/messages.xml
@@ -721,7 +721,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Approve item</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Once you've edited the item, use this option to commit the item to the archive.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Commit to archive</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select "Return item to submitter".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Return item to submitter</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Select this option to change the item's metadata.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edit metadata</message>

--- a/dspace/modules/atmire-workflow/atmire-workflow-xmlui-api/src/main/resources/aspects/Submission/i18n/messages.xml
+++ b/dspace/modules/atmire-workflow/atmire-workflow-xmlui-api/src/main/resources/aspects/Submission/i18n/messages.xml
@@ -58,28 +58,28 @@
     <message key="xmlui.Submission.workflow.ClaimActionXMLUI.leave_help">Leave this task in the pool for another to take.</message>
     <message key="xmlui.Submission.workflow.ClaimActionXMLUI.leave_submit">Leave task</message>
     <message key="xmlui.Submission.workflow.ClaimActionXMLUI.back">Back to overview</message>
-    <message key="xmlui.Submission.workflow.ClaimActionXMLUI.title">Accept/Reject Task</message>
+    <message key="xmlui.Submission.workflow.ClaimActionXMLUI.title">Accept/Return Task</message>
 
-    <message key="xmlui.Submission.workflow.AcceptActionXMLUI.head">Perform task: Accept/Reject item</message>
+    <message key="xmlui.Submission.workflow.AcceptActionXMLUI.head">Perform task: Accept/Return item</message>
     <message key="xmlui.Submission.workflow.AcceptActionXMLUI.info1">Actions you may perform on this task:</message>
     <message key="xmlui.Submission.workflow.AcceptActionXMLUI.reject_help">If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
-    <message key="xmlui.Submission.workflow.AcceptActionXMLUI.reject_submit">Reject item</message>
+    <message key="xmlui.Submission.workflow.AcceptActionXMLUI.reject_submit">Return item to submitter</message>
     <message key="xmlui.Submission.workflow.AcceptActionXMLUI.approve_help">If you have reviewed the item and it is suitable for inclusion in the collection, select "Approve".</message>
     <message key="xmlui.Submission.workflow.AcceptActionXMLUI.approve_submit">Approve item</message>
 
 
-    <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.head">Perform task: Accept/Reject/Edit item</message>
+    <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.head">Perform task: Accept/Return/Edit item</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.info1">Actions you may perform on this task:</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.reject_help">If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
-    <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.reject_submit">Reject item</message>
+    <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.reject_submit">Return item</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.approve_help">If you have reviewed the item and it is suitable for inclusion in the collection, select "Approve".</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.approve_submit">Approve item</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.edit_help">Select this option to change the item's metadata.</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.edit_submit">Edit metadata</message>
 
-    <message key="xmlui.Submission.Submissions.default.startStep.acceptAction">First step: Accept/Reject action</message>
-    <message key="xmlui.Submission.Submissions.default.2ndstep.editMetadataAction">Second step: Accept/Edit/Reject action</message>
-    <message key="xmlui.Submission.Submissions.claimAction">Accept/Reject task</message>
+    <message key="xmlui.Submission.Submissions.default.startStep.acceptAction">First step: Accept/Return action</message>
+    <message key="xmlui.Submission.Submissions.default.2ndstep.editMetadataAction">Second step: Accept/Edit/Return action</message>
+    <message key="xmlui.Submission.Submissions.claimAction">Accept/Return task</message>
     <message key="xmlui.Submission.Submissions.step.unknown">Unknown state</message>
 
   </catalogue>

--- a/dspace/modules/xmlui/src/main/resources/aspects/Submission/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Submission/i18n/messages.xml
@@ -58,20 +58,20 @@
     <message key="xmlui.Submission.workflow.ClaimActionXMLUI.leave_help">Leave this task in the pool for another to take.</message>
     <message key="xmlui.Submission.workflow.ClaimActionXMLUI.leave_submit">Leave task</message>
     <message key="xmlui.Submission.workflow.ClaimActionXMLUI.back">Back to overview</message>
-    <message key="xmlui.Submission.workflow.ClaimActionXMLUI.title">Accept/Reject Task</message>
+    <message key="xmlui.Submission.workflow.ClaimActionXMLUI.title">Accept/Return Task</message>
 
-    <message key="xmlui.Submission.workflow.AcceptActionXMLUI.head">Perform task: Accept/Reject item</message>
+    <message key="xmlui.Submission.workflow.AcceptActionXMLUI.head">Perform task: Accept/Return item</message>
     <message key="xmlui.Submission.workflow.AcceptActionXMLUI.info1">Actions you may perform on this task:</message>
     <message key="xmlui.Submission.workflow.AcceptActionXMLUI.reject_help">If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
-    <message key="xmlui.Submission.workflow.AcceptActionXMLUI.reject_submit">Reject item</message>
+    <message key="xmlui.Submission.workflow.AcceptActionXMLUI.reject_submit">Return item to submitter</message>
     <message key="xmlui.Submission.workflow.AcceptActionXMLUI.approve_help">If you have reviewed the item and it is suitable for inclusion in the collection, select "Approve".</message>
     <message key="xmlui.Submission.workflow.AcceptActionXMLUI.approve_submit">Approve item</message>
 
 
-    <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.head">Perform task: Accept/Reject/Edit item</message>
+    <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.head">Perform task: Accept/Return/Edit item</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.info1">Actions you may perform on this task:</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.reject_help">If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
-    <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.reject_submit">Reject item</message>
+    <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.reject_submit">Return item to submitter</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.approve_help">If you have reviewed the item and it is suitable for inclusion in the collection, select "Approve".</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.approve_submit">Approve item</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.return_help">Return the task to the pool so that another user may perform the task.</message>
@@ -81,9 +81,9 @@
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.delete_help">Select this option to delete this version.</message>
     <message key="xmlui.Submission.workflow.EditMetadataActionXMLUI.delete_submit">Delete this version</message>
 
-    <message key="xmlui.Submission.Submissions.default.startStep.acceptAction">First step: Accept/Reject action</message>
-    <message key="xmlui.Submission.Submissions.default.2ndstep.editMetadataAction">Second step: Accept/Edit/Reject action</message>
-    <message key="xmlui.Submission.Submissions.claimAction">Accept/Reject task</message>
+    <message key="xmlui.Submission.Submissions.default.startStep.acceptAction">First step: Accept/Return action</message>
+    <message key="xmlui.Submission.Submissions.default.2ndstep.editMetadataAction">Second step: Accept/Edit/Return action</message>
+    <message key="xmlui.Submission.Submissions.claimAction">Accept/Return task</message>
     <message key="xmlui.Submission.Submissions.step.unknown">Unknown state</message>
 
 </catalogue>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -1034,7 +1034,7 @@
 		and found it is <strong>not</strong> suitable for inclusion in the collection, select "Reject".
 		You will then be asked to enter a message indicating why the item is unsuitable, and whether the
 		submitter should change something and resubmit.</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Reject item</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Return item to submitter</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Select this option to change
 		the item's metadata.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edit metadata</message>
@@ -1051,12 +1051,12 @@
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
 	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Please enter your reason for
-		rejecting the submission into the box below, indicating whether the submitter may fix a problem
+		returning the submission into the box below, indicating whether the submitter may fix a problem
 		and resubmit.</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Reason</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">The reason field is
 		required</message>
-	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Reject item</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Return item to submitter</message>
 
 
 


### PR DESCRIPTION
Remove the negative connotation of "rejecting" a submission, by changing all wording to "return".

To test, go to "My tasks" and look at the button names for returning a submission.
