### PR TITLE
Add menu link to edit journals

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/authority/Navigation.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/authority/Navigation.java
@@ -50,11 +50,9 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
     private static final Message T_administrative_authority 	= message("xmlui.administrative.Navigation.administrative_authority_control");
     private static final Message T_administrative_scheme_metadata = message("xmlui.administrative.Navigation.administrative_metadata_scheme");
     private static final Message T_administrative_registry = message("xmlui.administrative.Navigation.administrative_metadata_registry");
-
-
     private static final Message T_account_export			 		= message("xmlui.administrative.Navigation.account_export");
-
     private static final Message T_my_account                       = message("xmlui.EPerson.Navigation.my_account");
+    private static final Message T_administrative_journal_settings = message("xmlui.administrative.Navigation.administrative_journal_settings");
 
     /** Cached validity object */
     private SourceValidity validity;
@@ -184,6 +182,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
 
             authority.setHead(T_administrative_authority);
             authority.addItemXref(contextPath+"/admin/scheme",T_administrative_scheme_metadata);
+	    authority.addItemXref(contextPath+"/admin/scheme?schemeID=3&search",T_administrative_journal_settings);
         }
     }
     /**

--- a/dspace-xmlui/dspace-xmlui-api/src/main/resources/aspects/Authority/i18n/messages.xml
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/resources/aspects/Authority/i18n/messages.xml
@@ -420,6 +420,7 @@
 
     <message key="xmlui.administrative.Navigation.administrative_metadata_registry">Registry</message>
     <message key="xmlui.administrative.Navigation.administrative_metadata_scheme">Manage Scheme</message>
+    <message key="xmlui.administrative.Navigation.administrative_journal_settings">Manage Journal Settings</message>
 
     <message key="xmlui.aspect.authority.concept.ManageMetadataRegistryMain.actions_head">Metadata Registries</message>
     <message key="xmlui.aspect.authority.concept.ManageMetadataRegistryMain.main_head">Metadata Registries</message>


### PR DESCRIPTION
This new entry on the menu allows quick access to the journal concepts.

Replaces #944, which had some other changes that are no longer relevant.
