### PR TITLE
Fix page title of /payments

### DIFF
--- a/dspace/config/pages/payment.xml
+++ b/dspace/config/pages/payment.xml
@@ -7,7 +7,7 @@
     <meta>
         <userMeta/>
         <pageMeta>
-            <metadata element="title">Payment plans</metadata>
+            <metadata element="title">Payment</metadata>
             <trail target="/">Dryad Digital Repository</trail>
         </pageMeta>
         <repositoryMeta/>


### PR DESCRIPTION
Tiny change -- I noticed the page title still said "Payment plans"
