### PR TITLE
On the My Tasks page, don't display a workflow section if there are no items in it

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/MyTasksTransformer.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/MyTasksTransformer.java
@@ -244,6 +244,10 @@ public class MyTasksTransformer extends DiscoverySubmissions{
 
 
         SolrDocumentList solrResults = queryResults.getResults();
+	if(solrResults.size() <= 0) {
+	    log.debug("no solr results for workflow step " + count.getName());
+	    return;
+	}
 
         if(isStepFilterPage()){
             // Pagination variables.
@@ -274,7 +278,7 @@ public class MyTasksTransformer extends DiscoverySubmissions{
         }
 
 
-        Table resultTable = workflowResultsDiv.addTable("results", solrResults.size(), 2);
+	Table resultTable = workflowResultsDiv.addTable("results", solrResults.size(), 2);
 
         boolean showMoreUrl = false;
         if(solrResults.size() < solrResults.getNumFound()){


### PR DESCRIPTION
This change allows the My Tasks page to be viewed when there are no items listed.

To test:
- check out older commit (before the recent solr change), such as `75cbd16` and deploy
- rebuild the solr index, `/opt/dryad/bin/dspace update-discovery-index -b`
- check out the current dryad-master branch and deploy
- view the My Tasks page -- there should be an error, and the page won't be displayed
- merge in this PR and deploy
- view the My Tasks page again -- the page should display now
