### PR TITLE
Correct indexing issues with XOAI

### DIFF
--- a/dspace-xoai/dspace-xoai-api/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-xoai/dspace-xoai-api/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -229,7 +229,10 @@ public class XOAI
                     log.error(e.getMessage(), e);
                 }
                 i++;
-                if (i % 100 == 0) System.out.println(i+" items imported so far...");
+                if (i % 100 == 0) {
+		    server.commit();
+		    System.out.println(i+" items imported so far...");
+		}
             }
             System.out.println("Total: "+i+" items");
             server.commit();


### PR DESCRIPTION
When indexing, commit the changed items more frequently, so the server doesn't run out of memory.

To test:
1. Ensure maven has a setting for default.solr.xoai.server that references the solr/xoai core
2. Deploy
3. Ensure this runs without error:

   /opt/dryad/bin/dspace xoai import -c -o -v
