### PR TITLE
Fix for publication doi prefix

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -483,7 +483,7 @@ public class DryadDataPackage extends DryadObject {
         // check that this DOI starts with the doi: prefix. if not, add it.
         Pattern doiPattern = Pattern.compile("^doi:.*");
         Matcher matcher = doiPattern.matcher(publicationDOI);
-        if (!matcher.find()) {
+        if (!("".equals(publicationDOI)) && !matcher.find()) {
             publicationDOI = "doi:" + publicationDOI;
         }
         addSingleMetadataValue(Boolean.FALSE, RELATION_SCHEMA, RELATION_ELEMENT, RELATION_ISREFERENCEDBY_QUALIFIER, publicationDOI);

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
@@ -61,6 +61,7 @@ public class EmailParser {
         fieldToXMLTagMap.put("contact author state", Manuscript.STATE);
         fieldToXMLTagMap.put("contact author country", Manuscript.COUNTRY);
         fieldToXMLTagMap.put("contact author zip/postal code", Manuscript.ZIP);
+        fieldToXMLTagMap.put("publication doi", Manuscript.PUBLICATION_DOI);
 
         // commonly-used field names for optional XML tags
         fieldToXMLTagMap.put("ISSN", Manuscript.ISSN);
@@ -178,6 +179,7 @@ public class EmailParser {
         correspondingAuthor.address.country = (String) dataForXML.remove(Manuscript.COUNTRY);
         correspondingAuthor.address.zip = (String) dataForXML.remove(Manuscript.ZIP);
         manuscript.setDryadDataDOI((String) dataForXML.remove(Manuscript.DRYAD_DOI));
+        manuscript.setPublicationDOI((String) dataForXML.remove(Manuscript.PUBLICATION_DOI));
         manuscript.optionalProperties = dataForXML;
     }
 


### PR DESCRIPTION
Two things:
- if there isn’t anything in the publicationDOI, don’t prefix with `doi:`.
- if a publication DOI is provided in the metadata email, populate the Manuscript.
