### PR TITLE
URGENT: provenance can't be created for rejected files

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowManager.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowManager.java
@@ -482,6 +482,10 @@ public class WorkflowManager {
             workflowItemRole.delete();
         }
 
+        if (ePerson == null) {
+            ePerson = c.getCurrentUser();
+        }
+
         // rejection provenance
         Item myitem = wi.getItem();
 


### PR DESCRIPTION
As one of the changes we made this week, provenance is now generated for all rejected items, but sometimes the system passes in null. The default user should be the current user when this happens, instead of no provenance being created.
