### PR TITLE
Email paragraph break

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -272,7 +272,7 @@ public class DryadEmailSubmission extends HttpServlet {
             }
 
             // Stop reading lines if we've run into the sig line
-            if (StringUtils.stripToEmpty(line).equals("--")) {
+            if (StringUtils.stripToEmpty(line).equals("--") && (dryadContentStarted == true)) {
                 break;
             }
 


### PR DESCRIPTION
I thought that I’d fixed this metadata parsing error in a different PR, but it doesn’t seem to be in the code base.
