### PR TITLE
Maven 2.2 and Maven 3 use `project.version`, not `pom.version`.

### DIFF
--- a/dspace/modules/api-stats/pom.xml
+++ b/dspace/modules/api-stats/pom.xml
@@ -49,7 +49,7 @@
                 <dependency>
                     <groupId>org.dspace</groupId>
                     <artifactId>dspace-api</artifactId>
-                    <version>${pom.version}</version>
+                    <version>${project.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.solr</groupId>

--- a/dspace/modules/journal-landing/journal-landing-webapp/pom.xml
+++ b/dspace/modules/journal-landing/journal-landing-webapp/pom.xml
@@ -100,12 +100,12 @@
         <dependency>
             <groupId>org.dspace.modules</groupId>
             <artifactId>api-stats</artifactId>
-            <version>${pom.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.dspace.modules</groupId>
             <artifactId>api</artifactId>
-            <version>${pom.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <!-- This is required to get the base classes for tests -->
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-api</artifactId>
-            <version>${pom.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.dspace.discovery</groupId>
@@ -133,23 +133,23 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-xmlui-api</artifactId>
-            <version>${pom.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-xmlui-wing</artifactId>
-            <version>${pom.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-xmlui-webapp</artifactId>
             <type>war</type>
-            <version>${pom.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-stats</artifactId>
-            <version>${pom.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -71,25 +71,25 @@
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>api</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>identifier-services</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>versioning-api</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>doi-service</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
                <dependency>
@@ -97,27 +97,27 @@
                    <artifactId>versioning-webapp</artifactId>
                    <type>jar</type>
                    <classifier>classes</classifier>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>versioning-webapp</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                    <type>war</type>
                </dependency>
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>versioning-api</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>payment-api</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
                <dependency>
@@ -125,13 +125,13 @@
                    <artifactId>payment-webapp</artifactId>
                    <type>jar</type>
                    <classifier>classes</classifier>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>payment-webapp</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                    <type>war</type>
                </dependency>
 
@@ -140,13 +140,13 @@
                    <artifactId>dryad-widgets-webapp</artifactId>
                    <type>jar</type>
                    <classifier>classes</classifier>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                </dependency>
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
                    <artifactId>dryad-widgets-webapp</artifactId>
-                   <version>${pom.version}</version>
+                   <version>${project.version}</version>
                    <type>war</type>
                </dependency>
 

--- a/dspace/modules/versioning/pom.xml
+++ b/dspace/modules/versioning/pom.xml
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>org.dspace.modules</groupId>
                 <artifactId>versioning-api</artifactId>
-                <version>${pom.version}</version>
+                <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -843,12 +843,12 @@
 	<dependency>
 	  <groupId>org.dspace.modules</groupId>
 	  <artifactId>bagit-api</artifactId>
-      <version>${pom.version}</version>
+      <version>${project.version}</version>
 	</dependency>
 	<dependency>
 	  <groupId>org.dspace.modules</groupId>
 	  <artifactId>doi-service</artifactId>
-	  <version>${pom.version}</version>
+	  <version>${project.version}</version>
 	  <exclusions>
 	    <exclusion>
 	      <artifactId>ehcache</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
                               <descriptorRef>src-release</descriptorRef>
                            </descriptorRefs>
                            <tarLongFileMode>gnu</tarLongFileMode>
-                           <finalName>dspace-${pom.version}</finalName>
+                           <finalName>dspace-${project.version}</finalName>
                         </configuration>
                         <phase>package</phase>
                         <goals>


### PR DESCRIPTION
In Maven 3, `pom.` properties don't even work!
