### PR TITLE
Flip booleans for Accepted articles

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/js/utils.js
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/js/utils.js
@@ -107,7 +107,7 @@ function initFirstSubmissionForm() {
                 jQuery("#aspect_submission_StepTransformer_item_manu-number-status-accepted").hide();
                 jQuery("#aspect_submission_StepTransformer_item_manu_accepted-cb").hide();
             }
-            else if (integrated==true) {
+            else if (integrated!=true) {
                 jQuery("#aspect_submission_StepTransformer_item_manu_accepted-cb").show();
                 jQuery("#aspect_submission_StepTransformer_item_manu-number-status-accepted").hide();
             }
@@ -271,7 +271,7 @@ function initFirstSubmissionForm() {
                     jQuery("#aspect_submission_StepTransformer_item_manu_accepted-cb").hide();
                 }
                 //else if (journal.indexOf('*') != -1) {
-                else if(integrated == true){
+                else if(integrated != true){
                     jQuery("#aspect_submission_StepTransformer_item_manu_accepted-cb").show();
                     jQuery("#aspect_submission_StepTransformer_item_manu-number-status-accepted").hide();
                     //update the order form after enter journal name


### PR DESCRIPTION
Fixes https://trello.com/c/Jca1KJvH/416-small-item-fix-the-manuscript-number-box-on-accepted-articles-on-first-submit-page

If you type in an integrated journal for an Accepted article, you should see the manuscript number box, and if the journal is not integrated, you should see the checkbox.
