### PR TITLE
Don't send provenance information to datacite.

### DIFF
--- a/dspace/config/crosswalks/DIM2DATACITE.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE.xsl
@@ -251,7 +251,8 @@
 			<xsl:if test="$datatype='DataFile'">
 				<descriptions>
 					<description descriptionType="Other">
-						<xsl:value-of select="dspace:field[@element='description']"/>
+					        <!-- Exclude provenance fields, since these often contain private information -->
+						<xsl:value-of select="dspace:field[@element='description' and not(@qualifier='provenance')]"/>
 					</description>
 				</descriptions>
 			</xsl:if>

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
@@ -101,7 +101,7 @@ public class CDLDataCiteService {
     }
 
     public static String generateEzidUrl(String aDOI) {
-        if (aDOI.startsWith("doi")) {
+        if (aDOI.toUpperCase().startsWith("DOI")) {
             aDOI = aDOI.substring(4);
         }
         return BASEURL + "/id/doi%3A" + aDOI;


### PR DESCRIPTION
It often includes private information like rejection notices.

To test:
- on local vm in dspace.cfg, set datacite.connected =  true
- find a data file (not package) on your vm that is already registered at ezid; ensure the metadata is the same for both items
- on the vm, add a provenance field to this data file
- run a manual update of the metadata, like:
  
  /opt/dryad/bin/dsrun org.dspace.doi.CDLDataCiteService dryad <password> doi:10.5061/dryad.59/1 http://datadryad.org/resource/doi:10.5061/DRYAD.59/1 update
- verify that EZID shows a new "date modified", but there is no provenance field
- remove the provenance field and re-run the manual update
