### PR TITLE
Remove duplicate dependency specification.

### DIFF
--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -109,13 +109,6 @@
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>
-                   <artifactId>versioning-api</artifactId>
-                   <version>${pom.version}</version>
-               </dependency>
-
-
-               <dependency>
-                   <groupId>org.dspace.modules</groupId>
                    <artifactId>payment-api</artifactId>
                    <version>${pom.version}</version>
                </dependency>


### PR DESCRIPTION
In Maven 3, this is a hard error, and breaks the build. The identical dependency
is a few lines earlier in the same `<dependencyManagement>` section.
