### PR TITLE
Remove final voucher box from payment page.

### DIFF
--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/PaymentService.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/PaymentService.java
@@ -49,8 +49,6 @@ public interface PaymentService
 
     public void generatePaypalForm(Division mandiv, ShoppingCart shoppingCart, String actionURL, String type,Context context) throws WingException, SQLException;
 
-    public void generateVoucherForm(Division form, String voucherCode, String actionURL, String knotId) throws WingException;
-
     public void generateNoCostForm(Division actionsDiv, ShoppingCart transaction, org.dspace.content.Item item, PaymentSystemConfigurationManager manager, PaymentSystemService paymentSystemService) throws WingException, SQLException;
 
     public void showSkipPaymentButton(Division mainDiv, String message) throws WingException;

--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/PaymentServiceImpl.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/PaymentServiceImpl.java
@@ -351,15 +351,6 @@ public class PaymentServiceImpl implements PaymentService {
         }
     }
 
-    public void generateVoucherForm(Division form, String voucherCode, String actionURL, String knotId) throws WingException {
-
-        List list = form.addList("voucher-list");
-        list.addLabel("Voucher Code ");
-        list.addItem().addText("voucher").setValue(voucherCode);
-        list.addItem().addButton("submit-voucher").setValue("Apply");
-
-    }
-
     public void generateNoCostForm(Division actionsDiv, ShoppingCart shoppingCart, org.dspace.content.Item item, PaymentSystemConfigurationManager manager, PaymentSystemService paymentSystemService) throws WingException, SQLException {
         //Lastly add the finalize submission button
 
@@ -513,12 +504,6 @@ public class PaymentServiceImpl implements PaymentService {
                 } else {
                     mainDiv.setHead(T_HEAD);
                     mainDiv.addPara(T_HELP);
-                    Division voucherDiv = mainDiv.addDivision("voucher");
-                    if (PAYMENT_ERROR_VOUCHER.equals(errorMessage)) {
-                        voucherDiv.addPara("voucher-error", "voucher-error").addHighlight("bold").addContent(T_voucher_error);
-                    }
-
-                    generateVoucherForm(voucherDiv, voucherCode, actionURL, knotId);
                     Division creditcard = mainDiv.addDivision("creditcard");
                     generatePaypalForm(creditcard, shoppingCart, actionURL, type, context);
                     mainDiv.addPara().addContent(T_payment_note);


### PR DESCRIPTION
This box works inconsistently at best and adds no additional functionality to the page. Let’s ditch it.
