### PR TITLE
Add "back to top" links to the Terms of Service

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/policies.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/policies.xhtml
@@ -31,7 +31,7 @@
 		<p>Please address questions or comments regarding these Terms of Service to <a href="mailto:help@datadryad.org">help@datadryad.org</a>.</p>
 	
 	<p>
-			<h2>Contents</h2>
+			<h2 id="top">Contents</h2>
 		<ul>
 			<li><a href="#definitions">1. Definitions</a></li>
 			<li><a href="#publication">2. Publication Policies</a>
@@ -133,6 +133,8 @@
 	</ul>
 </p>
 
+<p><a href="#top">(back to top)</a></p>
+
 <h2 id="publication">2. Publication Policies</h2>
 <br />
 <h3 id="content">2.1 Content Criteria</h3>
@@ -180,6 +182,8 @@
 <h3 id="large-files">2.4 Large files</h3>
 
 <p>During the process of submission and review, and with the knowledge and consent of the Submitter, unusually large files that are within the scope of another repository may be transferred for archiving by Dryad to that secondary repository without retention of a copy in the Repository.</p>
+
+<p><a href="#top">(back to top)</a></p>
 
 
 <h2 id="dryad-obligations">3. Dryad Obligations, Representations and Warranties to Purchasers and Submitters</h2>
@@ -332,7 +336,7 @@
 	</ul>
 </p>
 
-
+<p><a href="#top">(back to top)</a></p>
 
 <h2 id="purchaser-obligations">4. Purchaser Obligations, Representations and Warranties to Dryad</h2>
 
@@ -355,7 +359,7 @@
 	</ul>
 </p>
 			
-
+<p><a href="#top">(back to top)</a></p>
 
 <h2 id="submitter-obligations">5. Submitter Obligations, Representations and Warranties to Dryad</h2>
 <br />
@@ -379,6 +383,8 @@
 		<li>If Submitter requests a Waiver, the Submitter represents and warrants that s/he is employed by an institution in an Eligible Country or is an independent researcher in residence in an Eligible Country.</li>
 	</ul>
 </p>
+
+<p><a href="#top">(back to top)</a></p>
 
 		
 <h2 id="payment">6. Payment</h2>
@@ -410,6 +416,7 @@
 
 <p>Data Publishing Charges and excess storage fees are not refundable. Please see Purchase Agreements for information regarding refunds for Payment Plans.</p>
 
+<p><a href="#top">(back to top)</a></p>
 
 		
 <h2 id="usage">7. Usage</h2>
@@ -449,6 +456,8 @@
 		<li>Users, Purchasers and Submitters may not use trademarks associated with Dryad (including, without limitation, the Dryad logo) to imply an association or endorsement by Dryad without prior written consent.</li>
 	</ul>
 </p>
+
+<p><a href="#top">(back to top)</a></p>
 
 		
 <h2 id="privacy">8. Privacy</h2>
@@ -517,6 +526,7 @@ particular function on our resources. These logs may be made available, after an
 
 <p>If you are concerned about the accuracy of personally identifiable information maintained by Dryad or wish to review, access, amend or correct this information, or would like your personally identifiable information removed from Dryad's records or otherwise deactivated, please contact us at <a href="mailto:help@datadryad.org">help@datadryad.org</a>. We reserve the right to review requests on a case by case basis.</p>
 
+<p><a href="#top">(back to top)</a></p>
 
 	
 <h2 id="general">9. General Provisions</h2>
@@ -562,6 +572,8 @@ particular function on our resources. These logs may be made available, after an
 <h3 id="misc">9.8 General Miscellaneous Provisions</h3>
 	
 <p>Each party shall comply with all applicable laws. Dryad reserves the right to take any actions necessary in order to comply with applicable laws or court orders in any jurisdiction. These Terms of Service, together with the Purchase Agreement in the case of Purchasers, makes up the entire agreement between Dryad and Purchaser, Submitter or User, and supersedes any prior written or oral agreements related to the subject matter hereof. If any term is unenforceable, it will not affect the other Terms of Service which shall remain in full force and effect. A waiver of any provision or breach shall not be deemed to be a waiver of any other provision or breach. These Terms of Service do not create any third party rights. Submitter/Purchaser/User (as the case may be) may not assign or otherwise transfer its rights hereunder without the prior written consent of Dryad, and any transfer to the contrary shall be null and void. Dryad reserves the right to transfer all of its rights and obligations under any Purchase Agreement and these Terms of Service, including ownership and/or operation of the Dryad Repository to another nonprofit entity in the event of a merger, joint venture, dissolution, or other corporate restructuring.</p>
+
+<p><a href="#top">(back to top)</a></p>
 
 </p>
 </div>    


### PR DESCRIPTION
I was unable to preview this on my VM due to "an error while executing `VBoxManage`, a CLI used by Vagrant for controlling VirtualBox." It's a minor change, but please confirm that it's working as expected.
