### PR TITLE
Every email might have "dryad author url" in the dryad metadata block.

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
@@ -91,6 +91,9 @@ public class EmailParser {
         fieldToXMLTagMap.put("ISSN", ISSN);
         fieldToXMLTagMap.put("ms dryad doi", DRYAD_DOI);
         fieldToXMLTagMap.put("contact author orcid", CORRESPONDING_AUTHOR_ORCID);
+
+        // unnecessary fields
+        fieldToXMLTagMap.put("Dryad author url", UNNECESSARY);
     }
 
     /** The Pattern for dryad_ id. */

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForEcoApp.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForEcoApp.java
@@ -13,9 +13,6 @@ public class EmailParserForEcoApp extends EmailParser {
 		fieldToXMLTagMap.put("journal senior editor", "Journal_Editor");
 		fieldToXMLTagMap.put("journal admin email", "Journal_Editor_Email");
 		fieldToXMLTagMap.put("journal embargo period", "Journal_Embargo_Period");
-
-		// unnecessary fields
-		fieldToXMLTagMap.put("Dryad author url", UNNECESSARY);
 	}
 
 	@Override


### PR DESCRIPTION
Apparently ManuscriptCentral emails also contain this useless tag.
