### PR TITLE
Improve logic for displaying items in the review dropdown on the initial submission page

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/SelectPublicationStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/SelectPublicationStep.java
@@ -353,7 +353,7 @@ public class SelectPublicationStep extends AbstractSubmissionStep {
             String name = journalConcepts[i].getPreferredLabel();
 
             // add only journal with allowReviewWorkflow=true;
-            if(JournalUtils.getBooleanAllowReviewWorkflow(journalConcepts[i]))
+            if(JournalUtils.getBooleanAllowReviewWorkflow(journalConcepts[i]) && JournalUtils.getBooleanIntegrated(journalConcepts[i]))
 
                 // select journal only if status is "In Review"
                 if(pBean!=null && (manuscriptStatus!=null && (manuscriptStatus.equals(PublicationBean.STATUS_IN_REVIEW)


### PR DESCRIPTION
Only show journals in the review dropdown if they are both integrated and allowReviewWorkflow.

To test: in the concept system, edit the metadata for a journal. The journal should only appear in the dropdown for "In preparation or in review" when the concept indicates that both integrated=true and allowReviewWorkflow=true.
