### PR TITLE
2016 Community Meeting now past

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl
@@ -238,11 +238,6 @@
                 <div id="dryad-home-carousel" class="ds-static-div primary">
                     <!-- REMINDER: slide publication dates are in the format YEAR-MONTH-DAY, eg, 2013-12-28 -->
                     <div class="bxslider" style="">
-						<div><span class="publication-date">2016-05-09</span>
-						                            <a href="/pages/membershipMeeting2016">
-						                                <img alt="2016 Dryad Virtual Community Meeting" src="/themes/Mirage/images/membershipMeeting2016_carousel.png" />
-						                            </a>
-						                        </div>
                         <div><span class="publication-date">2015-04-14</span>
                             <a href="/pages/submissionIntegration">
                                 <img src="/themes/Mirage/images/integration-slide.jpg" alt="Publishers: Simplify data submission. Strengthen links between articles and data. For free. Integrate your journal with Dryad now" />

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -448,7 +448,7 @@ references to stylesheets pulled directly from the pageMeta element. -->
                                     <a href="/pages/employment">Employment opportunities</a>
                                 </li>
                                 <li>
-                                    <a href="/pages/membershipMeeting2016">Membership meeting</a>
+                                    <a href="/pages/membershipMeeting">Membership meeting</a>
                                 </li>
                                 <li>
                                   <a href="/pages/faq">FAQs</a>
@@ -497,7 +497,7 @@ references to stylesheets pulled directly from the pageMeta element. -->
                                     <a href="/pages/membershipOverview">Membership</a>
                                 </li> 
                                 <li>
-                                    <a href="/pages/membershipMeeting2016">Membership meeting</a>
+                                    <a href="/pages/membershipMeeting">Membership meeting</a>
                                 </li>                            
                                 <li>
                                     <a href="/pages/paymentPlans">Payment plans</a>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipMeeting.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipMeeting.xhtml
@@ -57,7 +57,7 @@
       </p>
     </div>  
 
-    <div class="lastmodified">Last revised: 2015-05-28</div>
+    <div class="lastmodified">Last revised: 2016-06-08</div>
  </div>
  </body>
 </html>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipMeeting.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipMeeting.xhtml
@@ -31,6 +31,10 @@
   <h1 style="margin: 6px 0 4px;">Previous meetings</h1>
 
 <div id="membershipMeeting2014" class="featured-image">
+  <a href="/pages/membershipMeeting2016"><img src="/themes/Mirage/images/membershipMeeting2016_banner.png" alt="Dryad 2016 Membership Meeting" /></a>
+</div>
+<br />
+<div id="membershipMeeting2014" class="featured-image">
   <a href="/pages/membershipMeeting2015"><img src="/themes/Mirage/images/membershipMeeting2015_banner.jpg" alt="Dryad 2015 Membership Meeting" /></a>
 </div>
 <br />


### PR DESCRIPTION
- Remove banner from homepage carousel
- Add banner/link to previous meetings page /membershipMeeting
- Change Membership meeting links in site nav to point to /membershipMeeting

(please check carefully, unable to preview on VM)
