### PR TITLE
Clean up authorizations in Authority system

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/MetadataField.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataField.java
@@ -267,11 +267,9 @@ public class MetadataField
      * @param qualifier qualifier (may be ANY or null)
      * @return recalled metadata field
      * @throws SQLException
-     * @throws AuthorizeException
      */
     public static MetadataField findByElement(Context context, int schemaID,
-            String element, String qualifier) throws SQLException,
-            AuthorizeException
+            String element, String qualifier) throws SQLException
     {
         // Grab rows from DB
         TableRowIterator tri;
@@ -410,7 +408,7 @@ public class MetadataField
         if (!AuthorizeManager.isAdmin(context))
         {
             throw new AuthorizeException(
-                    "Only administrators may modiffy the Dublin Core registry");
+                    "Only administrators may modify the Dublin Core registry");
         }
 
         // Check to see if the schema ID was altered. If is was then we will
@@ -453,11 +451,9 @@ public class MetadataField
      * @param qualifier qualifier name
      * @return true if the field exists
      * @throws SQLException
-     * @throws AuthorizeException
      */
     private static boolean hasElement(Context context, int schemaID,
-            String element, String qualifier) throws SQLException,
-            AuthorizeException
+            String element, String qualifier) throws SQLException
     {
         return MetadataField.findByElement(context, schemaID, element,
                 qualifier) != null;
@@ -496,13 +492,11 @@ public class MetadataField
      * @param element
      * @param qualifier
      * @return true if unique
-     * @throws AuthorizeException
      * @throws SQLException
      * @throws IOException
      */
     private boolean unique(Context context, int schemaID, String element,
-            String qualifier) throws IOException, SQLException,
-            AuthorizeException
+            String qualifier) throws IOException, SQLException
     {
         int count = 0;
         Connection con = null;

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
@@ -256,9 +256,8 @@ public class MetadataValue
      * @param context
      *            DSpace context object
      * @throws SQLException
-     * @throws AuthorizeException
      */
-    public void create(Context context) throws SQLException, AuthorizeException
+    public void create(Context context) throws SQLException
     {
         // Create a table row and update it with the values
         row = DatabaseManager.row("MetadataValue");
@@ -286,10 +285,9 @@ public class MetadataValue
      * @return recalled metadata value
      * @throws IOException
      * @throws SQLException
-     * @throws AuthorizeException
      */
     public static MetadataValue find(Context context, int valueId)
-            throws IOException, SQLException, AuthorizeException
+            throws IOException, SQLException
     {
         // Grab rows from DB
         TableRowIterator tri = DatabaseManager.queryTable(context, "MetadataValue",
@@ -331,10 +329,9 @@ public class MetadataValue
      * @return a collection of metadata values
      * @throws IOException
      * @throws SQLException
-     * @throws AuthorizeException
      */
     public static List<MetadataValue> findByField(Context context, int fieldId)
-            throws IOException, SQLException, AuthorizeException
+            throws IOException, SQLException
     {
         // Grab rows from DB
         TableRowIterator tri = DatabaseManager.queryTable(context, "MetadataValue",
@@ -368,9 +365,8 @@ public class MetadataValue
      *
      * @param context dspace context
      * @throws SQLException
-     * @throws AuthorizeException
      */
-    public void update(Context context) throws SQLException, AuthorizeException
+    public void update(Context context) throws SQLException
     {
         row.setColumn("item_id", itemId);
         row.setColumn("metadata_field_id", fieldId);
@@ -390,9 +386,8 @@ public class MetadataValue
      *
      * @param context dspace context
      * @throws SQLException
-     * @throws AuthorizeException
      */
-    public void delete(Context context) throws SQLException, AuthorizeException
+    public void delete(Context context) throws SQLException
     {
         log.info(LogManager.getHeader(context, "delete_metadata_value",
                 " metadata_value_id=" + getValueId()));

--- a/dspace-api/src/main/java/org/dspace/content/authority/AuthorityMetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/AuthorityMetadataValue.java
@@ -250,7 +250,7 @@ public class AuthorityMetadataValue {
      * @throws java.sql.SQLException
      * @throws org.dspace.authorize.AuthorizeException
      */
-    public void delete(Context context) throws SQLException, AuthorizeException
+    public void delete(Context context) throws SQLException
     {
         log.info(LogManager.getHeader(context, "delete_metadata_value",
                 " id=" + getValueId()));
@@ -265,7 +265,7 @@ public class AuthorityMetadataValue {
      * @throws java.sql.SQLException
      * @throws org.dspace.authorize.AuthorizeException
      */
-    public void create(Context context) throws SQLException, AuthorizeException
+    public void create(Context context) throws SQLException
     {
         // Create a table row and update it with the values
         row = DatabaseManager.row(tableName);
@@ -304,7 +304,7 @@ public class AuthorityMetadataValue {
      * @throws java.sql.SQLException
      * @throws org.dspace.authorize.AuthorizeException
      */
-    public void update(Context context) throws SQLException, AuthorizeException
+    public void update(Context context) throws SQLException
     {
         row.setColumn("parent_id", parentId);
         row.setColumn("field_id", fieldId);

--- a/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
@@ -9,7 +9,6 @@ package org.dspace.content.authority;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
@@ -434,7 +433,7 @@ public abstract class AuthorityObject extends DSpaceObject {
 
     private transient MetadataField[] allMetadataFields = null;
 
-    protected MetadataField getMetadataField(AuthorityMetadataValue dcv) throws SQLException, AuthorizeException
+    protected MetadataField getMetadataField(AuthorityMetadataValue dcv) throws SQLException
     {
         if (allMetadataFields == null)
         {
@@ -478,7 +477,7 @@ public abstract class AuthorityObject extends DSpaceObject {
     /**
      * Update the scheme - writing out scheme object and Concept list if necessary
      */
-    public void update() throws SQLException, AuthorizeException
+    public void update() throws SQLException
     {
         if(metadataModified)
         {

--- a/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
@@ -710,20 +710,4 @@ public abstract class AuthorityObject extends DSpaceObject {
     public static String createIdentifier(){
         return UUID.randomUUID().toString().replace("-", "");
     }
-
-    public static String hash(String input) {
-
-        try {
-            MessageDigest m = MessageDigest.getInstance("MD5");
-            byte[] data = input.getBytes();
-            m.update(data, 0, data.length);
-            BigInteger i = new BigInteger(1, m.digest());
-            return String.format("%1$032X", i);
-        } catch (NoSuchAlgorithmException e) {
-            log.error(e.getMessage(),e);
-            throw new RuntimeException(e.getMessage(),e);
-        }
-
-    }
-
 }

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept.java
@@ -165,27 +165,16 @@ public class Concept extends AuthorityObject
      * @param context
      *            DSpace context object
      */
-    public static Concept create(Context context) throws SQLException,
-            AuthorizeException
+    public static Concept create(Context context) throws SQLException, AuthorizeException
     {
-        // authorized?
-        if (!AuthorizeManager.isAdmin(context))
-        {
-            throw new AuthorizeException(
-                    "You must be an admin to create an Concept");
-        }
-
         return create(context, AuthorityObject.createIdentifier());
     }
 
-    public static Concept create(Context context, String identifier) throws SQLException,
-            AuthorizeException
+    public static Concept create(Context context, String identifier) throws SQLException, AuthorizeException
     {
         // authorized?
-        if (!AuthorizeManager.isAdmin(context))
-        {
-            throw new AuthorizeException(
-                    "You must be an admin to create an Concept");
+        if (!AuthorizeManager.isAdmin(context)) {
+            throw new AuthorizeException("You must be an admin to create a Concept");
         }
 
         // Create a table row
@@ -243,12 +232,13 @@ public class Concept extends AuthorityObject
      * @param t
      *            term
      */
-    public void removePreferredTerm(Term t)throws SQLException,
-            AuthorizeException, IOException
+    public void removePreferredTerm(Term t)throws SQLException, AuthorizeException, IOException
     {
 
-        // Check authorisation
-        AuthorizeManager.isAdmin(myContext);
+        // authorized?
+        if (!AuthorizeManager.isAdmin(myContext)) {
+            throw new AuthorizeException("You must be an admin to remove a Concept's Preferred Term");
+        }
         log.info(LogManager.getHeader(myContext, "remove_preferredTerm",
                 "concept_id=" + getID() + ",term_id=" + t.getID()));
 
@@ -281,11 +271,12 @@ public class Concept extends AuthorityObject
      * @param t
      *            term
      */
-    public void removeAltTerm(Term t)throws SQLException,
-            AuthorizeException, IOException
+    public void removeAltTerm(Term t)throws SQLException, AuthorizeException, IOException
     {
-        // Check authorisation
-        AuthorizeManager.isAdmin(myContext);
+        // authorized?
+        if (!AuthorizeManager.isAdmin(myContext)) {
+            throw new AuthorizeException("You must be an admin to remove a Concept's Alternate Term");
+        }
         log.info(LogManager.getHeader(myContext, "remove_altTerm",
                 "concept_id=" + getID() + ",term_id=" + t.getID()));
 
@@ -316,11 +307,12 @@ public class Concept extends AuthorityObject
      *
      * @param c
      */
-    public void removeParentConcept(Concept c)throws SQLException,
-            AuthorizeException, IOException
+    public void removeParentConcept(Concept c)throws SQLException, AuthorizeException, IOException
     {
-        // Check authorisation
-        AuthorizeManager.isAdmin(myContext);
+        // authorized?
+        if (!AuthorizeManager.isAdmin(myContext)) {
+            throw new AuthorizeException("You must be an admin to remove a Concept's Parent Concept");
+        }
         log.info(LogManager.getHeader(myContext, "remove_parentConcept",
                 "concept_id=" + getID() + ",parent_concept_id=" + c.getID()));
 
@@ -343,11 +335,12 @@ public class Concept extends AuthorityObject
      *
      * @param c
      */
-    public void removeChildConcept(Concept c)throws SQLException,
-            AuthorizeException, IOException
+    public void removeChildConcept(Concept c)throws SQLException, AuthorizeException, IOException
     {
-        // Check authorisation
-        AuthorizeManager.isAdmin(myContext);
+        // authorized?
+        if (!AuthorizeManager.isAdmin(myContext)) {
+            throw new AuthorizeException("You must be an admin to remove a Concept's Child Concept");
+        }
         log.info(LogManager.getHeader(myContext, "remove_parentConcept",
                 "concept_id=" + getID() + ",child_concept_id=" + c.getID()));
 
@@ -443,7 +436,7 @@ public class Concept extends AuthorityObject
      * @return the matching Concepts, or null if not found
      */
     public static ArrayList<Concept> findByConceptMetadata(Context context, String searchString, String metadataSchema, String metadataElement)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         ArrayList<Concept> concepts = new ArrayList<Concept>();
         try {
@@ -457,9 +450,9 @@ public class Concept extends AuthorityObject
             if (row == null) {
                 return null;
             } else {
-            while(row.hasNext()) {
-                concepts.add(new Concept(context,row.next()));
-            }
+                while(row.hasNext()) {
+                    concepts.add(new Concept(context,row.next()));
+                }
             }
         } catch (NullPointerException e) {
             log.error("Unable to find concept by metadata: search=" + searchString + ", schema=" + metadataSchema + ", element=" + metadataElement, e);
@@ -1228,12 +1221,12 @@ public class Concept extends AuthorityObject
         return conceptArray;
     }
 
-    public void addParentConcept(Concept incoming,int roleId) throws SQLException,
-            AuthorizeException
+    public void addParentConcept(Concept incoming,int roleId) throws SQLException, AuthorizeException
     {
-
-        // Check authorisation
-        AuthorizeManager.isAdmin(myContext);
+        // authorized?
+        if (!AuthorizeManager.isAdmin(myContext)) {
+            throw new AuthorizeException("You must be an admin to modify a Concept's Parent Concept");
+        }
 
         log.info(LogManager.getHeader(myContext, "add_parentConcept",
                 "concept_id=" + getID() + ",parent_concept_id=" + incoming.getID()));
@@ -1268,11 +1261,12 @@ public class Concept extends AuthorityObject
         }
     }
 
-    public void addChildConcept(Concept outgoing, int roleId) throws SQLException,
-            AuthorizeException
+    public void addChildConcept(Concept outgoing, int roleId) throws SQLException, AuthorizeException
     {
-        // Check authorisation
-        AuthorizeManager.isAdmin(myContext);
+        // authorized?
+        if (!AuthorizeManager.isAdmin(myContext)) {
+            throw new AuthorizeException("You must be an admin to add a Concept's Child Concept");
+        }
 
         log.info(LogManager.getHeader(myContext, "add_childConcept",
                 "concept_id=" + getID() + ",child_concept_id=" + outgoing.getID()));
@@ -1342,11 +1336,12 @@ public class Concept extends AuthorityObject
         return label;
     }
 
-    public void addTerm(Term t,int role_id) throws SQLException,
-            AuthorizeException
+    public void addTerm(Term t,int role_id) throws SQLException, AuthorizeException
     {
-        // Check authorisation
-        AuthorizeManager.isAdmin(myContext);
+        // authorized?
+        if (!AuthorizeManager.isAdmin(myContext)) {
+            throw new AuthorizeException("You must be an admin to add a Term to a Concept");
+        }
 
         log.info(LogManager.getHeader(myContext, "add_term",
                 "concept_id=" + getID() + ",term_id=" + t.getID()));

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept2Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept2Concept.java
@@ -238,11 +238,9 @@ public class Concept2Concept
 
      * @return recalled metadata relation
      * @throws java.sql.SQLException
-     * @throws org.dspace.authorize.AuthorizeException
      */
     public static Concept2Concept findByElement(Context context, int role_id,
-                                                int incoming_id, int outgoing_id) throws SQLException,
-            AuthorizeException
+                                                int incoming_id, int outgoing_id) throws SQLException
     {
         // Grab rows from DB
         TableRowIterator tri;
@@ -414,11 +412,9 @@ public class Concept2Concept
 
      * @return true if the relation exists
      * @throws java.sql.SQLException
-     * @throws org.dspace.authorize.AuthorizeException
      */
     private static boolean hasElement(Context context, int role_id,
-                                      int incoming_id, int outgoing_id) throws SQLException,
-            AuthorizeException
+                                      int incoming_id, int outgoing_id) throws SQLException
     {
         return Concept2Concept.findByElement(context, role_id, incoming_id,
                 outgoing_id) != null;
@@ -456,13 +452,11 @@ public class Concept2Concept
      * @param role_id
 
      * @return true if unique
-     * @throws org.dspace.authorize.AuthorizeException
      * @throws java.sql.SQLException
      * @throws java.io.IOException
      */
     private boolean unique(Context context, int role_id, int incoming_id,
-                           int outgoing_id) throws IOException, SQLException,
-            AuthorizeException
+                           int outgoing_id) throws IOException, SQLException
     {
         int count = 0;
         Connection con = null;
@@ -787,7 +781,7 @@ public class Concept2Concept
 
 
     public static Concept2Concept findByConceptAndConcept(Context context,Integer incoming_id,Integer outgoing_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (incoming_id == null||outgoing_id == null||incoming_id<0||outgoing_id<0)
         {
@@ -835,7 +829,7 @@ public class Concept2Concept
 
 
     public static Concept2Concept[] findByParentAndRole(Context context,Integer incoming_id,Integer role_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (incoming_id == null||role_id == null||incoming_id<0||role_id<0)
         {
@@ -882,7 +876,7 @@ public class Concept2Concept
 
     }
     public static Concept2Concept[] findByChildAndRole(Context context,Integer outgoing_id,Integer role_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (outgoing_id == null||role_id == null||outgoing_id<0||role_id<0)
         {
@@ -929,7 +923,7 @@ public class Concept2Concept
     }
 
     public static Concept2Concept[] findByChild(Context context,Integer outgoing_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (outgoing_id == null||outgoing_id<0)
         {
@@ -976,7 +970,7 @@ public class Concept2Concept
     }
 
     public static Concept2Concept[] findByParent(Context context,Integer incoming_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (incoming_id == null||incoming_id<0)
         {

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept2ConceptRole.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept2ConceptRole.java
@@ -217,8 +217,7 @@ public class Concept2ConceptRole
      * @throws org.dspace.authorize.AuthorizeException
      */
     public static Concept2ConceptRole findByRole(Context context,
-                                                 String role, String label) throws SQLException,
-            AuthorizeException
+                                                 String role, String label) throws SQLException
     {
         // Grab rows from DB
         TableRowIterator tri;
@@ -396,11 +395,9 @@ public class Concept2ConceptRole
 
      * @return true if the relation exists
      * @throws java.sql.SQLException
-     * @throws org.dspace.authorize.AuthorizeException
      */
     private static boolean hasElement(Context context,
-                                      String role, String label) throws SQLException,
-            AuthorizeException
+                                      String role, String label) throws SQLException
     {
         return Concept2ConceptRole.findByRole(context, role,
                 label) != null;
@@ -437,13 +434,11 @@ public class Concept2ConceptRole
      * @param context dspace context
 
      * @return true if unique
-     * @throws org.dspace.authorize.AuthorizeException
      * @throws java.sql.SQLException
      * @throws java.io.IOException
      */
     private boolean unique(Context context, String role,
-                           String label) throws IOException, SQLException,
-            AuthorizeException
+                           String label) throws IOException, SQLException
     {
         int count = 0;
         Connection con = null;

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept2Term.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept2Term.java
@@ -241,8 +241,7 @@ public class Concept2Term
      * @throws org.dspace.authorize.AuthorizeException
      */
     public static Concept2Term findByElement(Context context, int role_id,
-                                             int concept_id, int term_id) throws SQLException,
-            AuthorizeException
+                                             int concept_id, int term_id) throws SQLException
     {
         // Grab rows from DB
         TableRowIterator tri;
@@ -417,8 +416,7 @@ public class Concept2Term
      * @throws org.dspace.authorize.AuthorizeException
      */
     private static boolean hasElement(Context context, int role_id,
-                                      int concept_id, int term_id) throws SQLException,
-            AuthorizeException
+                                      int concept_id, int term_id) throws SQLException
     {
         return Concept2Term.findByElement(context, role_id, concept_id,
                 term_id) != null;
@@ -461,8 +459,7 @@ public class Concept2Term
      * @throws java.io.IOException
      */
     private boolean unique(Context context, int role_id, int concept_id,
-                           int term_id) throws IOException, SQLException,
-            AuthorizeException
+                           int term_id) throws IOException, SQLException
     {
         int count = 0;
         Connection con = null;
@@ -787,7 +784,7 @@ public class Concept2Term
 
 
     public static Concept2Term findByConceptAndTerm(Context context,Integer concept_id,Integer term_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (concept_id == null||term_id == null||concept_id<0||term_id<0)
         {
@@ -835,7 +832,7 @@ public class Concept2Term
 
 
     public Concept2Term[] findByConceptAndRole(Context context,Integer concept_id,Integer role_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (concept_id == null||role_id == null||concept_id<0||role_id<0)
         {
@@ -882,7 +879,7 @@ public class Concept2Term
 
     }
     public Concept2Term[] findByTermAndRole(Context context,Integer term_id,Integer role_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (term_id == null||role_id == null||term_id<0||role_id<0)
         {
@@ -929,7 +926,7 @@ public class Concept2Term
     }
 
     public Concept2Term[] findByTerm(Context context,Integer term_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (term_id == null||term_id<0)
         {
@@ -976,7 +973,7 @@ public class Concept2Term
     }
 
     public Concept2Term[] findByConcept(Context context,Integer term_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (term_id == null||term_id<0)
         {

--- a/dspace-api/src/main/java/org/dspace/content/authority/Concept2TermRole.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Concept2TermRole.java
@@ -213,8 +213,7 @@ public class Concept2TermRole
      * @throws org.dspace.authorize.AuthorizeException
      */
     public static Concept2TermRole findByRole(Context context,
-                                              String role, String label) throws SQLException,
-            AuthorizeException
+                                              String role, String label) throws SQLException
     {
         // Grab rows from DB
         TableRowIterator tri;
@@ -395,8 +394,7 @@ public class Concept2TermRole
      * @throws org.dspace.authorize.AuthorizeException
      */
     private static boolean hasElement(Context context,
-                                      String role, String label) throws SQLException,
-            AuthorizeException
+                                      String role, String label) throws SQLException
     {
         return Concept2TermRole.findByRole(context, role,
                 label) != null;
@@ -438,8 +436,7 @@ public class Concept2TermRole
      * @throws java.io.IOException
      */
     private boolean unique(Context context, String role,
-                           String label) throws IOException, SQLException,
-            AuthorizeException
+                           String label) throws IOException, SQLException
     {
         int count = 0;
         Connection con = null;

--- a/dspace-api/src/main/java/org/dspace/content/authority/Scheme.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Scheme.java
@@ -666,8 +666,7 @@ public class Scheme extends AuthorityObject
      * @param c
      *            collection to add
      */
-    public void addConcept(Concept c) throws SQLException,
-            AuthorizeException
+    public void addConcept(Concept c) throws SQLException
     {
         // Check authorisation
         AuthorizeManager.isAdmin(myContext);
@@ -755,7 +754,7 @@ public class Scheme extends AuthorityObject
     }
 
 
-    public Concept createConcept() throws SQLException, AuthorizeException, NoSuchAlgorithmException {
+    public Concept createConcept() throws SQLException, AuthorizeException {
         Concept concept = Concept.create(this.myContext);
         Date date = new Date();
         concept.setLastModified(date);
@@ -767,7 +766,7 @@ public class Scheme extends AuthorityObject
         return concept;
     }
 
-    public Concept createConcept(String identifier) throws SQLException, AuthorizeException, NoSuchAlgorithmException {
+    public Concept createConcept(String identifier) throws SQLException, AuthorizeException {
 
         Concept concept = Concept.create(this.myContext, identifier);
 

--- a/dspace-api/src/main/java/org/dspace/content/authority/Scheme2Concept.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Scheme2Concept.java
@@ -209,11 +209,9 @@ public class Scheme2Concept
 
      * @return recalled metadata relation
      * @throws java.sql.SQLException
-     * @throws org.dspace.authorize.AuthorizeException
      */
     public static Scheme2Concept findByElement(Context context, int role_id,
-                                               int scheme_id, int concept_id) throws SQLException,
-            AuthorizeException
+                                               int scheme_id, int concept_id) throws SQLException
     {
         // Grab rows from DB
         TableRowIterator tri;
@@ -366,11 +364,9 @@ public class Scheme2Concept
 
      * @return true if the relation exists
      * @throws java.sql.SQLException
-     * @throws org.dspace.authorize.AuthorizeException
      */
     private static boolean hasElement(Context context, int role_id,
-                                      int scheme_id, int concept_id) throws SQLException,
-            AuthorizeException
+                                      int scheme_id, int concept_id) throws SQLException
     {
         return Scheme2Concept.findByElement(context, role_id, scheme_id,
                 concept_id) != null;
@@ -408,13 +404,11 @@ public class Scheme2Concept
      * @param role_id
 
      * @return true if unique
-     * @throws org.dspace.authorize.AuthorizeException
      * @throws java.sql.SQLException
      * @throws java.io.IOException
      */
     private boolean unique(Context context, int role_id, int scheme_id,
-                           int concept_id) throws IOException, SQLException,
-            AuthorizeException
+                           int concept_id) throws IOException, SQLException
     {
         int count = 0;
         Connection con = null;
@@ -734,7 +728,7 @@ public class Scheme2Concept
 
 
     public static Scheme2Concept findBySchemeAndConcept(Context context,Integer scheme_id,Integer concept_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (scheme_id == null||concept_id == null||scheme_id<0||concept_id<0)
         {
@@ -782,7 +776,7 @@ public class Scheme2Concept
 
 
     public Scheme2Concept[] findBySchemeAndRole(Context context,Integer scheme_id,Integer role_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (scheme_id == null||role_id == null||scheme_id<0||role_id<0)
         {
@@ -829,7 +823,7 @@ public class Scheme2Concept
 
     }
     public Scheme2Concept[] findByConceptAndRole(Context context,Integer concept_id,Integer role_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (concept_id == null||role_id == null||concept_id<0||role_id<0)
         {
@@ -876,7 +870,7 @@ public class Scheme2Concept
     }
 
     public Scheme2Concept[] findByConcept(Context context,Integer concept_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (concept_id == null||concept_id<0)
         {
@@ -923,7 +917,7 @@ public class Scheme2Concept
     }
 
     public Scheme2Concept[] findByScheme(Context context,Integer concept_id)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (concept_id == null||concept_id<0)
         {

--- a/dspace-api/src/main/java/org/dspace/content/authority/Term.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Term.java
@@ -186,7 +186,7 @@ public class Term extends AuthorityObject {
      */
 
     public static Term findByLiteralForm(Context context , String literalForm)
-            throws SQLException, AuthorizeException
+            throws SQLException
     {
         if (literalForm == null)
         {

--- a/dspace-api/src/test/java/org/dspace/content/MetadataFieldTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataFieldTest.java
@@ -67,11 +67,6 @@ public class MetadataFieldTest extends AbstractUnitTest
             this.mf.setScopeNote(scopeNote);
             context.restoreAuthSystemState();
         }
-        catch (AuthorizeException ex)
-        {
-            log.error("Authorize Error in init", ex);
-            fail("Authorize Error in init");
-        }
         catch (SQLException ex)
         {
             log.error("SQL Error in init", ex);


### PR DESCRIPTION
This has absolutely no visible effect: all I did was to make sure that AuthorizeExceptions that are never thrown aren’t stated as being thrown, and that when isAdmin is checked, an AuthorizeException is thrown if it’s false.
