### PR TITLE
Add lookup table info for North American Fauna, Systematic Botany Monographs

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/journalLookup.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/journalLookup.xhtml
@@ -278,7 +278,6 @@
                 <td class="right-border ds-table-cell">Y</td>
                 <td class="ds-table-cell">British Editorial Society of Bone &amp; Joint Surgery</td>
             </tr>
-
             <tr class="ds-table-row even">
                 <td class="right-border ds-table-cell">Comparative Cytogenetics </td>
                 <td class="ds-table-cell">Y</td>
@@ -335,7 +334,6 @@
                 <td class="right-border ds-table-cell">N</td>
                 <td class="ds-table-cell">Ecological Society of America</td>
             </tr>
-            
              <tr class="ds-table-row odd">
                 <td class="right-border ds-table-cell">Ecology</td>
                 <td class="ds-table-cell">Y</td>
@@ -401,7 +399,6 @@
                 <td class="right-border ds-table-cell">N</td>
                 <td class="ds-table-cell">Society for the Study of Evolution</td>
             </tr>
-          
             <tr class="ds-table-row even">
                 <td class="right-border ds-table-cell">Evolutionary Applications</td>
                 <td class="ds-table-cell">Y</td>
@@ -698,7 +695,6 @@
                 <td class="right-border ds-table-cell">N</td>
                 <td class="ds-table-cell">Pensoft</td>
             </tr>
-            
              <tr class="ds-table-row even">
                 <td class="right-border ds-table-cell">Nordic Journal of Botany</td>
                 <td class="ds-table-cell">Y</td>
@@ -707,7 +703,14 @@
                 <td class="right-border ds-table-cell">N</td>
                 <td class="ds-table-cell">Nordic Society Oikos</td>
             </tr>
-            
+             <tr class="ds-table-row even">
+                <td class="right-border ds-table-cell">North American Fauna</td>
+                <td class="ds-table-cell">N</td>
+                <td class="ds-table-cell">A</td>
+                <td class="ds-table-cell">Y</td>
+                <td class="right-border ds-table-cell">Y</td>
+                <td class="ds-table-cell">U.S. Fish and Wildlife Service</td>
+            </tr>            
             <tr class="ds-table-row odd">
                 <td class="right-border ds-table-cell">Nota Lepidopterologica </td>
                 <td class="ds-table-cell">Y</td>
@@ -716,7 +719,6 @@
                 <td class="right-border ds-table-cell">Y</td>
                 <td class="ds-table-cell">Pensoft</td>
             </tr>
-            
              <tr class="ds-table-row even">
                 <td class="right-border ds-table-cell">Oikos</td>
                 <td class="ds-table-cell">Y</td>
@@ -725,8 +727,6 @@
                 <td class="right-border ds-table-cell">N</td>
                 <td class="ds-table-cell">Nordic Society Oikos</td>
             </tr>
-            
-            
              <tr class="ds-table-row odd">
                 <td class="right-border ds-table-cell">Open Biology</td>
                 <td class="ds-table-cell">N</td>
@@ -927,6 +927,14 @@
                 <td class="right-border ds-table-cell">Y</td>
                 <td class="ds-table-cell">American Society of Plant Taxonomists</td>
             </tr>
+            <tr class="ds-table-row even">
+                <td class="right-border ds-table-cell">Systematic Botany Monographs</td>
+                <td class="ds-table-cell">N</td>
+                <td class="ds-table-cell">A</td>
+                <td class="ds-table-cell">Y</td>
+                <td class="right-border ds-table-cell">Y</td>
+                <td class="ds-table-cell">American Society of Plant Taxonomists</td>
+            </tr>            
             <tr class="ds-table-row odd">
                 <td class="right-border ds-table-cell">Toxicological Sciences</td>
                 <td class="ds-table-cell">Y</td>


### PR DESCRIPTION
Add two journals (North American Fauna, Systematic Botany Monographs) and their publishers’ respective payment plans to the "Look up your journal" table.
https://trello.com/c/zmSTrCPd/115-systematic-botany-monographs (edited)
https://trello.com/c/vwK0XYXY/114-north-american-fauna
