### PR TITLE
Update email for payment system errors

### DIFF
--- a/dspace/config/modules/payment-system.cfg
+++ b/dspace/config/modules/payment-system.cfg
@@ -19,10 +19,10 @@ dryad.paymentsystem.sizeFileFeeAfter= USD:50;GBP:999;EUR:999;CAD:999;JPY:99999;A
 #[currency]:[fee];[currency][fee]...
 dryad.paymentsystem.notIntegratedJournalFee=USD:0;GBP:0;EUR:0;CAD:0;JPY:0;AUD:0
 
-dryad.paymentsystem.help.email = help@datadryad.org
+dryad.paymentsystem.help.email = ${default.mail.help}
 dryad.paymentsystem.help.call = 000-000-0000
 
-dryad.paymentsystem.alert.recipient = help@datadryad.org
+dryad.paymentsystem.alert.recipient = ${default.mail.help}
 
 
 paypal.link = ${paypal.link}

--- a/dspace/config/modules/payment-system.cfg
+++ b/dspace/config/modules/payment-system.cfg
@@ -22,7 +22,7 @@ dryad.paymentsystem.notIntegratedJournalFee=USD:0;GBP:0;EUR:0;CAD:0;JPY:0;AUD:0
 dryad.paymentsystem.help.email = help@datadryad.org
 dryad.paymentsystem.help.call = 000-000-0000
 
-dryad.paymentsystem.alert.recipient = ${default.automated.email.recipient}
+dryad.paymentsystem.alert.recipient = help@datadryad.org
 
 
 paypal.link = ${paypal.link}


### PR DESCRIPTION
Payment system errors should go to the help address, rather than the (rarely-used) automated-messages group.
