### PR TITLE
Remove Evolutionary Applications

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipOverview.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipOverview.xhtml
@@ -130,8 +130,6 @@
             <li><a href="http://elementascience.org/">Elementa: Science of the Anthropocene</a></li>
 
             <li><a href="http://www.eseb.org/">European Society for Evolutionary Biology</a> <span class="charter-mark">*</span></li>
-            <li><a href="http://www.blackwellpublishing.com/eva_enhanced/">Evolutionary
-            Applications</a> <span class="charter-mark">*</span></li>
             <li><a href="http://www.nature.com/hdy/">The Genetics Society</a><span class="charter-mark">*</span></li>
 
             <li><a href="http://www.zbmed.de/en/">German National Libary of Medicine</a></li>


### PR DESCRIPTION
Although they were listed as a charter member, they never had an active membership plan.
