### PR TITLE
Only override ms if its status is going to advance

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
@@ -170,6 +170,26 @@ public class Manuscript {
         return PUBLISHED_STATUSES.contains(status);
     }
 
+    public Boolean canOverrideStatusOf(Manuscript ms) {
+        // these are the most terminal statuses: nothing supersedes them.
+        if (ms.isPublished() || ms.isRejected()) {
+            return false;
+        }
+
+        if (this.isPublished() || this.isRejected()) {
+            return true;
+        }
+
+        if (ms.isSubmitted()) {
+            // this is the lowest status, of course we can override it.
+            return true;
+        }
+
+        // at this point, ms can only be Accepted and this can only be Submitted or Accepted.
+        // In either case, this cannot override ms.
+        return false;
+    }
+
     @JsonIgnore
     public Boolean isValid() {
         // Required fields are: manuscriptID, status, authors (though author identifiers are optional), and title. All other fields are optional.

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
@@ -226,11 +226,14 @@ public class ManuscriptDatabaseStorageImpl extends AbstractManuscriptStorage {
             TableRow existingRow = DatabaseManager.querySingleTable(context, MANUSCRIPT_TABLE, query, msid, organizationId, ACTIVE_TRUE);
 
             if (existingRow != null) {
-                String json_data = writer.writeValueAsString(manuscript);
-                existingRow.setColumn(COLUMN_JSON_DATA, json_data);
-                existingRow.setColumn(COLUMN_STATUS, manuscript.getStatus());
-                existingRow.setColumn(COLUMN_DATE_ADDED, new Date());
-                DatabaseManager.update(context, existingRow);
+                // only update if the new manuscript can override the status of the existing one.
+                if (manuscript.canOverrideStatusOf(manuscriptFromTableRow(existingRow))) {
+                    String json_data = writer.writeValueAsString(manuscript);
+                    existingRow.setColumn(COLUMN_JSON_DATA, json_data);
+                    existingRow.setColumn(COLUMN_STATUS, manuscript.getStatus());
+                    existingRow.setColumn(COLUMN_DATE_ADDED, new Date());
+                    DatabaseManager.update(context, existingRow);
+                }
             }
         }
     }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowEmailManager.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowEmailManager.java
@@ -182,6 +182,9 @@ public class WorkflowEmailManager {
 
             email.addRecipient(wi.getSubmitter().getEmail());
 
+            // email the eperson who rejected this as well
+            email.addRecipient(e.getEmail());
+
             email.addArgument(title);
             email.addArgument(dataFileTitles);
             email.addArgument(rejector);


### PR DESCRIPTION
If a manuscript is submitted through either email or REST and it already exists in our system, it should only be updated with the new data if the status is more advanced; i.e. submitted < accepted/rejected < published.
