### PR TITLE
Update 2016 meeting page

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipMeeting2016.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipMeeting2016.xhtml
@@ -81,13 +81,15 @@
 
 
 <div class="ds-static-div primary">
-<h2>How to participate</h2>
-<p>Free registration for this virtual event is available via <a href="http://www.eventbrite.co.uk/e/leadership-in-data-publishing-the-2016-dryad-virtual-community-meeting-tickets-25209285652">Eventbrite</a>.</p>
-	
 <h2>Overview</h2>
 <p>The Dryad Community Meeting is an annual event for researchers, journal editors, librarians, data managers, publishers, funders and other individuals or organizations with a stake in the preservation and availability of the scientific and medical data associated with the published literature.</p> 
 
-<p>The theme of this year’s meeting is &quot;<strong>Leadership in data publishing: Dryad and learned societies</strong>.&quot; To make attendance easier, this year's meeting will be held <strong>online</strong>, and in an abbreviated format. </p>
+<p>The theme of the 2016 meeting was &quot;<strong>Leadership in data publishing: Dryad and learned societies</strong>.&quot; To make attendance easier, this year's meeting was held <strong>online</strong>, and in an abbreviated format. </p>
+
+<h2>Video</h2>
+
+<p>A <a href="https://www.youtube.com/watch?v=TGFzhBbdOaQ">recorded video of the meeting</a> can be viewed on the Dryad YouTube channel.
+</p>
 
 <h2>Program</h2>
         <div class="agenda">
@@ -138,11 +140,6 @@
     </div>
 
 <br />
-<h2>Registration</h2>
-<p>There is no cost for registration, but space is limited, so please register early to ensure availability. <a href="http://www.eventbrite.co.uk/e/leadership-in-data-publishing-the-2016-dryad-virtual-community-meeting-tickets-25209285652">Register today!</a>.</p>
-
-<h2>For inquiries</h2>
-<p>Please contact Executive Director <a href="mailto:mmorovati@datadryad.org">Meredith Morovati</a>.</p>
 
     </div>
 
@@ -156,7 +153,7 @@
       </p>
     </div>  
 
-    <div class="lastmodified">Last revised: 2016-05-10</div>
+    <div class="lastmodified">Last revised: 2016-05-25</div>
  </div>
  </body>
 </html>


### PR DESCRIPTION
Update the page to indicate that the meeting is over, and provide a link to the video.
