### PR TITLE
change default payment-alert recipient

### DIFF
--- a/dspace/config/modules/payment-system.cfg
+++ b/dspace/config/modules/payment-system.cfg
@@ -22,7 +22,7 @@ dryad.paymentsystem.notIntegratedJournalFee=USD:0;GBP:0;EUR:0;CAD:0;JPY:0;AUD:0
 dryad.paymentsystem.help.email = ${default.mail.help}
 dryad.paymentsystem.help.call = 000-000-0000
 
-dryad.paymentsystem.alert.recipient = ${default.mail.help}
+dryad.paymentsystem.alert.recipient = ${default.automated.email.recipient}
 
 
 paypal.link = ${paypal.link}

--- a/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/PaymentSystemImpl.java
+++ b/dspace/modules/payment-system/payment-api/src/main/java/org/dspace/paymentsystem/PaymentSystemImpl.java
@@ -727,7 +727,7 @@ public class PaymentSystemImpl implements PaymentSystemService {
         try {
             Email email = ConfigurationManager.getEmail(I18nUtil.getEmailFilename(c.getCurrentLocale(), "payment_error"));
             // only send result of shopping cart errors to administrators
-            email.addRecipient(ConfigurationManager.getProperty("payment-system", "dryad.paymentsystem.alert.recipient"));
+            email.addRecipient(ConfigurationManager.getProperty("payment-system", "dryad.paymentsystem.help.email"));
             email.addArgument(wfi.getItem().getName());
             email.addArgument(wfi.getItem().getID());
             email.addArgument(error);
@@ -769,7 +769,7 @@ public class PaymentSystemImpl implements PaymentSystemService {
             Email email = ConfigurationManager.getEmail(I18nUtil.getEmailFilename(c.getCurrentLocale(), "payment_rejected"));
             // temporarily only send result of shopping cart errors to administrators
             email.addRecipient(wfi.getSubmitter().getEmail());
-            email.addRecipient(ConfigurationManager.getProperty("payment-system", "dryad.paymentsystem.alert.recipient"));
+            email.addRecipient(ConfigurationManager.getProperty("payment-system", "dryad.paymentsystem.help.email"));
             email.addArgument(wfi.getItem().getName());
 
             email.addArgument(wfi.getSubmitter().getFullName() + " (" + wfi.getSubmitter().getEmail() + ")");


### PR DESCRIPTION
Tiny fix to redirect emails of payment approvals to the default automated email recipient instead of the helpdesk.
