### PR TITLE
Small formatting tweaks

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/EditFileStep.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/EditFileStep.java
@@ -23,6 +23,7 @@ import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.app.xmlui.wing.element.Select;
 import org.dspace.app.xmlui.wing.element.Text;
+import org.dspace.app.xmlui.utils.XSLUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
@@ -116,7 +117,7 @@ public class EditFileStep extends AbstractStep
     	
         int itemID = submissionInfo.getSubmissionItem().getItem().getID();
     	String fileUrl = contextPath + "/bitstream/item/" + itemID + "/" + bitstream.getName();
-    	String fileName = bitstream.getName();
+    	String fileName = XSLUtils.getShortFileName(bitstream.getName(), 25);
     	
     	// Build the form that describes an item.
     	Division div = body.addInteractiveDivision("submit-edit-file", actionURL, Division.METHOD_POST, "primary submission");

--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
@@ -33,15 +33,15 @@ public class XSLUtils {
             try {
                 if (string.charAt(targetLength) == ' ')
                 {
-                    return string.substring(0, targetLength) + " ...";
+                    return string.substring(0, targetLength) + "...";
                 }
                 if (string.charAt(targetLength + currentDeviation) == ' ')
                 {
-                    return string.substring(0, targetLength + currentDeviation) + " ...";
+                    return string.substring(0, targetLength + currentDeviation) + "...";
                 }
                 if (string.charAt(targetLength - currentDeviation) == ' ')
                 {
-                    return string.substring(0, targetLength - currentDeviation) + " ...";
+                    return string.substring(0, targetLength - currentDeviation) + "...";
                 }
             } catch (Exception e) {
                 //just in case
@@ -50,7 +50,53 @@ public class XSLUtils {
             currentDeviation++;
         }
 
-        return string.substring(0, targetLength) + " ...";
+        return string.substring(0, targetLength) + "...";
 
+    }
+
+    /**
+     * Shorten a file name for display with a maximum length.
+     * If the maxlen specified is less than 10, return a string with length of 10.
+     * @param maxlen
+     *
+     * @return the name of the bitstream
+     */
+    public static String getShortFileName(String name, int maxlen)
+    {
+        if (name == null) {
+            return null;
+        }
+
+        // If the maxlen specified is less than 10, return a string with length of 10.
+        if (maxlen < 10) {
+            maxlen = 10;
+        }
+
+        if (name.length() > maxlen) {
+            String prefix = null;
+            String suffix = null;
+            // the plan is to split the name into two parts:
+            // the suffix will be the file extension plus the two letters before: e.g., "ly.txt"
+            // if there is no file extension (or the file extension is longer than six), the suffix is the last six letters.
+            // the prefix will be the first part of the name, truncated to the length needed to make the whole thing be maxlen.
+            // so the whole thing is prefix...suffix
+            String[] parts = name.split("\\.");
+            if (parts.length > 1) {
+                // there is a file extension.
+                suffix = parts[parts.length - 1];
+                suffix = name.substring(name.length() - suffix.length() - 3, name.length() - suffix.length() - 1) + "." + suffix;
+            }
+
+            if ((suffix == null) || (suffix.length() > 6)){
+                // if the file extension is longer than six or it doesn't have a file extension:
+                // the suffix will be the last six letters.
+                suffix = name.substring(name.length() - 5, name.length());
+            }
+            suffix = "..." + suffix;
+            prefix = name.substring(0, maxlen - suffix.length());
+            return prefix + suffix;
+        } else {
+            return name;
+        }
     }
 }

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DepositConfirmedStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DepositConfirmedStep.java
@@ -6,6 +6,7 @@ import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
 import org.dspace.app.xmlui.wing.element.Item;
+import org.dspace.app.xmlui.utils.XSLUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
 import org.dspace.identifier.DOIIdentifierProvider;
@@ -62,7 +63,7 @@ public class DepositConfirmedStep extends AbstractSubmissionStep{
 
         int i = 0;
         for (org.dspace.content.Item dataFile : dataFiles){
-            addPara(dataFileDiv, " " + dataFile.getName());
+            addPara(dataFileDiv, " " + XSLUtils.getShortFileName(dataFile.getName(), 50));
         }
 
     }

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeDatasetStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeDatasetStep.java
@@ -6,6 +6,7 @@ import org.dspace.app.xmlui.aspect.submission.AbstractSubmissionStep;
 import org.dspace.app.xmlui.wing.element.*;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.utils.XSLUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
 import org.dspace.content.Item;
