### PR TITLE
Refactoring updating metadata in Item.java

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -1698,7 +1698,7 @@ public class Item extends DSpaceObject
 
     public void updateMetadata() {
         if (dublinCore.metadataChanged) {
-            modified = dublinCore.updateMetadata(ourContext, getID(), log);
+            modified = dublinCore.updateMetadata(getID());
         }
     }
 
@@ -2644,7 +2644,7 @@ public class Item extends DSpaceObject
 
     private List<DCValue> getMetadata()
     {
-        return dublinCore.get(ourContext, getID(), log);
+        return dublinCore.get(getID());
     }
 
     private void setMetadata(List<DCValue> metadata)
@@ -2657,7 +2657,7 @@ public class Item extends DSpaceObject
         List<DCValue> metadata = null;
         boolean metadataChanged = true;
 
-        List<DCValue> get(Context c, int itemId, Logger log) {
+        List<DCValue> get(int itemId) {
             if ((metadataChanged==true)||(metadata == null)) {
                 metadata = new ArrayList<DCValue>();
 
@@ -2670,12 +2670,12 @@ public class Item extends DSpaceObject
 
                             // Get the associated metadata field and schema information
                             int fieldID = resultRow.getIntColumn("metadata_field_id");
-                            MetadataField field = MetadataField.find(c, fieldID);
+                            MetadataField field = MetadataField.find(ourContext, fieldID);
 
                             if (field == null) {
                                 log.error("Loading item - cannot find metadata field " + fieldID);
                             } else {
-                                MetadataSchema schema = MetadataSchema.find(c, field.getSchemaID());
+                                MetadataSchema schema = MetadataSchema.find(ourContext, field.getSchemaID());
                                 if (schema == null) {
                                     log.error("Loading item - cannot find metadata schema " + field.getSchemaID() + ", field " + fieldID);
                                 } else {
@@ -2722,7 +2722,7 @@ public class Item extends DSpaceObject
             return null;
         }
 
-        boolean updateMetadata(Context ourContext, int itemId, Logger log) {
+        boolean updateMetadata(int itemId) {
             boolean hasBeenModified = false;
 
             metadataChanged = false;
@@ -2734,7 +2734,7 @@ public class Item extends DSpaceObject
             Map<String,Integer> elementCount = new HashMap<String,Integer>();
 
             try {
-                List<DCValue> currMetadata = get(ourContext,itemId,log);
+                List<DCValue> currMetadata = get(itemId);
                 // Arrays to store the working information required
                 int[]     placeNum = new int[currMetadata.size()];
                 boolean[] storedDC = new boolean[currMetadata.size()];
@@ -2891,10 +2891,10 @@ public class Item extends DSpaceObject
                 }
 
                 // Add missing in-memory DC
-                for (int dcIdx = 0; dcIdx < get(ourContext, itemId, log).size(); dcIdx++) {
+                for (int dcIdx = 0; dcIdx < get(itemId).size(); dcIdx++) {
                     // Only write values that are not already in the db
                     if (!storedDC[dcIdx]) {
-                        DCValue dcv = get(ourContext, itemId, log).get(dcIdx);
+                        DCValue dcv = get(itemId).get(dcIdx);
 
                         // Write DCValue
                         MetadataValue metadata = new MetadataValue();

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -2939,7 +2939,7 @@ public class Item extends DSpaceObject
                         hasBeenModified = true;
                     }
                 }
-            } catch (SQLException e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
             return hasBeenModified;

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -99,6 +99,8 @@ public class Item extends DSpaceObject
      */
     private boolean modified;
 
+    private int internalItemId;
+
     /**
      * Construct an item with the given table row
      *
@@ -112,6 +114,7 @@ public class Item extends DSpaceObject
     {
         ourContext = context;
         itemRow = row;
+        internalItemId = row.getIntColumn("item_id");
         dublinCore.metadataChanged = false;
         modified = false;
         clearDetails();
@@ -120,7 +123,7 @@ public class Item extends DSpaceObject
         handle = HandleManager.findHandle(context, this);
 
         // Cache ourselves
-        context.cache(this, row.getIntColumn("item_id"));
+        context.cache(this, internalItemId);
     }
 
     /**
@@ -261,9 +264,8 @@ public class Item extends DSpaceObject
      *
      * @return the internal identifier
      */
-    public int getID()
-    {
-        return itemRow.getIntColumn("item_id");
+    public int getID() {
+        return internalItemId;
     }
 
 

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -2644,16 +2644,7 @@ public class Item extends DSpaceObject
 
     private List<DCValue> getMetadata()
     {
-        try
-        {
-            return dublinCore.get(ourContext, getID(), log);
-        }
-        catch (SQLException e)
-        {
-            log.error("Loading item - cannot load metadata");
-        }
-
-        return new ArrayList<DCValue>();
+        return dublinCore.get(ourContext, getID(), log);
     }
 
     private void setMetadata(List<DCValue> metadata)
@@ -2666,15 +2657,18 @@ public class Item extends DSpaceObject
         List<DCValue> metadata = null;
         boolean metadataChanged = true;
 
-        List<DCValue> get(Context c, int itemId, Logger log) throws SQLException
+        List<DCValue> get(Context c, int itemId, Logger log)
         {
             if ((metadataChanged==true)||(metadata == null))
             {
                 metadata = new ArrayList<DCValue>();
 
                 // Get Dublin Core metadata
-                TableRowIterator tri = retrieveMetadata(itemId);
-
+                try {
+                    TableRowIterator tri = retrieveMetadata(itemId);
+                } catch (SQLException e) {
+                    throw new RuntimeException("couldn't access database metadata for item " + itemId, e);
+                }
                 if (tri != null)
                 {
                     try
@@ -2716,9 +2710,9 @@ public class Item extends DSpaceObject
                                 }
                             }
                         }
-                    }
-                    finally
-                    {
+                    } catch (SQLException e) {
+                        throw new RuntimeException("couldn't access database metadata for item " + itemId, e);
+                    } finally {
                         // close the TableRowIterator to free up resources
                         if (tri != null)
                         {

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -2864,7 +2864,7 @@ public class Item extends DSpaceObject
 
         List<DCValue> get(Context c, int itemId, Logger log) throws SQLException
         {
-            if (metadata == null)
+            if ((metadataChanged==true)||(metadata == null))
             {
                 metadata = new ArrayList<DCValue>();
 

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -526,7 +526,7 @@ public class Item extends DSpaceObject
     {
         // Build up list of matching values
         List<DCValue> values = new ArrayList<DCValue>();
-        for (DCValue dcv : getMetadata())
+        for (DCValue dcv : dublinCore.getMetadata())
         {
             if (match(schema, element, qualifier, lang, dcv))
             {
@@ -811,7 +811,7 @@ public class Item extends DSpaceObject
     public void addMetadata(String schema, String element, String qualifier, String lang,
                             String[] values, String authorities[], int confidences[])
     {
-        List<DCValue> dcValueList = getMetadata();
+        List<DCValue> dcValueList = dublinCore.getMetadata();
         MetadataAuthorityManager mam = MetadataAuthorityManager.getManager();
         boolean authorityControlled = mam.isAuthorityControlled(schema, element, qualifier);
         boolean authorityRequired = mam.isAuthorityRequired(schema, element, qualifier);
@@ -1005,7 +1005,7 @@ public class Item extends DSpaceObject
     {
         // We will build a list of values NOT matching the values to clear
         List<DCValue> values = new ArrayList<DCValue>();
-        for (DCValue dcv : getMetadata())
+        for (DCValue dcv : dublinCore.getMetadata())
         {
             if (!match(schema, element, qualifier, lang, dcv))
             {
@@ -1014,7 +1014,7 @@ public class Item extends DSpaceObject
         }
 
         // Now swap the old list of values for the new, unremoved values
-        setMetadata(values);
+        dublinCore.setMetadata(values);
         dublinCore.metadataChanged = true;
         updateMetadata();
     }
@@ -2642,23 +2642,12 @@ public class Item extends DSpaceObject
         return new ItemIterator(context, rows);
     }
 
-
-    private List<DCValue> getMetadata()
-    {
-        return dublinCore.get();
-    }
-
-    private void setMetadata(List<DCValue> metadata)
-    {
-        dublinCore.set(metadata);
-    }
-
     class MetadataCache
     {
         List<DCValue> metadata = null;
         boolean metadataChanged = true;
 
-        List<DCValue> get() {
+        List<DCValue> getMetadata() {
             if ((metadataChanged==true)||(metadata == null)) {
                 metadata = new ArrayList<DCValue>();
 
@@ -2705,7 +2694,7 @@ public class Item extends DSpaceObject
             return metadata;
         }
 
-        void set(List<DCValue> m)
+        void setMetadata(List<DCValue> m)
         {
             metadata = m;
             metadataChanged = true;
@@ -2735,7 +2724,7 @@ public class Item extends DSpaceObject
             Map<String,Integer> elementCount = new HashMap<String,Integer>();
 
             try {
-                List<DCValue> currMetadata = get();
+                List<DCValue> currMetadata = getMetadata();
                 // Arrays to store the working information required
                 int[]     placeNum = new int[currMetadata.size()];
                 boolean[] storedDC = new boolean[currMetadata.size()];
@@ -2892,14 +2881,14 @@ public class Item extends DSpaceObject
                 }
 
                 // Add missing in-memory DC
-                for (int dcIdx = 0; dcIdx < get().size(); dcIdx++) {
+                for (int dcIdx = 0; dcIdx < getMetadata().size(); dcIdx++) {
                     // Only write values that are not already in the db
                     if (!storedDC[dcIdx]) {
-                        DCValue dcv = get().get(dcIdx);
+                        DCValue dcv = getMetadata().get(dcIdx);
 
                         // Write DCValue
                         MetadataValue metadata = new MetadataValue();
-                        metadata.setItemId(Item.this.internalItemId);
+                        metadata.setItemId(internalItemId);
                         metadata.setFieldId(dcFields[dcIdx].getFieldID());
                         metadata.setValue(dcv.value);
                         metadata.setLanguage(dcv.language);
@@ -2909,7 +2898,7 @@ public class Item extends DSpaceObject
                         try {
                             metadata.create(ourContext);
                         } catch (Exception e) {
-                            throw new RuntimeException("Couldn't create metadata for item " + Item.this.internalItemId, e);
+                            throw new RuntimeException("Couldn't create metadata for item " + internalItemId, e);
                         }
                         hasBeenModified = true;
                     }

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -810,7 +810,7 @@ public class Item extends DSpaceObject
     public void addMetadata(String schema, String element, String qualifier, String lang,
                             String[] values, String authorities[], int confidences[])
     {
-        List<DCValue> dublinCore = getMetadata();
+        List<DCValue> dcValueList = getMetadata();
         MetadataAuthorityManager mam = MetadataAuthorityManager.getManager();
         boolean authorityControlled = mam.isAuthorityControlled(schema, element, qualifier);
         boolean authorityRequired = mam.isAuthorityRequired(schema, element, qualifier);
@@ -872,8 +872,8 @@ public class Item extends DSpaceObject
             {
                 dcv.value = null;
             }
-            if(!dublinCore.contains(dcv)){
-                dublinCore.add(dcv);
+            if(!dcValueList.contains(dcv)){
+                dcValueList.add(dcv);
                 addDetails(fieldName);
                 if (values.length > 0)
                 {
@@ -881,11 +881,6 @@ public class Item extends DSpaceObject
                 }
             }
         }
-
-//        if (values.length > 0)
-//        {
-//            dublinCoreChanged = true;
-//        }
     }
 
     /**

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -1689,15 +1689,16 @@ public class Item extends DSpaceObject
         if (dublinCore.metadataChanged) {
 
             dublinCore.metadataChanged = false;
+            List<DCValue> currMetadata = getMetadata();
             // Arrays to store the working information required
-            int[]     placeNum = new int[getMetadata().size()];
-            boolean[] storedDC = new boolean[getMetadata().size()];
-            MetadataField[] dcFields = new MetadataField[getMetadata().size()];
+            int[]     placeNum = new int[currMetadata.size()];
+            boolean[] storedDC = new boolean[currMetadata.size()];
+            MetadataField[] dcFields = new MetadataField[currMetadata.size()];
 
             // Work out the place numbers for the in memory DC
-            for (int dcIdx = 0; dcIdx < getMetadata().size(); dcIdx++)
+            for (int dcIdx = 0; dcIdx < currMetadata.size(); dcIdx++)
             {
-                DCValue dcv = getMetadata().get(dcIdx);
+                DCValue dcv = currMetadata.get(dcIdx);
 
                 // Work out the place number for ordering
                 int current = 0;
@@ -1755,13 +1756,13 @@ public class Item extends DSpaceObject
                         boolean removeRow = true;
 
                         // Go through the in-memory metadata, unless we've already decided to keep this row
-                        for (int dcIdx = 0; dcIdx < getMetadata().size() && removeRow; dcIdx++)
+                        for (int dcIdx = 0; dcIdx < currMetadata.size() && removeRow; dcIdx++)
                         {
                             // Only process if this metadata has not already been matched to something in the DB
                             if (!storedDC[dcIdx])
                             {
                                 boolean matched = true;
-                                DCValue dcv   = getMetadata().get(dcIdx);
+                                DCValue dcv   = currMetadata.get(dcIdx);
 
                                 // Check the metadata field is the same
                                 if (matched && dcFields[dcIdx].getFieldID() != tr.getIntColumn("metadata_field_id"))

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -2657,43 +2657,28 @@ public class Item extends DSpaceObject
         List<DCValue> metadata = null;
         boolean metadataChanged = true;
 
-        List<DCValue> get(Context c, int itemId, Logger log)
-        {
-            if ((metadataChanged==true)||(metadata == null))
-            {
+        List<DCValue> get(Context c, int itemId, Logger log) {
+            if ((metadataChanged==true)||(metadata == null)) {
                 metadata = new ArrayList<DCValue>();
 
                 // Get Dublin Core metadata
                 try {
                     TableRowIterator tri = retrieveMetadata(itemId);
-                } catch (SQLException e) {
-                    throw new RuntimeException("couldn't access database metadata for item " + itemId, e);
-                }
-                if (tri != null)
-                {
-                    try
-                    {
-                        while (tri.hasNext())
-                        {
+                    if (tri != null) {
+                        while (tri.hasNext()) {
                             TableRow resultRow = tri.next();
 
                             // Get the associated metadata field and schema information
                             int fieldID = resultRow.getIntColumn("metadata_field_id");
                             MetadataField field = MetadataField.find(c, fieldID);
 
-                            if (field == null)
-                            {
+                            if (field == null) {
                                 log.error("Loading item - cannot find metadata field " + fieldID);
-                            }
-                            else
-                            {
+                            } else {
                                 MetadataSchema schema = MetadataSchema.find(c, field.getSchemaID());
-                                if (schema == null)
-                                {
+                                if (schema == null) {
                                     log.error("Loading item - cannot find metadata schema " + field.getSchemaID() + ", field " + fieldID);
-                                }
-                                else
-                                {
+                                } else {
                                     // Make a DCValue object
                                     DCValue dcv = new DCValue();
                                     dcv.element = field.getElement();
@@ -2710,18 +2695,12 @@ public class Item extends DSpaceObject
                                 }
                             }
                         }
-                    } catch (SQLException e) {
-                        throw new RuntimeException("couldn't access database metadata for item " + itemId, e);
-                    } finally {
-                        // close the TableRowIterator to free up resources
-                        if (tri != null)
-                        {
-                            tri.close();
-                        }
+                        tri.close();
                     }
+                } catch (SQLException e) {
+                    throw new RuntimeException("couldn't access database metadata for item " + itemId, e);
                 }
             }
-
             return metadata;
         }
 

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -122,13 +122,6 @@ public class Item extends DSpaceObject
         context.cache(this, row.getIntColumn("item_id"));
     }
 
-    private TableRowIterator retrieveMetadata() throws SQLException
-    {
-        return DatabaseManager.queryTable(ourContext, "MetadataValue",
-                "SELECT * FROM MetadataValue WHERE item_id= ? ORDER BY metadata_field_id, place",
-                itemRow.getIntColumn("item_id"));
-    }
-
     /**
      * Get an item from the database. The item, its Dublin Core metadata, and
      * the bundle and bitstream metadata are all loaded into memory.
@@ -1744,11 +1737,10 @@ public class Item extends DSpaceObject
 
             // Now the precalculations are done, iterate through the existing metadata
             // looking for matches
-            TableRowIterator tri = retrieveMetadata();
-            if (tri != null)
-            {
-                try
-                {
+            try {
+                TableRowIterator tri = dublinCore.retrieveMetadata(getID());
+
+                if (tri != null) {
                     while (tri.hasNext())
                     {
                         TableRow tr = tri.next();

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -880,6 +880,7 @@ public class Item extends DSpaceObject
                 }
             }
         }
+        updateMetadata();
     }
 
     /**
@@ -1013,6 +1014,7 @@ public class Item extends DSpaceObject
         // Now swap the old list of values for the new, unremoved values
         setMetadata(values);
         dublinCore.metadataChanged = true;
+        updateMetadata();
     }
 
     /**

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -1698,6 +1698,7 @@ public class Item extends DSpaceObject
 
     public void updateMetadata() {
         if (dublinCore.metadataChanged) {
+            modified = dublinCore.updateMetadata(ourContext, getID(), log);
         }
     }
 

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -2811,13 +2811,9 @@ public class Item extends DSpaceObject
                                     + " " + dcv.qualifier);
                         }
                 }
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
 
-            // Now the precalculations are done, iterate through the existing metadata
-            // looking for matches
-            try {
+                // Now the precalculations are done, iterate through the existing metadata
+                // looking for matches
                 TableRowIterator tri = retrieveMetadata(getID());
 
                 if (tri != null) {
@@ -2919,11 +2915,7 @@ public class Item extends DSpaceObject
                     }
                     tri.close();
                 }
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
 
-            try {
                 // Add missing in-memory DC
                 for (int dcIdx = 0; dcIdx < get(ourContext, itemId, log).size(); dcIdx++) {
                     // Only write values that are not already in the db


### PR DESCRIPTION
So many fixes. The main thing was to separate out the actual updating of the metadata from the update() call overall, so that addMetadata and clearMetadata can refresh the MetadataCache without incurring the rest of the overhead. I also took out some unneeded Event calls, refactored the two classes, a bunch of stuff.

There shouldn't be any behavioral changes, but we're testing this on dev right now. Things I've done to test:
- Submit a package, add files.
- Curate a package: to blackout, to archive, etc.
- Add new metadata to the archived package and propagate.
- Add authors with ORCIDs.
