### PR TITLE
Cleanup diagnostic messages in some Dryad pages.

### DIFF
--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/DryadLab/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/DryadLab/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -53,7 +53,6 @@
                 <xsl:apply-templates select="./mets:fileSec/mets:fileGrp[@USE='ORE']"/>
             </xsl:when>
             <xsl:otherwise>
-<h1>TEST from themes/DryadLab/lib/xsl/aspect/artifactbrowser/item-view.xsl</h1>
                 <h2><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-head</i18n:text></h2>
                 <table class="ds-table file-list">
                     <tr class="ds-table-header-row">

--- a/dspace/modules/xmlui/src/main/webapp/themes/DryadLab/collection-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/DryadLab/collection-view.xsl
@@ -41,11 +41,6 @@
 
     <!-- A collection rendered in the detailView pattern; default way of viewing a collection. -->
     <xsl:template name="collectionDetailView-DIM">
-<h1>TEST - dspace/modules/xmlui/src/main/webapp/themes/DryadLab/collection-view.xsl</h1>
-<xsl:message>
-	<xsl:text>HELLO from dspace/modules/xmlui/src/main/webapp/themes/DryadLab/collection-view.xsl</xsl:text>
-	<!--<xsl:value-of select="name()"/>-->
-</xsl:message>
         <div class="detail-view">&#160;
             <!-- Generate the logo, if present, from the file section -->
             <xsl:apply-templates select="./mets:fileSec/mets:fileGrp[@USE='LOGO']"/>

--- a/dspace/modules/xmlui/src/main/webapp/themes/DryadLab/integrated-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/DryadLab/integrated-view.xsl
@@ -23,7 +23,6 @@
 
 
     <xsl:template match="dri:referenceSet[@type = 'embeddedView']" priority="2">
-<h1>TEST from themes/DryadLab/integrated-view.xsl</h1>
       <h2 class="ds-list-head">Files in this package</h2>
         <div class="file-list">
 	   <!-- TODO: need to test if we have one of the specially-licensed items -->

--- a/dspace/modules/xmlui/src/main/webapp/themes/DryadLab/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/DryadLab/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -58,7 +58,6 @@
                     <h2><i18n:text>xmlui.dri2xhtml.METS-1.0.files-external-head</i18n:text></h2>
                   </xsl:when>
                   <xsl:otherwise>
-<h1>TEST from themes/DryadLab/lib/xsl/aspect/artifactbrowser/item-view.xsl</h1>
                     <h2><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-head</i18n:text></h2>
                   </xsl:otherwise>
                 </xsl:choose>


### PR DESCRIPTION
@ryscher, this removes the unwanted diagnostic message in some Dryad templates. Sorry for the mess!