@@ -113,8 +114,8 @@ public class DescribeDatasetStep extends AbstractSubmissionStep {
             fileItem.addHighlight("head").addContent(message("xmlui.Submission.submit.UploadStep.column5"));
             fileItem.addHighlight("head").addContent(message("xmlui.Submission.submit.UploadStep.column7"));
 
-            fileItem.addHighlight("content").addXref(url, fileFound.getName());
-            fileItem.addHighlight("content").addContent((fileFound.getSize() / 1000) + "Kb");
+            fileItem.addHighlight("content").addXref(url, XSLUtils.getShortFileName(fileFound.getName(), 25));
+            fileItem.addHighlight("content").addContent((fileFound.getSize() / 1000) + " Kb");
             fileItem.addHighlight("content").addContent(fileFound.getFormat().getDescription());
             fileItem.addHidden("remove_dataset_id").setValue("" + fileFound.getID());
             fileItem.addHidden("dataset_id_present").setValue("" + fileFound.getID());

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/OverviewStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/OverviewStep.java
@@ -7,6 +7,7 @@ import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
 import org.dspace.app.xmlui.wing.element.Item;
+import org.dspace.app.xmlui.utils.XSLUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
 import org.dspace.core.ConfigurationManager;
@@ -270,7 +271,7 @@ public class OverviewStep extends AbstractStep {
     private boolean renderDatasetItem(boolean submissionNotFinished, List dataSetList, org.dspace.content.Item dataset, InProgressSubmission wsDataset) throws WingException, SQLException {
         Item dataItem = dataSetList.addItem();
 
-        String datasetTitle = wsDataset.getItem().getName();
+        String datasetTitle = XSLUtils.getShortFileName(wsDataset.getItem().getName(), 50);
         if(datasetTitle == null)
             datasetTitle = "Untitled";
 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -157,74 +157,36 @@
                     </p>
                     <div class="citation-sample">
                         <xsl:call-template name="make-author-string"/>
-                        <xsl:choose>
-                            <xsl:when test="$meta[@element='date'][@qualifier='issued']">
-                                <xsl:value-of select="$meta[@element='date'][@qualifier='issued']"/>
-                            </xsl:when>
-                            <xsl:when test="$meta[@element='dateIssued'][@qualifier='package']">
-                                <xsl:value-of
-                                        select="$meta[@element='dateIssued'][@qualifier='package']"/>
-                            </xsl:when>
-                        </xsl:choose>
-                        <xsl:text> </xsl:text>
-                        <xsl:variable name="title"
-                                      select="$meta[@element='title'][@qualifier='package']"/>
-                        <xsl:value-of select="$title"/>
-                        <span>
-                            <i18n:text>xmlui.DryadItemSummary.dryadRepo</i18n:text>
-                        </span>
-                        <!-- if Item not_archived don't add the link. -->
-                        <xsl:variable name="id" select="$meta[@element='identifier'][@qualifier='package']"/>
-			<xsl:text> </xsl:text>
-                        <xsl:choose>
-                            <xsl:when
-                                    test="not(/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@mdschema='dc'][@element='date' ][@qualifier='accessioned'])">
+                        <xsl:call-template name="package-citation">
+                            <xsl:with-param name="package_doi">
+                                <xsl:variable name="id" select="$meta[@element='identifier'][@qualifier='package']"/>
                                 <xsl:choose>
                                     <xsl:when test="starts-with($id, 'doi')">
-                                        <xsl:value-of  select="concat('http://dx.doi.org/', substring-after($id, 'doi:'))"/>
+                                        <xsl:value-of
+                                                select="concat('http://dx.doi.org/', substring-after($id, 'doi:'))"/>
                                     </xsl:when>
                                     <xsl:when test="starts-with($id,'http://dx.doi')">
-                                      <xsl:value-of select="$id"/>
+                                        <xsl:value-of select="$id"/>
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <xsl:value-of select="concat('http://hdl.handle.net/', $id)"/>
                                     </xsl:otherwise>
                                 </xsl:choose>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <a>
-                                    <!-- link -->
-                                    <xsl:attribute name="href">
-                                        <xsl:choose>
-                                            <xsl:when test="starts-with($id, 'doi')">
-                                                <xsl:value-of
-                                                        select="concat('http://dx.doi.org/', substring-after($id, 'doi:'))"/>
-                                            </xsl:when>
-                                            <xsl:when test="starts-with($id,'http://dx.doi')">
-                                               <xsl:value-of select="$id"/>
-                                             </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="concat('http://hdl.handle.net/', $id)"/>
-                                            </xsl:otherwise>
-                                        </xsl:choose>
-                                    </xsl:attribute>
 
-                                    <!-- text -->
-                                    <xsl:choose>
-                                        <xsl:when test="starts-with($id, 'doi')">
-                                            <xsl:value-of 
-                                                        select="concat('http://dx.doi.org/', substring-after($id, 'doi:'))"/>
-                                        </xsl:when>
-                                        <xsl:when test="starts-with($id,'http://dx.doi')">
-                                           <xsl:value-of select="$id"/>
-                                         </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:value-of select="concat('http://hdl.handle.net/', $id)"/>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </a>
-                            </xsl:otherwise>
-                        </xsl:choose>
+                            </xsl:with-param>
+                            <xsl:with-param name="date">
+                                <xsl:choose>
+                                    <xsl:when test="$meta[@element='date'][@qualifier='issued']">
+                                        <xsl:value-of select="$meta[@element='date'][@qualifier='issued']"/>
+                                    </xsl:when>
+                                    <xsl:when test="$meta[@element='dateIssued'][@qualifier='package']">
+                                        <xsl:value-of select="$meta[@element='dateIssued'][@qualifier='package']"/>
+                                    </xsl:when>
+                                </xsl:choose>
+                            </xsl:with-param>
+                            <xsl:with-param name="title" select="$meta[@element='title'][@qualifier='package']"/>
+                            <xsl:with-param name="date_accessioned" select="/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@mdschema='dc'][@element='date' ][@qualifier='accessioned']"/>
+                        </xsl:call-template>
                     </div>
                     <!-- only show citation/share if viewing from page with real handle (not in process) -->
                     <xsl:if
@@ -437,85 +399,26 @@
                         </p>
                         <div class="citation-sample">
                             <xsl:call-template name="make-author-string"/>
-                            <xsl:choose>
-                                <xsl:when test=".//dim:field[@element='date'][@qualifier='issued']">
-                                    <xsl:text> </xsl:text>
-                                    <xsl:value-of
-                                            select="concat('(', substring(.//dim:field[@element='date'][@qualifier='issued'], 1, 4), ') ')"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:text>. </xsl:text>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            <xsl:choose>
-                                <xsl:when test="not(.//dim:field[@element='title'])">
-                                    <xsl:text> </xsl:text>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:variable name="title"
-                                                  select=".//dim:field[@element='title']/node()"/>
-                                    <xsl:if test="not(starts-with($title, 'Data from: '))">
-                                        <i18n:text>xmlui.DryadItemSummary.dataFrom</i18n:text>
-                                    </xsl:if>
-                                    <xsl:value-of select="$title"/>
-                                    <xsl:variable name="titleEndChar"
-                                                  select="substring($title, string-length($title), 1)"/>
+                            <xsl:call-template name="package-citation">
+                                <xsl:with-param name="date" select=".//dim:field[@element='date'][@qualifier='issued']"/>
+                                <xsl:with-param name="title" select=".//dim:field[@element='title']"/>
+                                <xsl:with-param name="date_accessioned" select="/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@mdschema='dc'][@element='date' ][@qualifier='accessioned']"/>
+                                <xsl:with-param name="package_doi">
                                     <xsl:choose>
-                                        <xsl:when test="$titleEndChar != '.' and $titleEndChar != '?'">
-                                            <xsl:text>. </xsl:text>
+                                        <xsl:when test="$my_doi">
+                                            <xsl:value-of
+                                                    select="concat('http://dx.doi.org/', substring-after($my_doi, 'doi:'))"/>
+                                        </xsl:when>
+                                        <xsl:when test="$my_full_doi">
+                                            <xsl:value-of select="$my_full_doi"/>
                                         </xsl:when>
                                         <xsl:otherwise>
-                                            <xsl:text>&#160;</xsl:text>
+                                            <xsl:value-of select="$my_uri"/>
                                         </xsl:otherwise>
                                     </xsl:choose>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            <span>
-                                <i18n:text>xmlui.DryadItemSummary.dryadRepo</i18n:text>
-                            </span>
-
-                            <!-- if Item not_archived don't add the link. -->
-                            <xsl:choose>
-                                <xsl:when
-                                        test="not(/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@mdschema='dc'][@element='date' ][@qualifier='accessioned'])">
-                                    <xsl:value-of select="$my_doi"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <a>
-                                        <!-- href -->
-                                        <xsl:attribute name="href">
-                                            <xsl:choose>
-                                                <xsl:when test="$my_doi">
-                                                    <xsl:value-of
-                                                            select="concat('http://dx.doi.org/', substring-after($my_doi, 'doi:'))"/>
-                                                </xsl:when>
-                                                <xsl:when test="$my_full_doi">
-                                                  <xsl:value-of select="$my_full_doi"/>
-                                                </xsl:when>
-                                                <xsl:otherwise>
-                                                    <xsl:value-of select="$my_uri"/>
-                                                </xsl:otherwise>
-                                            </xsl:choose>
-                                        </xsl:attribute>
-
-                                        <!-- text -->
-                                        <xsl:choose>
-                                            <xsl:when test="$my_doi">
-                                                <xsl:value-of
-                                                            select="concat('http://dx.doi.org/', substring-after($my_doi, 'doi:'))"/>
-                                            </xsl:when>
-                                           <xsl:when test="$my_full_doi">
-                                              <xsl:value-of select="$my_full_doi"/>
-                                            </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$my_uri"/>
-                                            </xsl:otherwise>
-                                        </xsl:choose>
-
-                                    </a>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                        </div>
+                                </xsl:with-param>
+                            </xsl:call-template>
+                       </div>
                     </xsl:if>
                     <!-- only show citation/share if viewing from page with real handle (not in process) -->
                     <xsl:if
@@ -1332,6 +1235,73 @@
               (DSpace deposit license hidden by default) -->
         <xsl:apply-templates select="mets:fileSec/mets:fileGrp[@USE='CC-LICENSE']"/>
 
+    </xsl:template>
+
+    <xsl:template name="package-citation">
+        <xsl:param name="date"/>
+        <xsl:param name="title"/>
+        <xsl:param name="date_accessioned"/>
+        <xsl:param name="package_doi"/>
+
+        <xsl:choose>
+            <xsl:when test="string-length($date) > 0">
+                <xsl:text> </xsl:text>
+                <xsl:choose>
+                    <xsl:when test="not(starts-with($date, '('))">
+                        <xsl:value-of select="concat('(', substring($date, 1, 4), ')')"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$date"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:text> </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>. </xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:choose>
+            <xsl:when test="not($title)">
+                <xsl:text> </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:if test="not(starts-with($title, 'Data from: '))">
+                    <i18n:text>xmlui.DryadItemSummary.dataFrom</i18n:text>
+                </xsl:if>
+                <xsl:variable name="clean-title" select="normalize-space($title)"/>
+                <xsl:value-of select="$clean-title"/>
+                <xsl:variable name="titleEndChar" select="substring($clean-title, string-length($clean-title), 1)"/>
+                <xsl:choose>
+                    <xsl:when test="$titleEndChar != '.' and $titleEndChar != '?'">
+                        <xsl:text>. </xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text> </xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+        <span>
+            <i18n:text>xmlui.DryadItemSummary.dryadRepo</i18n:text>
+        </span>
+
+        <!-- if Item not_archived don't add the link. -->
+        <xsl:choose>
+            <xsl:when test="not($date_accessioned)">
+                <xsl:value-of select="$package_doi"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <a>
+                    <!-- href -->
+                    <xsl:attribute name="href">
+                        <xsl:value-of select="$package_doi"/>
+                    </xsl:attribute>
+
+                    <!-- text -->
+                    <xsl:value-of select="$package_doi"/>
+                </a>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <!-- this generates the linked journal image - should find a way to drive this from the DryadJournalSubmission.properties file -->

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadUtils.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadUtils.xsl
@@ -47,6 +47,32 @@
         </xsl:if>
     </xsl:template>
 
+    <xsl:template name="fileSizeString">
+        <xsl:param name="size"/>
+        <xsl:choose>
+            <xsl:when test="$size &lt; 1000">
+                <xsl:value-of select="@SIZE"/>
+                <xsl:text> </xsl:text>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
+            </xsl:when>
+            <xsl:when test="$size &lt; 1000000">
+                <xsl:value-of select="substring(string($size div 1000),1,5)"/>
+                <xsl:text> </xsl:text>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
+            </xsl:when>
+            <xsl:when test="$size &lt; 1000000000">
+                <xsl:value-of select="substring(string($size div 1000000),1,5)"/>
+                <xsl:text> </xsl:text>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="substring(string($size div 1000000000),1,5)"/>
+                <xsl:text> </xsl:text>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
     <!--  This template can parse names and normalize the output; it works
 on names with last name first (comma delimited). -->
     <xsl:template name="name-parse-reverse">

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/integrated-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/integrated-view.xsl
@@ -114,31 +114,12 @@
 
                 <xsl:value-of select="util:getShortFileName(mets:FLocat/@xlink:title, 50)"/>
                 <!-- File Size -->
-                <span class="bitstream-filesize">
-		  <xsl:text> (</xsl:text>
-                    <xsl:choose>
-                        <xsl:when test="@SIZE &lt; 1000">
-                            <xsl:value-of select="@SIZE"/>
-                            <xsl:text> </xsl:text>
-                            <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
-                        </xsl:when>
-                        <xsl:when test="@SIZE &lt; 1000000">
-                            <xsl:value-of select="substring(string(@SIZE div 1000),1,5)"/>
-                            <xsl:text> </xsl:text>
-                            <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
-                        </xsl:when>
-                        <xsl:when test="@SIZE &lt; 1000000000">
-                            <xsl:value-of select="substring(string(@SIZE div 1000000),1,5)"/>
-                            <xsl:text> </xsl:text>
-                            <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="substring(string(@SIZE div 1000000000),1,5)"/>
-                            <xsl:text> </xsl:text>
-                            <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
-                        </xsl:otherwise>
-                    </xsl:choose>
-		    <xsl:text>)</xsl:text></span></a>
+                <xsl:text> (</xsl:text>
+                <xsl:call-template name="fileSizeString">
+                    <xsl:with-param name="size" select="@SIZE"/>
+                </xsl:call-template>
+                <xsl:text>)</xsl:text>
+              </a>
             </td>
           </tr>
 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/integrated-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/integrated-view.xsl
@@ -14,6 +14,7 @@
                 xmlns:xlink="http://www.w3.org/TR/xlink/" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xalan="http://xml.apache.org/xalan" xmlns:datetime="http://exslt.org/dates-and-times"
                 xmlns:encoder="xalan://java.net.URLEncoder" exclude-result-prefixes="xalan strings encoder datetime"
+                xmlns:util="org.dspace.app.xmlui.utils.XSLUtils"
                 version="1.0" xmlns:strings="http://exslt.org/strings"
                 xmlns:confman="org.dspace.core.ConfigurationManager">
 
@@ -62,7 +63,7 @@
           <tbody>
           <tr>
             <th>Title</th>
-            <th><xsl:value-of select=".//dim:field[@element='title']"/></th>        
+            <th><xsl:value-of select="util:shortenString(.//dim:field[@element='title'], 50, 5)"/></th>
 	    <!-- Download count -->
 	    <xsl:variable name="downloads" select=".//dim:field[@element='dryad'][@qualifier='downloads']"/>
 	    <xsl:if test="$downloads > 0">
@@ -111,25 +112,29 @@
                       </xsl:choose>
                 </xsl:attribute>
 
-                <xsl:value-of select="mets:FLocat/@xlink:title"/>
+                <xsl:value-of select="util:getShortFileName(mets:FLocat/@xlink:title, 50)"/>
                 <!-- File Size -->
                 <span class="bitstream-filesize">
 		  <xsl:text> (</xsl:text>
                     <xsl:choose>
                         <xsl:when test="@SIZE &lt; 1000">
                             <xsl:value-of select="@SIZE"/>
+                            <xsl:text> </xsl:text>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
                         </xsl:when>
                         <xsl:when test="@SIZE &lt; 1000000">
                             <xsl:value-of select="substring(string(@SIZE div 1000),1,5)"/>
+                            <xsl:text> </xsl:text>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
                         </xsl:when>
                         <xsl:when test="@SIZE &lt; 1000000000">
                             <xsl:value-of select="substring(string(@SIZE div 1000000),1,5)"/>
+                            <xsl:text> </xsl:text>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:value-of select="substring(string(@SIZE div 1000000000),1,5)"/>
+                            <xsl:text> </xsl:text>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
                         </xsl:otherwise>
                     </xsl:choose>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -446,28 +446,9 @@
                         <xsl:text>:</xsl:text>
                     </span>
                     <span>
-                        <xsl:choose>
-                            <xsl:when test="@SIZE &lt; 1000">
-                                <xsl:value-of select="@SIZE"/>
-                                <xsl:text> </xsl:text>
-                                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
-                            </xsl:when>
-                            <xsl:when test="@SIZE &lt; 1000000">
-                                <xsl:value-of select="substring(string(@SIZE div 1000),1,5)"/>
-                                <xsl:text> </xsl:text>
-                                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
-                            </xsl:when>
-                            <xsl:when test="@SIZE &lt; 1000000000">
-                                <xsl:value-of select="substring(string(@SIZE div 1000000),1,5)"/>
-                                <xsl:text> </xsl:text>
-                                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:value-of select="substring(string(@SIZE div 1000000000),1,5)"/>
-                                <xsl:text> </xsl:text>
-                                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
-                            </xsl:otherwise>
-                        </xsl:choose>
+                        <xsl:call-template name="fileSizeString">
+                            <xsl:with-param name="size" select="@SIZE"/>
+                        </xsl:call-template>
                     </span>
                 </div>
                 <!-- Lookup File Type description in local messages.xml based on MIME Type.

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -406,7 +406,7 @@
                     </xsl:choose>
                 </a>
             </div>
-            <div class="file-metadata" style="height: {$thumbnail.maxheight}px;">
+            <div class="file-metadata" style="min-height: {$thumbnail.maxheight}px;">
               <xsl:choose>
                 <xsl:when test="mets:FLocat[@LOCTYPE='TXT']/@xlink:text">
                  <div>
@@ -436,7 +436,7 @@
                     </span>
                     <span>
                         <xsl:attribute name="title"><xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:title"/></xsl:attribute>
-                        <xsl:value-of select="util:shortenString(mets:FLocat[@LOCTYPE='URL']/@xlink:title, 32, 5)"/>
+                        <xsl:value-of select="util:getShortFileName(mets:FLocat[@LOCTYPE='URL']/@xlink:title, 25)"/>
                     </span>
                 </div>
                 <!-- File size always comes in bytes and thus needs conversion -->
@@ -449,18 +449,22 @@
                         <xsl:choose>
                             <xsl:when test="@SIZE &lt; 1000">
                                 <xsl:value-of select="@SIZE"/>
+                                <xsl:text> </xsl:text>
                                 <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
                             </xsl:when>
                             <xsl:when test="@SIZE &lt; 1000000">
                                 <xsl:value-of select="substring(string(@SIZE div 1000),1,5)"/>
+                                <xsl:text> </xsl:text>
                                 <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
                             </xsl:when>
                             <xsl:when test="@SIZE &lt; 1000000000">
                                 <xsl:value-of select="substring(string(@SIZE div 1000000),1,5)"/>
+                                <xsl:text> </xsl:text>
                                 <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:value-of select="substring(string(@SIZE div 1000000000),1,5)"/>
+                                <xsl:text> </xsl:text>
                                 <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
                             </xsl:otherwise>
                         </xsl:choose>
@@ -514,7 +518,7 @@
               </xsl:otherwise>
             </xsl:choose>
             </div>
-            <div class="file-link" style="height: {$thumbnail.maxheight}px;">
+            <div class="file-link" style="min-height: {$thumbnail.maxheight}px;">
                 <a>
                     <xsl:attribute name="href">
                        <xsl:choose>


### PR DESCRIPTION
- Shortened file names for display
- Space between number and units for file sizes
- Package citation formatting is the same for files and packages
