### PR TITLE
Tweak to DryadLab theme

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -255,11 +255,6 @@
                                 <p style="drop-shadow: 4px 4px; position: absolute; right: 40px; bottom: 6px; font-size: 70%; text-align: right; text-shadow: 1px 2px 2px rgba(33, 33, 33, 0.25);">Learn More &#187;</p>
                             </a>
                         </div>
-                        <div><span class="publication-date">2015-03-04</span>
-                            <a href="/pages/membershipMeeting2015">
-                                <img src="/themes/Mirage/images/membershipMeeting2015_carousel.jpg" alt="Dryad Community Meeting, 27 May 2015, Washington DC" />
-                           </a>
-                        </div>
                         <div><span class="publication-date">2015-03-23</span>
                             <a href="/pages/membershipOverview">
                                 <img alt="" src="/themes/Mirage/images/watering-can.png" />


### PR DESCRIPTION
This is a tweak to pull #938 to re-remove the community meeting banner from the homepage carousel. It was accidentally kept when fixing the merge conflict for 938.
