### PR TITLE
Correct file name/title truncation when period appears early

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
@@ -82,9 +82,15 @@ public class XSLUtils {
             // so the whole thing is prefix...suffix
             String[] parts = name.split("\\.");
             if (parts.length > 1) {
-                // there is a file extension.
+                // there is a period
                 suffix = parts[parts.length - 1];
-                suffix = name.substring(name.length() - suffix.length() - 3, name.length() - suffix.length() - 1) + "." + suffix;
+
+		// if the period is near the beginning of the string, it's an abbreviation, not a file extension, so ignore it
+		if (name.length() - suffix.length() < 4) {
+		    suffix = null;
+		} else {
+		    suffix = name.substring(name.length() - suffix.length() - 3, name.length() - suffix.length() - 1) + "." + suffix;
+		}
             }
 
             if ((suffix == null) || (suffix.length() > 6)){


### PR DESCRIPTION
This corrects a problem with display of the Submisison Overview page when a file's dc.title is both long and has a period near the beginning, such as
"O. sagittarius occurrence data from some monitoring system somewhere in the whole wide world"

See:
- https://nescent.fogbugz.com/f/cases/22660/Error-when-accessing-unfinished-submission
- https://nescent.fogbugz.com/f/cases/22726/Unable-to-edit-submission
