### PR TITLE
ApproveReject fix for canonical msids

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadGmailService.java
@@ -46,7 +46,7 @@ public class DryadGmailService {
      * @throws IOException
      */
     public DryadGmailService(File credentialPath, String clientsecretsFile, String scope, String user) {
-        myUserID = user;
+        myUserID = "me";
         try {
             myDataStoreFactory = new FileDataStoreFactory(credentialPath);
             myHttpTransport = new NetHttpTransport();


### PR DESCRIPTION
Both ends of the comparison need to be canonicalized: the item’s metadata and the journal’s metadata. Partially fixes https://trello.com/c/c3m2vVRH/483-improve-matching-of-accept-reject-notices-to-dryad-items
