### PR TITLE
Disallow spiders from indexing /review URLs

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/static/robots.txt.production
+++ b/dspace/modules/xmlui/src/main/webapp/static/robots.txt.production
@@ -14,6 +14,7 @@ Disallow: /advanced-search
 Disallow: /search
 Disallow: /browse-date
 Disallow: /community-list
+Disallow: /review
 
 # Collection-specific search/browse for Main
 Disallow: /handle/10255/1/search


### PR DESCRIPTION
I've already added this change to the robots.txt on the deployed system, so we don't get any more robot activity than necessary.
