### PR TITLE
tiny fix: adding back original owner should be submitter, not taskowner

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowManager.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowManager.java
@@ -317,17 +317,18 @@ public class WorkflowManager {
 
     public static void deleteClaimedTask(Context c, WorkflowItem wi, ClaimedTask task) throws SQLException, AuthorizeException {
         if(task != null){
-            task.delete();
             EPerson e = EPerson.find(c, task.getOwnerID());
+            EPerson submitter = wi.getItem().getSubmitter();
+            task.delete();
             removeUserItemPolicies(c, wi.getItem(), e);
             // add back the original owner's policies
-            grantUserAllItemPolicies(c, wi.getItem(), e);
+            grantUserAllItemPolicies(c, wi.getItem(), submitter);
             //Also make sure that the user gets policies on our data files
             Item[] dataFiles = DryadWorkflowUtils.getDataFiles(c, wi.getItem());
             for (Item dataFile : dataFiles) {
                 removeUserItemPolicies(c, dataFile, e);
                 // add back the original owner's policies
-                grantUserAllItemPolicies(c, dataFile, e);
+                grantUserAllItemPolicies(c, dataFile, submitter);
             }
         }
     }


### PR DESCRIPTION
When a claimedTask is deleted and returned to submitter, it should restore the policies for the original submitter, not the task owner.
