### PR TITLE
ticket : 2294 : Move journal configuration into the database

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
@@ -434,6 +434,38 @@ public class Concept extends AuthorityObject
         }
         return concepts;
     }
+
+    /**
+     * Find the concept by its name - assumes name is unique
+     *
+     * @param context
+     * @param journalID
+     *
+     * @return the named Concept, or null if not found
+     */
+
+    public static ArrayList<Concept> findByJournalID(Context context, String journalID)
+            throws SQLException
+    {
+        ArrayList<Concept> concepts = new ArrayList<Concept>();
+        TableRowIterator row = DatabaseManager.query(context,"select c.* from concept as c, conceptmetadatavalue as cmv where cmv.text_value = '"+journalID+"' and cmv.parent_id=c.id;");
+
+        if (row == null)
+        {
+            return null;
+        }
+        else
+        {
+
+            while(row.hasNext())
+            {
+                concepts.add(new Concept(context,row.next()));
+
+            }
+        }
+        return concepts;
+    }
+
     /**
      * Finds all concepts in the site
      *

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -29,7 +29,11 @@ public class JournalUtils {
     public static Concept getJournalConceptById(Context context, String authorityId) throws SQLException {
         try
         {
-            return Concept.findByIdentifier(context,authorityId).iterator().next();
+            List<Concept> concepts = Concept.findByJournalID(context, authorityId);
+            if (concepts.size() > 0) {
+                Concept concept = concepts.get(0);
+                return concept;
+            }
         }
         catch(Exception e)
         {

--- a/dspace/modules/api/src/main/java/org/dspace/submit/utils/DryadJournalSubmissionUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/submit/utils/DryadJournalSubmissionUtils.java
@@ -10,13 +10,11 @@ import org.dspace.content.authority.Scheme;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.workflow.DryadWorkflowUtils;
-import org.dspace.workflow.WorkflowItem;
 
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
-import java.io.IOException;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by IntelliJ IDEA.
@@ -28,7 +26,6 @@ import java.util.*;
 public class DryadJournalSubmissionUtils {
     private static Logger log = Logger.getLogger(DryadJournalSubmissionUtils.class);
 
-    // Reading DryadJournalSubmission.properties
     public static final String FULLNAME = "fullname";
     public static final String METADATADIR = "metadataDir";
     public static final String INTEGRATED = "integrated";
@@ -37,7 +34,7 @@ public class DryadJournalSubmissionUtils {
     public static final String NOTIFY_ON_ARCHIVE = "notifyOnArchive";
     public static final String JOURNAL_ID = "journalID";
     public static final String SUBSCRIPTION_PAID = "subscriptionPaid";
-    public static final String journalPropFile =  ConfigurationManager.getProperty("solrauthority.searchscheme.prism_publicationName");
+
     public enum RecommendedBlackoutAction {
         BLACKOUT_TRUE
         , BLACKOUT_FALSE

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -13,6 +13,7 @@ import org.jdom.Document;
 import org.jdom.input.SAXBuilder;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
+import org.jdom.JDOMException;
 
 import javax.mail.*;
 import javax.mail.internet.MimeMessage;
@@ -22,6 +23,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -263,7 +265,6 @@ public class DryadEmailSubmission extends HttpServlet {
             throw new SubmissionException("Unexpected email type: "
                     + mime.getContent().getClass().getName() + " reported content-type was " + mime.getContentType());
         }
-
         String message;
         if (mime.getEncoding() != null) {
             message = (String) part.getContent();
@@ -281,24 +282,21 @@ public class DryadEmailSubmission extends HttpServlet {
 
             message = builder.toString();
         }
-
         // Then we can hand off to implementer of EmailParser
         ParsingResult result = parseMessage(message, mime.getFrom());
 
         if (result.getStatus() != null) {
             throw new SubmissionException(result.getStatus());
         }
-
         if (result.hasFlawedId()) {
             throw new SubmissionException("Result ID is flawed: "
                     + result.getSubmissionId());
         }
-
         return parseToXML(result);
 
     }
 
-    private String parseToXML (ParsingResult result) {
+    private String parseToXML (ParsingResult result) throws JDOMException, SQLException, IOException{
 
         // We'll use JDOM b/c the libs are already included in DSpace
         SAXBuilder saxBuilder = new SAXBuilder();
@@ -312,31 +310,30 @@ public class DryadEmailSubmission extends HttpServlet {
 
         StringReader xmlReader = new StringReader(xml);
 
+        Format format = Format.getPrettyFormat();
+        XMLOutputter toFile = new XMLOutputter(format);
+        Document doc = saxBuilder.build(xmlReader);
+        String journalCode = result.getJournalCode();
+
+        LOGGER.info("Getting metadata dir for " + journalCode);
+
+        Context context = new Context();
+        Concept journalConcept = JournalUtils.getJournalConceptByShortID(context, journalCode);
+        File dir = new File(JournalUtils.getMetadataDir(journalConcept));
+
+        String submissionId = result.getSubmissionId();
+        String filename = DryadJournalSubmissionUtils.escapeFilename(submissionId + ".xml");
+        File file = new File(dir, filename);
         try {
-            Format format = Format.getPrettyFormat();
-            XMLOutputter toFile = new XMLOutputter(format);
-            Document doc = saxBuilder.build(xmlReader);
-            String journalCode = result.getJournalCode();
-
-            LOGGER.debug("Getting metadata dir for " + journalCode);
-
-            Context context = new Context();
-            Concept journalConcept = JournalUtils.getJournalConceptByShortID(context, journalCode);
-            File dir = new File(JournalUtils.getMetadataDir(journalConcept));
-
-            String submissionId = result.getSubmissionId();
-            String filename = DryadJournalSubmissionUtils.escapeFilename(submissionId + ".xml");
-            File file = new File(dir, filename);
-            LOGGER.info ("wrote xml to file " + file.getAbsolutePath());
             FileOutputStream out = new FileOutputStream(file);
             OutputStreamWriter writer = new OutputStreamWriter(out, "UTF-8");
 
             // And we write the output to our submissions directory
             toFile.output(doc, new BufferedWriter(writer));
         } catch (Exception details) {
-            LOGGER.debug(xml);
             throw new SubmissionRuntimeException(details);
         }
+        LOGGER.info ("wrote xml to file " + file.getAbsolutePath());
         return xml;
     }
 


### PR DESCRIPTION
This switches to using the database (Concept) to get journal configuration, and cleans up some property file-related code that is no longer needed.

(Note from Chris: This compiles and doesn't appear to break anything for me locally, but needs to be tested in a more fully-functional environment.)
