### PR TITLE
Correct address of DataONE maven repo

### DIFF
--- a/dspace/modules/dataone-mn/pom.xml
+++ b/dspace/modules/dataone-mn/pom.xml
@@ -90,7 +90,7 @@
       <repositories>
         <repository>
 	  <id>dataone.org</id>
-	  <url>http://dev-testing.dataone.org/maven</url>
+	  <url>http://maven.dataone.org</url>
 	  <releases>
 	    <enabled>true</enabled>
 	  </releases>


### PR DESCRIPTION
DataONE has changed the address of their maven repository.

(This issue also affected DataVerse -- see https://github.com/IQSS/dataverse/pull/3344)
