### PR TITLE
ticket : 2524 : Second refinement of curator roles

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -439,6 +439,7 @@ core.authorization.community-admin.item.extract-metadata = true
 # Dryad Customization to create a site level administrative group that can
 # access certain administrative features.
 core.authorization.site-admin.group=Senior Curators
+core.authorization.site-admin.group2=Curators
 
 #### Stackable Authentication Methods #####
 

--- a/dspace/modules/api/src/main/java/org/dspace/app/xmlui/cocoon/MetadataExportReader.java
+++ b/dspace/modules/api/src/main/java/org/dspace/app/xmlui/cocoon/MetadataExportReader.java
@@ -7,12 +7,6 @@
  */
 package org.dspace.app.xmlui.cocoon;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.ArrayList;
-import javax.servlet.http.HttpServletResponse;
-import org.xml.sax.SAXException;
-
 import org.apache.avalon.excalibur.pool.Recyclable;
 import org.apache.avalon.framework.parameters.Parameters;
 import org.apache.cocoon.ProcessingException;
@@ -23,21 +17,25 @@ import org.apache.cocoon.environment.SourceResolver;
 import org.apache.cocoon.environment.http.HttpEnvironment;
 import org.apache.cocoon.reading.AbstractReader;
 import org.apache.log4j.Logger;
-
+import org.dspace.app.bulkedit.DSpaceCSV;
+import org.dspace.app.bulkedit.MetadataExport;
 import org.dspace.app.xmlui.utils.AuthenticationUtil;
 import org.dspace.app.xmlui.utils.ContextUtil;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.handle.HandleManager;
-import org.dspace.core.Context;
-import org.dspace.core.Constants;
-import org.dspace.core.LogManager;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.ItemIterator;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.core.LogManager;
+import org.dspace.handle.HandleManager;
+import org.xml.sax.SAXException;
 
-import org.dspace.app.bulkedit.DSpaceCSV;
-import org.dspace.app.bulkedit.MetadataExport;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
 
 /**
  *
@@ -102,7 +100,7 @@ public class MetadataExportReader extends AbstractReader implements Recyclable
             this.response = ObjectModelHelper.getResponse(objectModel);
             Context context = ContextUtil.obtainContext(objectModel);
 
-            if(AuthorizeManager.isCuratorOrAdmin(context))
+            if(AuthorizeManager.isCurator(context))
             {
 
                 /* Get our parameters that identify the item, collection

--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/Voucher.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/Voucher.java
@@ -183,8 +183,8 @@ public class Voucher {
     public static Voucher create(Context context) throws SQLException,AuthorizeException
 
     {
-        if(!AuthorizeManager.isCuratorOrAdmin(context)){
-            throw new AuthorizeException("you have to be a admin or senior curator to add a new voucher");
+        if(!AuthorizeManager.isSeniorCurator(context)){
+            throw new AuthorizeException("You must be a senior curator to add a new voucher");
         }
 
         // Create a table row
@@ -466,8 +466,8 @@ public class Voucher {
     }
 
     public void delete()throws SQLException,AuthorizeException{
-        if(!AuthorizeManager.isCuratorOrAdmin(myContext)){
-            throw new AuthorizeException("you have to be a admin to delete a new voucher");
+        if(!AuthorizeManager.isSeniorCurator(myContext)){
+            throw new AuthorizeException("You must be a senior curator to delete a new voucher");
         }
         // Remove from cache
         myContext.removeCached(this, getID());

--- a/dspace/modules/payment-system/payment-webapp/src/main/java/org/dspace/app/xmlui/aspect/shoppingcart/EditShoppingcartForm.java
+++ b/dspace/modules/payment-system/payment-webapp/src/main/java/org/dspace/app/xmlui/aspect/shoppingcart/EditShoppingcartForm.java
@@ -7,10 +7,6 @@ package org.dspace.app.xmlui.aspect.shoppingcart;
  */
 
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Properties;
-
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
 import org.apache.commons.lang.StringUtils;
@@ -20,13 +16,19 @@ import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
-import org.dspace.app.xmlui.wing.element.Item;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.content.*;
+import org.dspace.content.DCValue;
 import org.dspace.eperson.EPerson;
-import org.dspace.paymentsystem.*;
+import org.dspace.paymentsystem.PaymentSystemConfigurationManager;
+import org.dspace.paymentsystem.PaymentSystemService;
+import org.dspace.paymentsystem.ShoppingCart;
+import org.dspace.paymentsystem.Voucher;
 import org.dspace.utils.DSpace;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Properties;
 
 
 
