### PR TITLE
Clean journal code in one place instead of two.

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -322,9 +322,9 @@ public class DryadEmailSubmission extends HttpServlet {
                 continue;
             }
 
-            Matcher journalCodeMatcher = Pattern.compile("^\\s*>*\\s*(Journal Code):\\s*([a-zA-Z]+)").matcher(line);
+            Matcher journalCodeMatcher = Pattern.compile("^\\s*>*\\s*(Journal Code):\\s*(.+)").matcher(line);
             if (journalCodeMatcher.find()) {
-                journalCode = journalCodeMatcher.group(2);
+                journalCode = JournalUtils.cleanJournalCode(journalCodeMatcher.group(2));
                 dryadContentStarted = true;
             }
 
@@ -362,9 +362,7 @@ public class DryadEmailSubmission extends HttpServlet {
             if (journalCode == null) {
                 throw new SubmissionException("Journal Name " + journalName + " did not match a known Journal Name");
             }
-
             // find the associated concept and initialize the parser variable.
-            journalCode = JournalUtils.cleanJournalCode(journalCode);
             try {
                 concept = JournalUtils.getJournalConceptByShortID(context, journalCode);
             } catch (SQLException e) {


### PR DESCRIPTION
This fixes a bug I introduced in August, where journal codes that have numeric characters fail to process. After this PR gets deployed, I will need to reprocess emails from August for ECE3 and F1000R.
