### PR TITLE
Doi in pubblackout

### DIFF
--- a/dspace/config/emails/feedback
+++ b/dspace/config/emails/feedback
@@ -7,10 +7,11 @@
 #             {4} User-Agent HTTP Header
 #             {5} Session Id
 #             {6} The user's comments
+#             {7} email subject
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: Feedback Form Information
+Subject: {7}
 
 Comments:
 

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendFeedbackAction.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendFeedbackAction.java
@@ -78,6 +78,10 @@ public class SendFeedbackAction extends AbstractAction
         String agent = request.getHeader("User-Agent");
         String session = request.getSession().getId();
         String comments = request.getParameter("comments");
+        String subject = request.getParameter("subject");
+        if (subject == null) {
+            subject = "Feedback Form Information";
+        }
 
         // Obtain information from request
         // The page where the user came from
@@ -168,6 +172,7 @@ public class SendFeedbackAction extends AbstractAction
         email.addArgument(agent);      // User agent
         email.addArgument(session);    // Session ID
         email.addArgument(comments);   // The feedback itself
+        email.addArgument(subject);    // Subject
 
         // Replying to feedback will reply to email on form
         email.setReplyTo(address);

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/publicationBlackout.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/publicationBlackout.xhtml
@@ -12,7 +12,7 @@
         <script type="text/javascript" src="/themes/Mirage/lib/jquery-1.3.1.min.js"> </script> 
         <script type="text/javascript" src="/themes/Mirage/lib/utils.js"> </script> 
         <script type="text/javascript" src="/themes/Mirage/lib/jquery.tooltip.js"> </script>
-        <script type="text/javascript">var referrer=document.referrer;var doi=referrer.replace(/^.*http:\/\/ezid.cdlib.org\/id\//,"")</script>
+        <script type="text/javascript">var referrer=document.referrer;var ezidpattern=/^.*http:\/\/ezid.cdlib.org\/id\//; var doi=referrer.replace(ezidpattern,"")</script>
         <script type="text/javascript">var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));</script>
         <script type="text/javascript">try {var pageTracker = _gat._getTracker("UA-16949847-1");pageTracker._trackPageview();} catch(err) {}</script> 
         
@@ -26,7 +26,7 @@
             <h1 class="ds-div-head">Content restricted ahead of article publication<a id="contentRestricted">&#160;</a></h1>
             <div class="ds-static-div primary">
                 <form xmlns="http://di.tamu.edu/DRI/1.0/" id="aspect_artifactbrowser_FeedbackForm_div_feedback-form" class="ds-interactive-div primary" action="/feedback" method="post" onsubmit="javascript:tSubmit(this);">
-                    <p class="ds-paragraph">The DOI <span id="dryad-doi" class="ds-paragraph"></span> has been registered for this data package.
+                    <p class="ds-paragraph">The Dryad DOI <span id="dryad-doi" class="ds-paragraph">for this data package</span> has been registered.
                         As far as we know, the article associated with this data package has not yet been published,
                         and the journal requires us to suppress the data until then. Once the article is available,
                         we will update this DOI to automatically resolve you to the data package.</p>
@@ -79,5 +79,7 @@
 
             <div>Last revised: 2013-03-04</div>
           </div>
+        <script type="text/javascript">document.getElementById("aspect_artifactbrowser_FeedbackForm_field_page").setAttribute("value", document.referrer);</script>
+        <script type="text/javascript">if(referrer.search(ezidpattern)!=-1){document.getElementById("dryad-doi").innerHTML = doi;}</script>
     </body>
 </html>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/publicationBlackout.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/publicationBlackout.xhtml
@@ -11,8 +11,9 @@
         <script src="/themes/Mirage/lib/editor.js" language="javascript" type="text/javascript"> </script> 
         <script type="text/javascript" src="/themes/Mirage/lib/jquery-1.3.1.min.js"> </script> 
         <script type="text/javascript" src="/themes/Mirage/lib/utils.js"> </script> 
-        <script type="text/javascript" src="/themes/Mirage/lib/jquery.tooltip.js"> </script> 
-        <script type="text/javascript">var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));</script> 
+        <script type="text/javascript" src="/themes/Mirage/lib/jquery.tooltip.js"> </script>
+        <script type="text/javascript">var referrer=document.referrer;var doi=referrer.replace(/^.*http:\/\/ezid.cdlib.org\/id\//,"")</script>
+        <script type="text/javascript">var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));</script>
         <script type="text/javascript">try {var pageTracker = _gat._getTracker("UA-16949847-1");pageTracker._trackPageview();} catch(err) {}</script> 
         
 	<style type="text/css">
