### PR TITLE
Use valid repository IDs.

### DIFF
--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -21,7 +21,7 @@
 
    <repositories>
       <repository>
-         <id>maven.dspace.org/snapshot</id>
+         <id>maven.dspace.org-snapshot</id>
          <name>DSpace Maven Snapshot Repository</name>
          <url>http://maven.dspace.org/snapshot</url>
          <releases>


### PR DESCRIPTION
Somewhere in the late 2.x series, Maven stopped accepting `/` in repository IDs.
