### PR TITLE
Reconfigure management of contexts

### DIFF
--- a/dspace/modules/dataone-mn/dataone-mn-webapp/src/main/java/org/dspace/dataonemn/DataOneMN.java
+++ b/dspace/modules/dataone-mn/dataone-mn-webapp/src/main/java/org/dspace/dataonemn/DataOneMN.java
@@ -75,49 +75,6 @@ public class DataOneMN extends HttpServlet implements Constants {
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
     /**
-       Opens a DSpace context, and cleanly recovers if there is a problem opening it.
-    **/
-    private Context getContext() throws ServletException {
-	Context ctxt = null;
-	
-	try {
-	    ctxt = new Context();
-	    
-	    log.debug("DSpace context initialized");
-	    return ctxt;
-	}
-	catch (SQLException e) {
-	    log.error("Unable to initialize DSpace context", e);
-	    
-	    try {
-		if (ctxt != null) {
-		    ctxt.complete();
-		}
-	    }
-	    catch (SQLException e2) {
-		log.warn("unable to close context cleanly;" + e2.getMessage(), e2);
-	    }
-	    
-	    throw new ServletException("Unable to initialize DSpace context", e);
-	}
-    }
-
-    
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////
-    private void closeContext(Context ctxt) throws ServletException {
-	log.debug("closing context " + ctxt);
-	try {
-	    if (ctxt != null && ctxt.getDBConnection() != null) {   //if the connection is null how can we commit?
-		ctxt.complete();
-	    }
-	    log.debug("DSpace context closed.");
-	} catch (SQLException e) {
-	    log.warn("unable to close context cleanly;" + e.getMessage(), e);
-	}
-    }
-    
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////
-    /**
      * Receives the HEAD HTTP call and passes off to the appropriate method.
      **/
     protected void doHead(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -126,16 +83,24 @@ public class DataOneMN extends HttpServlet implements Constants {
 	String reqPath = buildReqPath(request.getPathInfo());
 	log.debug("pathinfo=" + reqPath);
 
-	Context ctxt = getContext();
-	
-	if (reqPath.startsWith("/object/")) {
-	    ObjectManager objManager = new ObjectManager(ctxt, myFiles, myPackages);
-	    describe(reqPath, response, objManager);
-	} else {
-	    response.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED);
+	Context context = null;
+
+	try{
+	    context = new Context();
+	    
+	    if (reqPath.startsWith("/object/")) {
+		ObjectManager objManager = new ObjectManager(context, myFiles, myPackages);
+		describe(reqPath, response, objManager);
+	    } else {
+		response.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED);
+	    }
+	} catch (SQLException e) {
+	    log.error("Unable to initialize context and object manager", e);
+	} finally {
+	    if (context != null) {
+		context.abort();
+	    }
 	}
-	
-	closeContext(ctxt);
     }
     
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -203,8 +168,6 @@ public class DataOneMN extends HttpServlet implements Constants {
         String queryString = request.getQueryString();
        	log.debug("reqPath=" + reqPath);
 	
-	Context ctxt = null;
-	
 	LogEntry le = new LogEntry();
 	String requestIP = request.getHeader("x-forwarded-for");
         if(requestIP == null) {
@@ -222,10 +185,12 @@ public class DataOneMN extends HttpServlet implements Constants {
 	le.setSubject(subjectBuff.toString());
 	le.setNodeIdentifier(d1NodeID);
 	//code for setting the log time moved to the LogEntry class, since the format needs to work with solr
+
+	Context context = null;
 	
 	try {
-	    ctxt = getContext();
-	    ObjectManager objManager = new ObjectManager(ctxt, myFiles, myPackages);     
+	    context = new Context();
+	    ObjectManager objManager = new ObjectManager(context, myFiles, myPackages);     
 		    
 	    if (reqPath.startsWith("/monitor/ping")) {
 		ping(response, objManager);
@@ -287,7 +252,9 @@ public class DataOneMN extends HttpServlet implements Constants {
 	} catch (Exception e) {
 	    log.error("UNEXPECTED EXCEPTION", e);
 	} finally {
-	    closeContext(ctxt);
+	    if (context != null) {
+		context.abort();
+	    }
 	}
     }
     
@@ -298,8 +265,8 @@ public class DataOneMN extends HttpServlet implements Constants {
      **/
     public void init() throws ServletException {
 	log.debug("initializing...");
-	ServletContext context = this.getServletContext();
-	String configFileName = context.getInitParameter("dspace.config");
+	ServletContext scontext = this.getServletContext();
+	String configFileName = scontext.getInitParameter("dspace.config");
 	File aConfig = new File(configFileName);
 	
 	if (aConfig != null) {
@@ -789,13 +756,11 @@ public class DataOneMN extends HttpServlet implements Constants {
 	try {
 	    long length = objManager.getObjectSize(id, idTimestamp);
 	    response.setContentLength((int) length);
-
+	    
 	    if (id.endsWith("/bitstream")) {
-	    ServletContext context = getServletContext();
 
 	    log.warn("NEED TO GET CORRECT MIME TYPE");
 	    String mimeType = "application/octet-stream";
-	    //String mimeType = context.getMimeType("f." + format);
 
 	    if (mimeType == null || mimeType.equals("")) {
 	        mimeType = "application/octet-stream";
@@ -857,9 +822,6 @@ public class DataOneMN extends HttpServlet implements Constants {
 	catch (Exception details) {
 	    log.error("UNEXPECTED EXCEPTION", details);
 	    response.sendError(HttpServletResponse.SC_NOT_FOUND);
-	}
-	finally {
-	    objManager.completeContext();
 	}
     }
 

--- a/dspace/modules/dataone-mn/dataone-mn-webapp/src/main/java/org/dspace/dataonemn/ObjectManager.java
+++ b/dspace/modules/dataone-mn/dataone-mn-webapp/src/main/java/org/dspace/dataonemn/ObjectManager.java
@@ -61,12 +61,12 @@ public class ObjectManager implements Constants {
     public static final int DEFAULT_START = 0;
     public static final int DEFAULT_COUNT = 20;
     
-    protected Context myContext;
+    protected Context context;
     protected String myFiles;
     protected String myPackages;
     
-    public ObjectManager(Context aContext, String aFilesCollection, String aPackagesCollection) {
-	myContext = aContext;
+    public ObjectManager(Context context, String aFilesCollection, String aPackagesCollection) {
+	this.context = context;
 	myFiles = aFilesCollection;
         myPackages = aPackagesCollection;
     }
@@ -145,7 +145,7 @@ public class ObjectManager implements Constants {
             totalDataPackageElements = 0l;
         }
 
-        myContext.turnOffAuthorisationSystem();
+        context.turnOffAuthorisationSystem();
 
         log.debug("Setting start parameter to: " + aStart);
         list.setStart(aStart);
@@ -196,7 +196,7 @@ public class ObjectManager implements Constants {
         serializer.flush();
         aOutStream.close();
 
-        myContext.restoreAuthSystemState();
+        context.restoreAuthSystemState();
     }
 
     private List<nu.xom.Element> buildDataPackagesList(int aStart, int aCount, Date aFrom, Date aTo, String aObjFormat, boolean useTimestamps) 
@@ -559,7 +559,7 @@ public class ObjectManager implements Constants {
                 + "AND s.short_id = ? "
                 + "AND f.element = ? "
                 + "AND f.qualifier is null";                
-        TableRow tr = DatabaseManager.querySingle(myContext, dcIdentifierFieldIDQuery, "dc", "identifier");
+        TableRow tr = DatabaseManager.querySingle(context, dcIdentifierFieldIDQuery, "dc", "identifier");
         int dcIdentifierFieldId = tr.getIntColumn("metadata_field_id");
 
         log.info("dc.identifier: metadata_field_id " + dcIdentifierFieldId); // should be 17
@@ -568,7 +568,7 @@ public class ObjectManager implements Constants {
     // pass countTotal as true to return the count instead of item data
     private TableRowIterator queryDataFilesDatabase(boolean countTotal, int start, int count, Date fromDate, Date toDate, String objFormat) 
     throws SQLException {
-        Collection c = (Collection) HandleManager.resolveToObject(myContext, myFiles);
+        Collection c = (Collection) HandleManager.resolveToObject(context, myFiles);
         int dcIdentifierFieldId = getDCIdentifierFieldID();
 
         StringBuilder queryBuilder = new StringBuilder();
@@ -642,12 +642,12 @@ public class ObjectManager implements Constants {
         // and text_value::timestamp < to_timestamp('2009-07-01','YYYY-MM-DD')
         // limit 10;
         log.debug ("Query files is " + queryBuilder.toString() + " with params " + bindParameters.toString());
-        return DatabaseManager.query(myContext, queryBuilder.toString(), bindParameters.toArray());
+        return DatabaseManager.query(context, queryBuilder.toString(), bindParameters.toArray());
     }
 
     private TableRowIterator queryDataPackagesDatabase(boolean countTotal, int start, int count, Date fromDate, Date toDate)
             throws SQLException {
-        Collection c = (Collection) HandleManager.resolveToObject(myContext, myPackages);
+        Collection c = (Collection) HandleManager.resolveToObject(context, myPackages);
         int dcIdentifierFieldId = getDCIdentifierFieldID();
         StringBuilder queryBuilder = new StringBuilder();
         // build up bind paramaters 
@@ -696,7 +696,7 @@ public class ObjectManager implements Constants {
             bindParameters.add(start);
         }
         log.debug ("Query packages is " + queryBuilder.toString() + " with params " + bindParameters.toString());
-        return DatabaseManager.query(myContext, queryBuilder.toString(), bindParameters.toArray());
+        return DatabaseManager.query(context, queryBuilder.toString(), bindParameters.toArray());
         
     }
     /**
@@ -726,7 +726,7 @@ public class ObjectManager implements Constants {
 		String shortID = aID.substring(0,bitsIndex);
 		aID = shortID;
 	    }
-	    item = (Item) doiService.resolve(myContext, aID, new String[] {});
+	    item = (Item) doiService.resolve(context, aID, new String[] {});
 	} catch (IdentifierNotFoundException e) {
 	    log.error(aID + " not found!");
 	    throw new NotFoundException(aID);
@@ -1049,16 +1049,4 @@ public class ObjectManager implements Constants {
 	iStream.close();
     }
     
-    public void completeContext() {
-	try {
-	    if (myContext != null) {
-		myContext.complete();
-	    }
-	} catch (SQLException e) {
-	    log.error("unable to complete DSpace context", e);
-	    
-	    // don't pass on the exception because this isn't an error in responding to a DataONE request,
-	    // it's an internal error in shutting down resources.
-	}
-    }
 }


### PR DESCRIPTION
Changes the usage of DSpace context and its associated database connection. The new arrangment should prevent us from getting database connections that are "idle in transaction".

Once this is on a server, it can be tested using the DataONE Member Node tester:
http://mncheck.test.dataone.org:8080/d1_web_test_site-v1/list
