### PR TITLE
Association anywhere adjustments

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
@@ -444,18 +444,20 @@ public class Concept extends AuthorityObject
      *
      * @return the named Concept, or null if not found
      */
+    public static ArrayList<Concept> findByJournalID(Context context, String journalID) throws SQLException, AuthorizeException {
+	// TODO: call the method below using  journalID.toUpperCase(), "journal, "journalID
 
-    public static ArrayList<Concept> findByJournalID(Context context, String journalID)
+    }
+
+    public static ArrayList<Concept> findByJournalID(Context context, String searchString, String schema, String element)
             throws SQLException, AuthorizeException
     {
         ArrayList<Concept> concepts = new ArrayList<Concept>();
-        String schema = "journal";
-        String element = "journalID";
         MetadataSchema mds = MetadataSchema.find(context, schema);
         MetadataField mdf = MetadataField.findByElement(context, mds.getSchemaID(), element, null);
-        journal_field_id = mdf.getFieldID();
+        target_field_id = mdf.getFieldID();
         log.info ("journal field id is " + journal_field_id);
-        TableRowIterator row = DatabaseManager.query(context, "select c.* from concept as c, conceptmetadatavalue as cmv where upper(cmv.text_value) = ? and cmv.parent_id = c.id and cmv.field_id = ?;", journalID.toUpperCase(), journal_field_id);
+        TableRowIterator row = DatabaseManager.query(context, "select c.* from concept as c, conceptmetadatavalue as cmv where upper(cmv.text_value) = ? and cmv.parent_id = c.id and cmv.field_id = ?;", searchString, target_field_id);
 
         if (row == null)
         {

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
@@ -437,27 +437,20 @@ public class Concept extends AuthorityObject
     }
 
     /**
-     * Find the concept by its name - assumes name is unique
+     * Find concepts by a metadata value in the concept metadata.
      *
-     * @param context
-     * @param journalID
-     *
-     * @return the named Concept, or null if not found
+     * @return the matching Concepts, or null if not found
      */
-    public static ArrayList<Concept> findByJournalID(Context context, String journalID) throws SQLException, AuthorizeException {
-	// TODO: call the method below using  journalID.toUpperCase(), "journal, "journalID
-
-    }
-
-    public static ArrayList<Concept> findByJournalID(Context context, String searchString, String schema, String element)
+    public static ArrayList<Concept> findByConceptMetadata(Context context, String searchString, String metadataSchema, String metadataElement)
             throws SQLException, AuthorizeException
     {
         ArrayList<Concept> concepts = new ArrayList<Concept>();
-        MetadataSchema mds = MetadataSchema.find(context, schema);
-        MetadataField mdf = MetadataField.findByElement(context, mds.getSchemaID(), element, null);
-        target_field_id = mdf.getFieldID();
-        log.info ("journal field id is " + journal_field_id);
+        MetadataSchema mds = MetadataSchema.find(context, metadataSchema);
+        MetadataField mdf = MetadataField.findByElement(context, mds.getSchemaID(), metadataElement, null);
+        int target_field_id = mdf.getFieldID();
+        log.info ("looking up concept metadata for " + searchString + " in field number " + target_field_id);
         TableRowIterator row = DatabaseManager.query(context, "select c.* from concept as c, conceptmetadatavalue as cmv where upper(cmv.text_value) = ? and cmv.parent_id = c.id and cmv.field_id = ?;", searchString, target_field_id);
+
 
         if (row == null)
         {

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
@@ -436,6 +436,18 @@ public class Concept extends AuthorityObject
         return concepts;
     }
 
+
+   /**
+     * Find concepts by a journalID in the concept metadata. The journalID is Dryad's 
+     * abbreviation for the journal name.
+     *
+     * @return the matching Concepts, or null if not found
+     */
+    public static ArrayList<Concept> findByJournalID(Context context, String journalID)
+	throws SQLException, AuthorizeException {
+	findByConceptMetadata(context, journalID, "journal", "journalID");
+    }
+
     /**
      * Find concepts by a metadata value in the concept metadata.
      *

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
@@ -437,17 +437,6 @@ public class Concept extends AuthorityObject
     }
 
 
-   /**
-     * Find concepts by a journalID in the concept metadata. The journalID is Dryad's 
-     * abbreviation for the journal name.
-     *
-     * @return the matching Concepts, or null if not found
-     */
-    public static ArrayList<Concept> findByJournalID(Context context, String journalID)
-	throws SQLException, AuthorizeException {
-	findByConceptMetadata(context, journalID, "journal", "journalID");
-    }
-
     /**
      * Find concepts by a metadata value in the concept metadata.
      *

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
@@ -445,27 +445,26 @@ public class Concept extends AuthorityObject
             throws SQLException, AuthorizeException
     {
         ArrayList<Concept> concepts = new ArrayList<Concept>();
-        MetadataSchema mds = MetadataSchema.find(context, metadataSchema);
-        MetadataField mdf = MetadataField.findByElement(context, mds.getSchemaID(), metadataElement, null);
-        int target_field_id = mdf.getFieldID();
-        log.info ("looking up concept metadata for " + searchString + " in field number " + target_field_id);
-        TableRowIterator row = DatabaseManager.query(context, "select c.* from concept as c, conceptmetadatavalue as cmv where upper(cmv.text_value) = ? and cmv.parent_id = c.id and cmv.field_id = ?;", searchString, target_field_id);
+	try {
+	    MetadataSchema mds = MetadataSchema.find(context, metadataSchema);
+	    MetadataField mdf = MetadataField.findByElement(context, mds.getSchemaID(), metadataElement, null);
+	    int target_field_id = mdf.getFieldID();
+	    log.info ("looking up concept metadata for " + searchString + " in field number " + target_field_id);
+	    TableRowIterator row = DatabaseManager.query(context, "select c.* from concept as c, conceptmetadatavalue as cmv where upper(cmv.text_value) = ? and cmv.parent_id = c.id and cmv.field_id = ?;", searchString, target_field_id);
 
 
-        if (row == null)
-        {
-            return null;
-        }
-        else
-        {
+	    if (row == null) {
+		    return null;
+	    } else {
+		while(row.hasNext()) {
+		    concepts.add(new Concept(context,row.next()));
+		}
+	    }
+	} catch (NullPointerException e) {
+	    log.error("Unable to find concept by metadata: search=" + searchString + ", schema=" + metadataSchema + ", element=" + metadataElement, e);
+	}
 
-            while(row.hasNext())
-            {
-                concepts.add(new Concept(context,row.next()));
-
-            }
-        }
-        return concepts;
+	return concepts;
     }
 
     /**

--- a/dspace/config/log4j-dspace-cli.properties
+++ b/dspace/config/log4j-dspace-cli.properties
@@ -18,7 +18,7 @@
 # CONSOLE is set to be a ConsoleAppender.
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.Threshold=ERROR
+log4j.appender.CONSOLE.Threshold=DEBUG
 log4j.appender.CONSOLE.layout.ConversionPattern=%d %-5p %c @ %m%n
 
 # FILE appender, receives messages from rootLogger
@@ -95,6 +95,9 @@ log4j.additivity.org.datadryad.submission=false
 # dataone-mn, to DATAONE_MN_FILE appender
 log4j.logger.org.dspace.dataonemn=WARN,DATAONE_MN_FILE
 log4j.additivity.org.dspace.dataonemn=false
+
+# AssociationAnywhere connection
+log4j.logger.org.datadryad.anywhere=DEBUG
 
 # In earlier XML configuration, some package names were specified
 # to log at a different level than WARN, overriding the root default

--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -188,3 +188,5 @@ log4j.logger.org.dspace.app.xmlui.aspect.dryadwidgets.display.WidgetDisplayBitst
 #journal landing pages
 log4j.logger.org.dspace.app.xmlui.aspect.journal.landing = ERROR
 
+# AssociationAnywhere connection
+log4j.logger.org.datadryad.anywhere=DEBUG

--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -189,4 +189,5 @@ log4j.logger.org.dspace.app.xmlui.aspect.dryadwidgets.display.WidgetDisplayBitst
 log4j.logger.org.dspace.app.xmlui.aspect.journal.landing = ERROR
 
 # AssociationAnywhere connection
-log4j.logger.org.datadryad.anywhere=DEBUG
+# This should NOT be set to DEBUG on a production system -- it will leave passwords in the log files.
+# log4j.logger.org.datadryad.anywhere=DEBUG

--- a/dspace/etc/postgres/database_dryad_registries.sql
+++ b/dspace/etc/postgres/database_dryad_registries.sql
@@ -172,6 +172,8 @@ INSERT INTO metadatafieldregistry (metadata_field_id, metadata_schema_id, elemen
 INSERT INTO metadatafieldregistry (metadata_field_id, metadata_schema_id, element, qualifier, scope_note) VALUES (136, 9, 'manuscriptNumberIgnorePattern', NULL, NULL);
 INSERT INTO metadatafieldregistry (metadata_field_id, metadata_schema_id, element, qualifier, scope_note) VALUES (137, 9, 'description', NULL, NULL);
 INSERT INTO metadatafieldregistry (metadata_field_id, metadata_schema_id, element, qualifier, scope_note) VALUES (138, 9, 'memberName', NULL, NULL);
+INSERT INTO metadatafieldregistry (metadata_field_id, metadata_schema_id, element, qualifier, scope_note) VALUES (139, 9, 'customerID', NULL, NULL);
+INSERT INTO metadatafieldregistry (metadata_field_id, metadata_schema_id, element, qualifier, scope_note) VALUES (140, 9, 'paymentPlanType', NULL, NULL);
 
 
 --

--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -69,18 +69,22 @@ public class AssociationAnywhere {
 	Context context = new Context(); 
 	try {
 	    if(line.hasOption("u")) {
+		log.debug("aa updating credits");
 		if(line.hasOption("i"))
 		    updateConcept(context, line.getOptionValue("i"));
 		else
 		    updateConcept(context);
 	    }
 	    else if(line.hasOption("t")){
+		log.debug("aa tallying credits");
 		tallyCredit(context, line.getOptionValue("i"), line.getOptionValue("p"));
 	    }
 	    else if(line.hasOption("l")){
+		log.debug("aa list customer");
 		System.out.print(printDocument(loadCustomerInfo(context, line.getOptionValue("i"))));
 	    }
 	    else if(line.hasOption("i")) {
+		log.debug("aa listing credits");
 		//load credit
 		String credit = getCredit(context, line.getOptionValue("i"));
 		System.out.println("credit : "+ credit);
@@ -179,7 +183,7 @@ public class AssociationAnywhere {
      * @throws AssociationAnywhereException
      */
     public static String tallyCredit(Context context, String customerId, String dataPackageID) throws AssociationAnywhereException {
-        log.debug("deducting one credit for customerId " + customerId);
+        log.debug("tallying one credit for customerId " + customerId);
         
         if("test".equals(customerId))
         {
@@ -379,6 +383,10 @@ public class AssociationAnywhere {
             transformer.setParameter("password", ConfigurationManager.getProperty("association.anywhere.password"));
             transformer.setParameter("customerID", customerID);
             transformer.setParameter("date", dateFormat.format(new Date()));
+
+	    if(transactionDescription == null) {
+		transactionDescription = "";
+	    }
 	    transformer.setParameter("transactionDescription", transactionDescription);
 
 	    Concept concept = JournalUtils.getJournalConceptByCustomerID(context, customerID);

--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -105,7 +105,7 @@ public class AssociationAnywhere {
             String requestUrl =  ConfigurationManager.getProperty("association.anywhere.url")
                     + "/CENCREDWEBSVCLIB.GET_CREDITS_XML?p_input_xml_doc="
                     + URLEncoder.encode(createRequest(customerId,"load-credit"));
-
+	    log.debug("AA URL is " + requestUrl);
             HttpClient client = new HttpClient();
             GetMethod get = new GetMethod(requestUrl);
             client.executeMethod(get);
@@ -143,6 +143,7 @@ public class AssociationAnywhere {
             String requestUrl =  ConfigurationManager.getProperty("association.anywhere.url")
                     + "/CENSSAWEBSVCLIB.GET_CUST_INFO_XML?p_input_xml_doc="
                     + URLEncoder.encode(createRequest(customerId,"customer-info"));
+	    log.debug("AA URL is " + requestUrl);
             HttpClient client = new HttpClient();
             GetMethod get = new GetMethod(requestUrl);
             client.executeMethod(get);
@@ -182,6 +183,7 @@ public class AssociationAnywhere {
             String requestUrl =  ConfigurationManager.getProperty("association.anywhere.url")
                     + "/CENCREDWEBSVCLIB.INS_CREDIT_XML?p_input_xml_doc="
                     + URLEncoder.encode(createRequest(customerId,"update-credit"));
+	    log.debug("AA URL is " + requestUrl);
             HttpClient client = new HttpClient();
             GetMethod get = new GetMethod(requestUrl);
             client.executeMethod(get);

--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -412,13 +412,13 @@ public class AssociationAnywhere {
         return null;
     }
 
-    private static void changeConceptMetadataValue(Concept concept, String field, String value)
+    private static void changeConceptMetadataValue(Concept concept,String field,String value)
     {
-        AuthorityMetadataValue[] metadataValues = concept.getMetadata("journal", field, null, Item.ANY);
+        AuthorityMetadataValue[] metadataValues = concept.getMetadata("internal","journal",field, Item.ANY);
         if(metadataValues==null||metadataValues.length==0)
         {
-            concept.addMetadata("journal", field, "en", value, null,-1);
-        }
+	    concept.addMetadata("internal","journal",field,"en",value,null,-1);
+	}
         else{
 
             for(AuthorityMetadataValue authorityMetadataValue:metadataValues)
@@ -426,7 +426,7 @@ public class AssociationAnywhere {
                 if(!authorityMetadataValue.value.equals(value))
                 {
                     concept.clearMetadata("internal","journal",field, Item.ANY);
-                    concept.addMetadata("internal","journal",field,"en",value,null,-1);
+		    concept.addMetadata("internal","journal",field,"en",value,null,-1);
                     break;
                 }
             }

--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -61,7 +61,7 @@ public class AssociationAnywhere {
 
         options.addOption("i", "customer id", true, "customer id");
         options.addOption("p", "data package id", false, "package id");
-        options.addOption("u", "update credit", false, "update credit");
+        options.addOption("u", "update customer settings", false, "update customer settings");
         options.addOption("t", "tally credit", false, "tally credit");
         options.addOption("l", "list customer", false, "list customer");
         CommandLine line = parser.parse(options, argv);

--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -355,7 +355,7 @@ public class AssociationAnywhere {
 
     static Templates template = null;
 
-    static SimpleDateFormat dateFormat = new SimpleDateFormat("dd/mm/yyyyy");
+    static SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy");
 
     private static String createRequest(String customerId, String form)
     {

--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -202,7 +202,7 @@ public class AssociationAnywhere {
         }
         catch (Exception e)
         {
-            throw new AssociationAnywhereException(e.getMessage());
+            throw new AssociationAnywhereException("unable to deduct credits for " + customerId, e);
         }
 
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -395,13 +395,16 @@ public class AssociationAnywhere {
 	
 		if (transactionType != null) {
 		    transformer.setParameter("transactionType", transactionType);
+	       
+		    String creditsAccepted = "1";
+		    if(transactionType.equals(JournalUtils.PREPAID_PLAN)) {
+			creditsAccepted = "-1";
+		    }
+		
+		    transformer.setParameter("creditsAccepted", creditsAccepted);
+		} else {
+		    log.error("Journal w/ customerID " + customerID + " does not have a transactionType.");
 		}
-
-		String creditsAccepted = "1";
-		if(transactionType.equals(JournalUtils.PREPAID_PLAN)) {
-		    creditsAccepted = "-1";
-		}
-		transformer.setParameter("creditsAccepted", creditsAccepted);
 	    }
             StringWriter writer = new StringWriter();
             transformer.transform(new StreamSource(new StringReader("<" + form + "/>")),new StreamResult(writer));

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -33,6 +33,9 @@ public class JournalUtils {
     public static final String NOTIFY_ON_ARCHIVE = "notifyOnArchive";
     public static final String JOURNAL_ID = "journalID";
     public static final String SUBSCRIPTION_PAID = "subscriptionPaid";
+    public static final String SUBSCRIPTION_PLAN = "subscription plan";
+    public static final String PREPAID_PLAN = "prepaid payment plan";
+    public static final String DEFERRED_PLAN = "deferred payment plan";
 
     public enum RecommendedBlackoutAction {
         BLACKOUT_TRUE
@@ -134,6 +137,11 @@ public class JournalUtils {
         }
 
         return null;
+    }
+
+
+    public static Concept getJournalConceptByCustomerId(String customerId) {
+	
     }
 
     public static Concept[] getJournalConcept(Context context,String journal) throws SQLException {

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -118,31 +118,37 @@ public class JournalUtils {
         return null;
     }
 
-
-    public static Concept getJournalConceptByShortID(Context context, String journalShortID) throws SQLException {
-        try
-        {
-            List<Concept> concepts = Concept.findByJournalID(context, journalShortID);
+    public static Concept getJournalConceptByCustomerID(Context context, String customerID) throws SQLException {
+        try {
+            List<Concept> concepts = Concept.findByConceptMetadata(context, customerID, "journal", "customerID");
             if (concepts.size() > 0) {
                 Concept concept = concepts.get(0);
                 return concept;
             }
         }
-        catch(Exception e)
-        {
-            if(log.isDebugEnabled())
-                log.error(e.getMessage(),e);
-            else
-                log.error(e);
+        catch(Exception e) {
+                log.error("unable to find journal by AssociationAnywhere customer ID",e);
         }
 
         return null;
     }
 
 
-    public static Concept getJournalConceptByCustomerId(String customerId) {
-	
+    public static Concept getJournalConceptByShortID(Context context, String journalShortID) throws SQLException {
+        try {
+            List<Concept> concepts = Concept.findByConceptMetadata(context, journalShortID.toUpperCase(), "journal", "journalID");
+            if (concepts.size() > 0) {
+                Concept concept = concepts.get(0);
+                return concept;
+            }
+        }
+        catch(Exception e) {
+                log.error("unable to find journal by journalID",e);
+        }
+
+        return null;
     }
+
 
     public static Concept[] getJournalConcept(Context context,String journal) throws SQLException {
         Scheme scheme = Scheme.findByIdentifier(context, ConfigurationManager.getProperty("solrauthority.searchscheme.prism_publicationName"));
@@ -267,6 +273,7 @@ public class JournalUtils {
 
         return null;
     }
+
     public static String getParsingScheme(Concept concept) {
         AuthorityMetadataValue[] vals = concept.getMetadata("journal","parsingScheme",null, Item.ANY);
         if(vals != null && vals.length > 0)
@@ -275,6 +282,13 @@ public class JournalUtils {
         return null;
     }
 
+    public static String getPaymentPlanType(Concept concept) {
+        AuthorityMetadataValue[] vals = concept.getMetadata("journal","paymentPlanType",null, Item.ANY);
+        if(vals != null && vals.length > 0)
+            return vals[0].value;
+
+        return null;
+    }
 
     public static String getEmbargoAllowed(Concept concept) {
         AuthorityMetadataValue[] vals = concept.getMetadata("journal","embargoAllowed",null, Item.ANY);

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -33,9 +33,9 @@ public class JournalUtils {
     public static final String NOTIFY_ON_ARCHIVE = "notifyOnArchive";
     public static final String JOURNAL_ID = "journalID";
     public static final String SUBSCRIPTION_PAID = "subscriptionPaid";
-    public static final String SUBSCRIPTION_PLAN = "subscription plan";
-    public static final String PREPAID_PLAN = "prepaid payment plan";
-    public static final String DEFERRED_PLAN = "deferred payment plan";
+    public static final String SUBSCRIPTION_PLAN = "SUBSCRIPTION";
+    public static final String PREPAID_PLAN = "PREPAID";
+    public static final String DEFERRED_PLAN = "DEFERRED";
 
     public enum RecommendedBlackoutAction {
         BLACKOUT_TRUE

--- a/dspace/modules/api/src/main/resources/anywhere/request-templates.xsl
+++ b/dspace/modules/api/src/main/resources/anywhere/request-templates.xsl
@@ -41,9 +41,10 @@
             <vendor-id><xsl:value-of select="$username"/></vendor-id>
             <vendor-password><xsl:value-of select="$password"/></vendor-password>
             <cust-id><xsl:value-of select="$customerId"/></cust-id>
-            <trans-type>DEFERRED</trans-type>
+            <trans-type>PREPAID</trans-type>
             <trans-date><xsl:value-of select="$date"/></trans-date>
             <cred-accepted>-1</cred-accepted>
+	    <cred-unit>DEP</cred-unit>
         </credit-request>
     </xsl:template>
 

--- a/dspace/modules/api/src/main/resources/anywhere/request-templates.xsl
+++ b/dspace/modules/api/src/main/resources/anywhere/request-templates.xsl
@@ -5,6 +5,7 @@
     <xsl:param name="customerID"/>
     <xsl:param name="date"/>
     <xsl:param name="transactionType"/>
+    <xsl:param name="transactionDescription"/>
     <xsl:param name="creditsAccepted"/>
 
     <xsl:template match="/load-credit">
@@ -43,6 +44,7 @@
             <vendor-id><xsl:value-of select="$username"/></vendor-id>
             <vendor-password><xsl:value-of select="$password"/></vendor-password>
             <cust-id><xsl:value-of select="$customerID"/></cust-id>
+	    <descr1><xsl:value-of select="$transactionDescription"/></descr1>
             <trans-type><xsl:value-of select="$transactionType"/></trans-type>
             <trans-date><xsl:value-of select="$date"/></trans-date>
             <cred-accepted><xsl:value-of select="$creditsAccepted"/></cred-accepted>

--- a/dspace/modules/api/src/main/resources/anywhere/request-templates.xsl
+++ b/dspace/modules/api/src/main/resources/anywhere/request-templates.xsl
@@ -4,6 +4,8 @@
     <xsl:param name="password"/>
     <xsl:param name="customerId"/>
     <xsl:param name="date"/>
+    <xsl:param name="transactionType"/>
+    <xsl:param name="creditsAccepted"/>
 
     <xsl:template match="/load-credit">
         <creditRequest>
@@ -41,9 +43,9 @@
             <vendor-id><xsl:value-of select="$username"/></vendor-id>
             <vendor-password><xsl:value-of select="$password"/></vendor-password>
             <cust-id><xsl:value-of select="$customerId"/></cust-id>
-            <trans-type>PREPAID</trans-type>
+            <trans-type><xsl:value-of select="$transactionType"/></trans-type>
             <trans-date><xsl:value-of select="$date"/></trans-date>
-            <cred-accepted>-1</cred-accepted>
+            <cred-accepted><xsl:value-of select="$creditsAccepted"/></cred-accepted>
 	    <cred-unit>DEP</cred-unit>
         </credit-request>
     </xsl:template>

--- a/dspace/modules/api/src/main/resources/anywhere/request-templates.xsl
+++ b/dspace/modules/api/src/main/resources/anywhere/request-templates.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.1" >
     <xsl:param name="username"/>
     <xsl:param name="password"/>
-    <xsl:param name="customerId"/>
+    <xsl:param name="customerID"/>
     <xsl:param name="date"/>
     <xsl:param name="transactionType"/>
     <xsl:param name="creditsAccepted"/>
@@ -11,14 +11,14 @@
         <creditRequest>
             <integratorUsername><xsl:value-of select="$username"/></integratorUsername>
             <integratorPassword><xsl:value-of select="$password"/></integratorPassword>
-            <custId><xsl:value-of select="$customerId"/></custId>
+            <custId><xsl:value-of select="$customerID"/></custId>
             <txTy>PREPAID</txTy>
         </creditRequest>
     </xsl:template>
 
     <xsl:template match="/customer-info">
         <custInfoRequest>
-            <custId><xsl:value-of select="$customerId"/></custId>
+            <custId><xsl:value-of select="$customerID"/></custId>
             <integratorUsername><xsl:value-of select="$username"/></integratorUsername>
             <integratorPassword><xsl:value-of select="$password"/></integratorPassword>
             <details includeCodeValues="true">
@@ -42,7 +42,7 @@
         <credit-request>
             <vendor-id><xsl:value-of select="$username"/></vendor-id>
             <vendor-password><xsl:value-of select="$password"/></vendor-password>
-            <cust-id><xsl:value-of select="$customerId"/></cust-id>
+            <cust-id><xsl:value-of select="$customerID"/></cust-id>
             <trans-type><xsl:value-of select="$transactionType"/></trans-type>
             <trans-date><xsl:value-of select="$date"/></trans-date>
             <cred-accepted><xsl:value-of select="$creditsAccepted"/></cred-accepted>

--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/workflow/actions/processingaction/FinalPaymentAction.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/workflow/actions/processingaction/FinalPaymentAction.java
@@ -79,34 +79,37 @@ public class FinalPaymentAction extends ProcessingAction {
             }
         }
 
-	    // if journal-based subscription is in place, transaction is paid
-	    if(shoppingCart.getJournalSub()) {
-		log.info("processed journal subscription for Item " + itemID + ", journal = " + shoppingCart.getJournal());
-        log.debug("tally credit for journal = " + shoppingCart.getJournal());
-        String success = "";
-        Scheme scheme = Scheme.findByIdentifier(c,ConfigurationManager.getProperty("solrauthority.searchscheme.prism_publicationName"));
-        Concept[] concepts = Concept.findByPreferredLabel(c,shoppingCart.getJournal(),scheme.getID());
-        if(concepts!=null&&concepts.length!=0){
-            AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("journal", "customerId", null, Item.ANY);
-            if(metadataValues!=null&&metadataValues.length>0){
-                try{
-		    String packageDOI = DOIIdentifierProvider.getDoiValue(wfi.getItem());
-                    success = AssociationAnywhere.tallyCredit(c, metadataValues[0].value, packageDOI);
-                    shoppingCart.setStatus(ShoppingCart.STATUS_COMPLETED);
-                    Date date= new Date();
-                    shoppingCart.setPaymentDate(date);
-                    shoppingCart.update();
-                    sendPaymentApprovedEmail(c,wfi,shoppingCart);
-                    return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
-                }catch (Exception e)
-                {
-                    log.error(e.getMessage(),e);
-                    sendPaymentErrorEmail(c, wfi, shoppingCart,"problem: credit not tallied successfully. \\n \\n " + e.getMessage());
-                    return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, 2);
-                }
-            }
-        }
+	// if journal-based subscription is in place, transaction is paid
+	if(shoppingCart.getJournalSub()) {
+	    log.info("processed journal subscription for Item " + itemID + ", journal = " + shoppingCart.getJournal());
+	    log.debug("tally credit for journal = " + shoppingCart.getJournal());
+	    String success = "";
+	    Scheme scheme = Scheme.findByIdentifier(c,ConfigurationManager.getProperty("solrauthority.searchscheme.prism_publicationName"));
+	    Concept[] concepts = Concept.findByPreferredLabel(c,shoppingCart.getJournal(),scheme.getID());
+	    if(concepts!=null&&concepts.length!=0){
+		AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("journal", "customerId", null, Item.ANY);
+		if(metadataValues!=null&&metadataValues.length>0){
+		    try{
+			String packageDOI = DOIIdentifierProvider.getDoiValue(wfi.getItem());
+			success = AssociationAnywhere.tallyCredit(c, metadataValues[0].value, packageDOI);
+			shoppingCart.setStatus(ShoppingCart.STATUS_COMPLETED);
+			Date date= new Date();
+			shoppingCart.setPaymentDate(date);
+			shoppingCart.update();
+			sendPaymentApprovedEmail(c,wfi,shoppingCart);
+			return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
+		    } catch (Exception e) {
+			log.error(e.getMessage(),e);
+			sendPaymentErrorEmail(c, wfi, shoppingCart,"problem: credit not tallied successfully. \\n \\n " + e.getMessage());
+			return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, 2);
+		    }
+		} else {
+		    log.error("unable to tally credit due to missing customerID");
+		}
+	    } else {
+		log.error("unable to tally credit due to missing concept");
 	    }
+	}
 
 			  
 

--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/workflow/actions/processingaction/FinalPaymentAction.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/workflow/actions/processingaction/FinalPaymentAction.java
@@ -81,7 +81,7 @@ public class FinalPaymentAction extends ProcessingAction {
 	    // if journal-based subscription is in place, transaction is paid
 	    if(shoppingCart.getJournalSub()) {
 		log.info("processed journal subscription for Item " + itemID + ", journal = " + shoppingCart.getJournal());
-        log.debug("deduct credit from journal = "+shoppingCart.getJournal());
+        log.debug("tally credit for journal = " + shoppingCart.getJournal());
         String success = "";
         Scheme scheme = Scheme.findByIdentifier(c,ConfigurationManager.getProperty("solrauthority.searchscheme.prism_publicationName"));
         Concept[] concepts = Concept.findByPreferredLabel(c,shoppingCart.getJournal(),scheme.getID());
@@ -89,7 +89,7 @@ public class FinalPaymentAction extends ProcessingAction {
             AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("journal", "customerId", null, Item.ANY);
             if(metadataValues!=null&&metadataValues.length>0){
                 try{
-                    success = AssociationAnywhere.deductCredit(metadataValues[0].value);
+                    success = AssociationAnywhere.tallyCredit(metadataValues[0].value, itemID);
                     shoppingCart.setStatus(ShoppingCart.STATUS_COMPLETED);
                     Date date= new Date();
                     shoppingCart.setPaymentDate(date);
@@ -99,7 +99,7 @@ public class FinalPaymentAction extends ProcessingAction {
                 }catch (Exception e)
                 {
                     log.error(e.getMessage(),e);
-                    sendPaymentErrorEmail(c, wfi, shoppingCart,"problem: credit not deducted successfully. \\n \\n " + e.getMessage());
+                    sendPaymentErrorEmail(c, wfi, shoppingCart,"problem: credit not tallied successfully. \\n \\n " + e.getMessage());
                     return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, 2);
                 }
             }

--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/workflow/actions/processingaction/FinalPaymentAction.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/workflow/actions/processingaction/FinalPaymentAction.java
@@ -87,7 +87,7 @@ public class FinalPaymentAction extends ProcessingAction {
 	    Scheme scheme = Scheme.findByIdentifier(c,ConfigurationManager.getProperty("solrauthority.searchscheme.prism_publicationName"));
 	    Concept[] concepts = Concept.findByPreferredLabel(c,shoppingCart.getJournal(),scheme.getID());
 	    if(concepts!=null&&concepts.length!=0){
-		AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("journal", "customerId", null, Item.ANY);
+		AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("journal", "customerID", null, Item.ANY);
 		if(metadataValues!=null&&metadataValues.length>0){
 		    try{
 			String packageDOI = DOIIdentifierProvider.getDoiValue(wfi.getItem());

--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/workflow/actions/processingaction/FinalPaymentAction.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/workflow/actions/processingaction/FinalPaymentAction.java
@@ -15,6 +15,7 @@ import org.dspace.content.authority.AuthorityMetadataValue;
 import org.dspace.content.authority.Concept;
 import org.dspace.content.authority.Scheme;
 import org.dspace.core.*;
+import org.dspace.identifier.DOIIdentifierProvider;
 import org.dspace.paymentsystem.PaymentSystemService;
 import org.dspace.paymentsystem.PaypalService;
 import org.dspace.paymentsystem.ShoppingCart;
@@ -89,7 +90,8 @@ public class FinalPaymentAction extends ProcessingAction {
             AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("journal", "customerId", null, Item.ANY);
             if(metadataValues!=null&&metadataValues.length>0){
                 try{
-                    success = AssociationAnywhere.tallyCredit(metadataValues[0].value, itemID);
+		    String packageDOI = DOIIdentifierProvider.getDoiValue(wfi.getItem());
+                    success = AssociationAnywhere.tallyCredit(c, metadataValues[0].value, packageDOI);
                     shoppingCart.setStatus(ShoppingCart.STATUS_COMPLETED);
                     Date date= new Date();
                     shoppingCart.setPaymentDate(date);

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/ReAuthorizationCreditActionXMLUI.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/ReAuthorizationCreditActionXMLUI.java
@@ -17,6 +17,7 @@ import org.dspace.content.authority.AuthorityMetadataValue;
 import org.dspace.content.authority.Concept;
 import org.dspace.content.authority.Scheme;
 import org.dspace.core.*;
+import org.dspace.identifier.DOIIdentifierProvider;
 import org.dspace.paymentsystem.PaymentSystemService;
 import org.dspace.paymentsystem.ShoppingCart;
 import org.dspace.utils.DSpace;
@@ -106,7 +107,7 @@ public class ReAuthorizationCreditActionXMLUI extends AbstractXMLUIAction {
                     AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("internal", "journal", "customerId", Item.ANY);
                     if(metadataValues!=null&&metadataValues.length>0){
                         try{
-                            success = AssociationAnywhere.tallyCredit(metadataValues[0].value, item.getID());
+                            success = AssociationAnywhere.tallyCredit(context, metadataValues[0].value, DOIIdentifierProvider.getDoiValue(item));
                             shoppingCart.setStatus(ShoppingCart.STATUS_COMPLETED);
                             Date date= new Date();
                             shoppingCart.setPaymentDate(date);

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/ReAuthorizationCreditActionXMLUI.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/ReAuthorizationCreditActionXMLUI.java
@@ -65,12 +65,12 @@ public class ReAuthorizationCreditActionXMLUI extends AbstractXMLUIAction {
             mainDiv.addPara(success);
             if(shoppingCart!=null&&!shoppingCart.getStatus().equals(ShoppingCart.STATUS_COMPLETED))
             {
-                mainDiv.addPara().addContent("NOTE : click the credit button will deduct your credit.");
+                mainDiv.addPara().addContent("NOTE : click the credit button will tally your credit.");
                 mainDiv.addList("submit-credit").addItem().addButton("submit-credit").setValue("Re-submit Credit");
             }
             else
             {
-                mainDiv.addPara().addContent("NOTE : credit already deducted ,click skip button to submit the item.");
+                mainDiv.addPara().addContent("NOTE : credit already tallied, click skip button to submit the item.");
                 mainDiv.addList("submit-next").addItem().addButton("submit-credit-next").setValue("Skip resubmit credit");
             }
 
@@ -98,7 +98,7 @@ public class ReAuthorizationCreditActionXMLUI extends AbstractXMLUIAction {
             // if journal-based subscription is in place, transaction is paid
             if(!shoppingCart.getStatus().equals(ShoppingCart.STATUS_COMPLETED)&&shoppingCart.getJournalSub()) {
                 log.info("processed journal subscription for Item " + item.getHandle() + ", journal = " + shoppingCart.getJournal());
-                log.debug("deduct credit from journal = "+shoppingCart.getJournal());
+                log.debug("tally credit for journal = "+shoppingCart.getJournal());
 
                 Scheme scheme = Scheme.findByIdentifier(context, ConfigurationManager.getProperty("solrauthority.searchscheme.prism_publicationName"));
                 Concept[] concepts = Concept.findByPreferredLabel(context,shoppingCart.getJournal(),scheme.getID());
@@ -106,7 +106,7 @@ public class ReAuthorizationCreditActionXMLUI extends AbstractXMLUIAction {
                     AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("internal", "journal", "customerId", Item.ANY);
                     if(metadataValues!=null&&metadataValues.length>0){
                         try{
-                            success = AssociationAnywhere.deductCredit(metadataValues[0].value);
+                            success = AssociationAnywhere.tallyCredit(metadataValues[0].value, item.getID());
                             shoppingCart.setStatus(ShoppingCart.STATUS_COMPLETED);
                             Date date= new Date();
                             shoppingCart.setPaymentDate(date);
@@ -115,7 +115,7 @@ public class ReAuthorizationCreditActionXMLUI extends AbstractXMLUIAction {
 
                         }catch (Exception e)
                         {
-                            sendPaymentErrorEmail(context, workflowItem, shoppingCart,"problem: credit not deducted successfully. \\n \\n " + e.getMessage());
+                            sendPaymentErrorEmail(context, workflowItem, shoppingCart,"problem: credit not tallied successfully. \\n \\n " + e.getMessage());
                             log.error(e.getMessage());
                             return e.getMessage();
                         }

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/ReAuthorizationCreditActionXMLUI.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/ReAuthorizationCreditActionXMLUI.java
@@ -104,7 +104,7 @@ public class ReAuthorizationCreditActionXMLUI extends AbstractXMLUIAction {
                 Scheme scheme = Scheme.findByIdentifier(context, ConfigurationManager.getProperty("solrauthority.searchscheme.prism_publicationName"));
                 Concept[] concepts = Concept.findByPreferredLabel(context,shoppingCart.getJournal(),scheme.getID());
                 if(concepts!=null&&concepts.length!=0){
-                    AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("internal", "journal", "customerId", Item.ANY);
+                    AuthorityMetadataValue[] metadataValues = concepts[0].getMetadata("internal", "journal", "customerID", Item.ANY);
                     if(metadataValues!=null&&metadataValues.length>0){
                         try{
                             success = AssociationAnywhere.tallyCredit(context, metadataValues[0].value, DOIIdentifierProvider.getDoiValue(item));


### PR DESCRIPTION
## Summary

This pull request makes the AssociationAnywhere interface functional for the first time.

When a data package is approved, the transaction is logged in AssociationAnywhere. The AssociationAnywhere API can only be called from specified IP
addresses. Therefore, this code is deployed on the dev server for
testing purposes.
## Viewing transactions in AssociationAnywhere
1. Login to the dev AssociationAnywhere using the account settings in
   LastPass.
2. In the upper right corner of the screen, lookup a journal by
   Customer Name.
3. Click on the journal's customer ID number in the search results.
4. Click on the Credit History tab -- this table will display the
   transactions that have been processed so far.
## Setup of customer IDs

For the AA integration can function correctly, a concept must be
present in Dryad that contains
- journal.customerID = an AA customerID
- journal.subscriptionPaid = true
- journal.paymentPlanType = DEFERRED or SUBSCRIPTION or PREPAID

Currently the Dryad dev system contains concepts for 
- customerID 1230729 = BMJ Open
- customerID 1230688 = Molecular Ecology
## To test command line

To tally a credit with the command line:
- On dev, run
  `sudo /opt/dryad/bin/dspace association-anywhere -t -i <customerID> -p <datapackage_DOI>`
- The datapackage_DOI can be any text; it will be added as an annotation to AA.
## To test user interface

To tally a credit via the Dryad user interface:
- Make a submission to Dryad associated with a journal that has the AA
  information setup.
- Approve this submission into the archive.
- The deposit will be noted in the AA Credit History table. The entry
  will include the Dryad DOI. The amount of the entry will be -1 for
  PREPAID journals, and 1 for journals with any other paymentPlanType.
