### PR TITLE
Pin versions of plugins.

### DIFF
--- a/dspace-discovery/dspace-discovery-xmlui-api/pom.xml
+++ b/dspace-discovery/dspace-discovery-xmlui-api/pom.xml
@@ -47,6 +47,7 @@
             <plugin>
                 <groupId>org.apache.cocoon</groupId>
                 <artifactId>cocoon-maven-plugin</artifactId>
+                <version>1.0.2</version>
                 <executions>
                     <execution>
                         <id>prepare</id>

--- a/dspace-discovery/dspace-discovery-xmlui-webapp/pom.xml
+++ b/dspace-discovery/dspace-discovery-xmlui-webapp/pom.xml
@@ -65,6 +65,7 @@
             <plugin>
                 <groupId>org.apache.cocoon</groupId>
                 <artifactId>cocoon-maven-plugin</artifactId>
+                <version>1.0.2</version>
                 <executions>
                     <execution>
                         <id>prepare</id>

--- a/dspace/modules/solr/pom.xml
+++ b/dspace/modules/solr/pom.xml
@@ -28,6 +28,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
+            <version>2.6</version>
             <executions>
                <execution>
                   <phase>prepare-package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
                               <descriptorRef>src-release</descriptorRef>
                            </descriptorRefs>
                            <tarLongFileMode>gnu</tarLongFileMode>
-                           <finalName>dspace-${pom.version}</finalName>
+                           <finalName>dspace-${plugin.version}</finalName>
                         </configuration>
                         <phase>package</phase>
                         <goals>


### PR DESCRIPTION
Newer versions of Maven require that plugins also be pinned to specific
versions, to better ensure builds are reproducible.