@@ -24,20 +25,19 @@
         <div id="ds-body">
             <h1 class="ds-div-head">Content restricted ahead of article publication<a id="contentRestricted">&#160;</a></h1>
             <div class="ds-static-div primary">
-                <form xmlns="http://di.tamu.edu/DRI/1.0/" id="aspect_artifactbrowser_FeedbackForm_div_feedback-form" class="ds-interactive-div primary" action="/feedback" method="post" onsubmit="javascript:tSubmit(this);"> 
-                <p class="ds-paragraph">As far as we know, the article
-                associated with this Dryad data package has not yet
-                been published, and the journal requires us to
-                suppress the data until article publication.  If you
-                know that the article has in fact been published,
-                please let us know by filling out the form below and
-                we will make the data available promptly. Thanks!</p> 
-                <fieldset xmlns="http://di.tamu.edu/DRI/1.0/" id="aspect_artifactbrowser_FeedbackForm_list_form" class="ds-form-list"> 
+                <form xmlns="http://di.tamu.edu/DRI/1.0/" id="aspect_artifactbrowser_FeedbackForm_div_feedback-form" class="ds-interactive-div primary" action="/feedback" method="post" onsubmit="javascript:tSubmit(this);">
+                    <p class="ds-paragraph">The DOI <span id="dryad-doi" class="ds-paragraph"></span> has been registered for this data package.
+                        As far as we know, the article associated with this data package has not yet been published,
+                        and the journal requires us to suppress the data until then. Once the article is available,
+                        we will update this DOI to automatically resolve you to the data package.</p>
+                    <p>If you know that the article has in fact been published, please let us know by filling out
+                        the form below and we will make the data available promptly. Thanks!</p>
+                    <fieldset xmlns="http://di.tamu.edu/DRI/1.0/" id="aspect_artifactbrowser_FeedbackForm_list_form" class="ds-form-list">
                     <ol> 
                         <li class="ds-form-item"> 
                             <label class="ds-form-label" for="aspect_artifactbrowser_FeedbackForm_field_email">Your Email:</label> 
                             <div xmlns="http://di.tamu.edu/DRI/1.0/" class="ds-form-content"> 
-                                <input id="aspect_artifactbrowser_FeedbackForm_field_email" class="ds-text-field" name="email" type="text" value="" title="This address will be used to follow&#10;&#9;&#9;up on your feedback." /> 
+                                <input id="aspect_artifactbrowser_FeedbackForm_field_email" class="ds-text-field" name="email" type="text" value="" title="This address will be used to follow up on your feedback." />
                                 <span class="field-help">This address will be used to follow
                                     up with you.</span> 
                             </div> 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/publicationBlackout.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/publicationBlackout.xhtml
@@ -57,11 +57,14 @@
                             </div> 
                         </li> 
                     </ol> 
-                </fieldset> 
-                <p id="aspect_artifactbrowser_FeedbackForm_p_hidden-fields" class="ds-paragraph hidden"> 
-                    <input id="aspect_artifactbrowser_FeedbackForm_field_page" class="ds-hidden-field" name="page" type="hidden" value="http://datadryad.org/publicationBlackout" /> 
-                </p> 
-            </form> 
+                </fieldset>
+                    <p id="aspect_artifactbrowser_FeedbackForm_p_hidden-fields" class="ds-paragraph hidden">
+                        <input id="aspect_artifactbrowser_FeedbackForm_field_page" class="ds-hidden-field" name="page" type="hidden" />
+                    </p>
+                    <p id="aspect_artifactbrowser_FeedbackForm_p_hidden-fields" class="ds-paragraph hidden">
+                        <input id="aspect_artifactbrowser_FeedbackForm_field_subject" class="ds-hidden-field" name="subject" type="hidden" value="Release data: article now published" />
+                    </p>
+                </form>
             </div>
 
     <div class="page-license">


### PR DESCRIPTION
If you get to the publication blackout page from the ezid doi link, that page is used as the referring page and is included in the text of the page as well as the email sent to the feedback form.

https://trello.com/c/tlvCyjvQ/91-add-doi-to-pub-blackout-page-and-include-in-email-to-helpdesk
