### PR TITLE
APPS & AMJBOT - remove sponsor/change to $120. Remove Plant Sciences Bulletin

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/journalLookup.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/journalLookup.xhtml
@@ -148,7 +148,7 @@
                 <td class="ds-table-cell">A</td>
                 <td class="ds-table-cell">Y</td>
                 <td class="right-border ds-table-cell">Y</td>
-                <td class="ds-table-cell">The Botanical Society of America</td>
+                <td class="ds-table-cell">$120</td>
             </tr>
             <tr class="ds-table-row odd">
                 <td class="right-border ds-table-cell">American Naturalist, The</td>
@@ -164,7 +164,7 @@
                 <td class="ds-table-cell">R</td>
                 <td class="ds-table-cell">N</td>
                 <td class="right-border ds-table-cell">Y</td>
-                <td class="ds-table-cell">The Botanical Society of America</td>
+                <td class="ds-table-cell">$120</td>
             </tr>
             <tr class="ds-table-row odd">
                 <td class="right-border ds-table-cell">Behavioral Ecology</td>
@@ -814,14 +814,6 @@
                 <td class="ds-table-cell">Y</td>
                 <td class="right-border ds-table-cell">Y</td>
                 <td class="ds-table-cell">American Society of Plant Biologists</td>
-            </tr>
-            <tr class="ds-table-row odd">
-                <td class="right-border ds-table-cell">Plant Science Bulletin</td>
-                <td class="ds-table-cell">N</td>
-                <td class="ds-table-cell">A</td>
-                <td class="ds-table-cell">Y</td>
-                <td class="right-border ds-table-cell">Y</td>
-                <td class="ds-table-cell">The Botanical Society of America</td>
             </tr>
             <tr class="ds-table-row even">
                 <td class="right-border ds-table-cell">PLOS Biology </td>


### PR DESCRIPTION
End sponsorship for BSA journals (Trello)
Updating the journalLookup page to show that the Botanical Society of America will no longer (as of Apr 1) sponsor data submissions for:
- American Journal of Botany
- Applications in Plant Sciences
- Plant Science Bulletin
