### PR TITLE
case-insensitive match

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -332,13 +332,13 @@ public class DryadEmailSubmission extends HttpServlet {
                 continue;
             }
 
-            Matcher journalCodeMatcher = Pattern.compile("^\\s*>*\\s*(Journal Code):\\s*(.+)").matcher(line);
+            Matcher journalCodeMatcher = Pattern.compile("^\\s*>*\\s*(Journal Code):\\s*(.+)", Pattern.CASE_INSENSITIVE).matcher(line);
             if (journalCodeMatcher.find()) {
                 journalCode = JournalUtils.cleanJournalCode(journalCodeMatcher.group(2));
                 dryadContentStarted = true;
             }
 
-            Matcher journalNameMatcher = Pattern.compile("^\\s*>*\\s*(JOURNAL|Journal Name):\\s*(.+)").matcher(line);
+            Matcher journalNameMatcher = Pattern.compile("^\\s*>*\\s*(JOURNAL|Journal Name):\\s*(.+)", Pattern.CASE_INSENSITIVE).matcher(line);
             if (journalNameMatcher.find()) {
                 journalName = journalNameMatcher.group(2);
                 journalName = StringUtils.stripToEmpty(journalName);


### PR DESCRIPTION
Journal Code/Journal Name in emails should match no matter what the case.
