### PR TITLE
Remove journal.subscriptionPaid

### DIFF
--- a/dspace/config/registries/journal-types.xml
+++ b/dspace/config/registries/journal-types.xml
@@ -49,11 +49,6 @@
 
     <dc-type>
         <schema>journal</schema>
-        <element>subscriptionPaid</element>
-    </dc-type>
-
-    <dc-type>
-        <schema>journal</schema>
         <element>sponsorName</element>
     </dc-type>
 

--- a/dspace/etc/postgres/remove-subscriptionPaid.sql
+++ b/dspace/etc/postgres/remove-subscriptionPaid.sql
@@ -1,0 +1,12 @@
+DELETE FROM ONLY conceptmetadatavalue AS cmv
+    USING metadataschemaregistry AS msr,
+        metadatafieldregistry AS mfr
+    WHERE mfr.metadata_field_id = cmv.field_id
+        AND mfr.element='subscriptionPaid'
+        AND mfr.metadata_schema_id = msr.metadata_schema_id
+        AND msr.short_id='journal';
+
+DELETE FROM ONLY metadatafieldregistry AS mfr USING metadataschemaregistry AS msr
+    WHERE mfr.element='subscriptionPaid'
+        AND mfr.metadata_schema_id = msr.metadata_schema_id
+        AND msr.short_id='journal';


### PR DESCRIPTION
This PR removes journal.subscriptionPaid from the schema registry and also includes an sql script that cleans it out of an existing database.