@@ -114,7 +116,7 @@ public class EditShoppingcartForm  extends AbstractDSpaceTransformer
     public void addBody(Body body) throws WingException, SQLException, AuthorizeException
     {
         // Get all our parameters
-        boolean admin = AuthorizeManager.isCuratorOrAdmin(context);
+        boolean admin = AuthorizeManager.isSeniorCurator(context);
 
         Request request = ObjectModelHelper.getRequest(objectModel);
 

--- a/dspace/modules/payment-system/payment-webapp/src/main/java/org/dspace/app/xmlui/aspect/shoppingcart/EditVoucherForm.java
+++ b/dspace/modules/payment-system/payment-webapp/src/main/java/org/dspace/app/xmlui/aspect/shoppingcart/EditVoucherForm.java
@@ -7,11 +7,6 @@ package org.dspace.app.xmlui.aspect.shoppingcart;
  */
 
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Properties;
-
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
 import org.apache.commons.lang.StringUtils;
@@ -20,12 +15,13 @@ import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
-import org.dspace.app.xmlui.wing.element.Item;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.content.*;
-import org.dspace.eperson.EPerson;
-import org.dspace.paymentsystem.*;
+import org.dspace.paymentsystem.Voucher;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Date;
 
 
 public class EditVoucherForm  extends AbstractDSpaceTransformer
@@ -92,7 +88,7 @@ public class EditVoucherForm  extends AbstractDSpaceTransformer
     public void addBody(Body body) throws WingException, SQLException, AuthorizeException
     {
         // Get all our parameters
-        boolean admin = AuthorizeManager.isCuratorOrAdmin(context);
+        boolean admin = AuthorizeManager.isSeniorCurator(context);
 
         Request request = ObjectModelHelper.getRequest(objectModel);
 

--- a/dspace/modules/payment-system/payment-webapp/src/main/java/org/dspace/app/xmlui/aspect/shoppingcart/Navigation.java
+++ b/dspace/modules/payment-system/payment-webapp/src/main/java/org/dspace/app/xmlui/aspect/shoppingcart/Navigation.java
@@ -7,13 +7,6 @@
  */
 package org.dspace.app.xmlui.aspect.shoppingcart;
 
-import org.apache.cocoon.caching.CacheableProcessingComponent;
-import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
-import java.io.IOException;
-import java.io.Serializable;
-import java.sql.SQLException;
-import java.util.Map;
-
 import org.apache.avalon.framework.parameters.Parameters;
 import org.apache.cocoon.ProcessingException;
 import org.apache.cocoon.environment.ObjectModelHelper;
@@ -23,6 +16,7 @@ import org.apache.cocoon.util.HashUtil;
 import org.apache.excalibur.source.SourceValidity;
 import org.apache.excalibur.source.impl.validity.NOPValidity;
 import org.dspace.app.itemexport.ItemExport;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
 import org.dspace.app.xmlui.utils.DSpaceValidity;
 import org.dspace.app.xmlui.utils.HandleUtil;
 import org.dspace.app.xmlui.utils.UIException;
@@ -32,10 +26,15 @@ import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.app.xmlui.wing.element.Options;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.content.*;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
 import org.dspace.eperson.Group;
-import org.dspace.paymentsystem.PaymentSystemConfigurationManager;
 import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * Navigation Class that support Navigation Options for Shopping Cart User Interface
@@ -44,7 +43,7 @@ import org.xml.sax.SAXException;
  * @author Fabio Bolognesi, fabio at atmire.com
  * @author Lantian Gai, lantian at atmire.com
  */
-public class Navigation extends AbstractDSpaceTransformer implements CacheableProcessingComponent {
+public class Navigation extends AbstractDSpaceTransformer  {
 
     private static final Message T_administrative_head 				= message("xmlui.administrative.Navigation.administrative_head");
 
@@ -167,7 +166,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
 
 
         //Check if a system administrator
-        boolean isSystemAdmin = AuthorizeManager.isCuratorOrAdmin(this.context);
+        boolean isSystemAdmin = AuthorizeManager.isSeniorCurator(this.context);
 
 
         if(isSystemAdmin){

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
@@ -7,14 +7,8 @@
  */
 package org.dspace.app.xmlui.aspect.administrative;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.sql.SQLException;
-import java.util.Map;
-
 import org.apache.avalon.framework.parameters.Parameters;
 import org.apache.cocoon.ProcessingException;
-import org.apache.cocoon.caching.CacheableProcessingComponent;
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.environment.SourceResolver;
@@ -41,6 +35,11 @@ import org.dspace.core.Constants;
 import org.dspace.eperson.Group;
 import org.xml.sax.SAXException;
 
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.util.Map;
+
 /**
  *
  * Create the navigation options for everything in the administrative aspects. This includes 
@@ -51,7 +50,7 @@ import org.xml.sax.SAXException;
  * @author Alexey Maslov
  * @author Jay Paz
  */
-public class Navigation extends AbstractDSpaceTransformer implements CacheableProcessingComponent
+public class Navigation extends AbstractDSpaceTransformer
 {
     private static final Message T_context_head 				= message("xmlui.administrative.Navigation.context_head");
     private static final Message T_context_edit_item 			= message("xmlui.administrative.Navigation.context_edit_item");
@@ -216,7 +215,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
             {
                 context.setHead(T_context_head);
                 context.addItem().addXref(contextPath+"/admin/item?itemID="+item.getID(), T_context_edit_item);
-                if (AuthorizeManager.isAdmin(this.context, dso)||AuthorizeManager.isCuratorOrAdmin(this.context))
+                if (AuthorizeManager.isAdmin(this.context, dso)||AuthorizeManager.isCurator(this.context))
                 {
                     context.addItem().addXref(contextPath+"/admin/export?itemID="+item.getID(), T_context_export_item );
                     context.addItem().addXref(contextPath+ "/csv/handle/"+dso.getHandle(),T_context_export_metadata );

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/Navigation.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/Navigation.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.xmlui.aspect.discovery;
 
-import org.apache.cocoon.caching.CacheableProcessingComponent;
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.util.HashUtil;
@@ -41,7 +40,7 @@ import java.sql.SQLException;
  *
  * This class has been adjusted to leave out the community browse option
  */
-public class Navigation extends AbstractDSpaceTransformer implements CacheableProcessingComponent
+public class Navigation extends AbstractDSpaceTransformer
 {
     /** Language Strings */
     private static final Message T_head_all_of_dspace =
@@ -60,6 +59,8 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
         message("xmlui.ArtifactBrowser.Navigation.head_this_community");
     private static final Message T_navigation_workflow_overview =
             message("xmlui.Discovery.Navigation.workflow-overview");
+    private static final Message T_navigation_my_tasks =
+            message("xmlui.Submission.MyTasks.title");
 
 
     private static final Message T_administrative_head = 
@@ -154,7 +155,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
         }
         */
 
-        if(AuthorizeManager.isCuratorOrAdmin(context)){
+        if(AuthorizeManager.isCurator(context)){
             List admin = options.addList("administrative");
             admin.setHead(T_administrative_head);
 

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/administrative/WorkflowOverviewDiscovery.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/administrative/WorkflowOverviewDiscovery.java
@@ -14,7 +14,10 @@ import org.dspace.app.xmlui.utils.ContextUtil;
 import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
-import org.dspace.app.xmlui.wing.element.*;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.PageMeta;
+import org.dspace.app.xmlui.wing.element.Row;
+import org.dspace.app.xmlui.wing.element.Table;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.DSpaceObject;
@@ -22,7 +25,6 @@ import org.dspace.content.Item;
 import org.dspace.discovery.SearchServiceException;
 import org.dspace.discovery.SearchUtils;
 import org.dspace.eperson.EPerson;
-import org.dspace.handle.HandleManager;
 import org.dspace.workflow.ClaimedTask;
 import org.dspace.workflow.DryadWorkflowUtils;
 import org.dspace.workflow.PoolTask;
@@ -31,7 +33,6 @@ import org.dspace.workflow.WorkflowItem;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.*;
-import java.util.List;
 
 /**
  * User: kevin (kevin at atmire.com)
@@ -53,7 +54,7 @@ public class WorkflowOverviewDiscovery extends SimpleSearch {
     public void addPageMeta(PageMeta pageMeta) throws WingException, SQLException, AuthorizeException {
         pageMeta.addMetadata("title").addContent(T_title);
 
-        if(!AuthorizeManager.isCuratorOrAdmin(ContextUtil.obtainContext(objectModel))){
+        if(!AuthorizeManager.isCurator(ContextUtil.obtainContext(objectModel))){
             throw new AuthorizeException();
         }
     }

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Navigation.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Navigation.java
@@ -39,25 +39,16 @@
  */
 package org.dspace.app.xmlui.aspect.submission;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Locale;
-
 import org.apache.cocoon.caching.CacheableProcessingComponent;
-import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.util.HashUtil;
 import org.apache.excalibur.source.SourceValidity;
 import org.apache.excalibur.source.impl.validity.NOPValidity;
 import org.apache.log4j.Logger;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
-import org.dspace.app.xmlui.utils.AuthenticationUtil;
-import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.utils.DSpaceValidity;
+import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.Item;
@@ -65,14 +56,17 @@ import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.app.xmlui.wing.element.Options;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.core.LogManager;
-import org.dspace.eperson.EPerson;
-import org.dspace.handle.HandleManager;
 import org.dspace.content.Collection;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.eperson.Group;
-import org.dspace.workflow.*;
+import org.dspace.handle.HandleManager;
 import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.util.Enumeration;
+import java.util.Locale;
 
 /**
  * Simple navigation class to add the top level link to
@@ -204,7 +198,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
 	    account.setHead(T_my_account);
         account.addItemXref(contextPath+"/submissions",T_submissions);
 
-            if(AuthorizeManager.isCuratorOrAdmin(context))
+            if (AuthorizeManager.isCurator(context))
             {
                 account.addItemXref(contextPath+"/my-tasks",T_my_tasks);
             }


### PR DESCRIPTION
This fixes the issue reported, where My Tasks and Workflow Overview were not showing up for members of Curator and Senior Curator groups immediately after people were added to those groups.

This PR includes some refactoring and method name changes in AuthorizeManager; the previous method names were misleading and took on too much responsibility. 

With these changes, there are only two curator group-checking methods in AuthorizeManager: isCurator and isSeniorCurator. They both only return true if the current user is a member of the relevant group. Cascading group membership rules, such as "Administrator members should also be members of Senior Curator", should be expressed in group membership settings themselves; not in code.
