### PR TITLE
Add journal page links to item pages

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -337,6 +337,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
                 pageMeta.addMetadata("publicationName").addContent(values[0].value);
                 pageMeta.addMetadata("journal", "cover").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getCoverImage());
                 pageMeta.addMetadata("journal", "website").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getWebsite());
+                pageMeta.addMetadata("journal", "issn").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getISSN());
             }
 
             // Data file metadata included on data package items (integrated view)

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -1033,6 +1033,15 @@
             </div>
         </xsl:if>
 
+	<!-- Link to journal pages -->
+        <xsl:variable name="issn" select="$meta[@element='journal'][@qualifier='issn']" />
+	<xsl:variable name="fullname" select=".//dim:field[@element='publicationName']" />
+        <xsl:if test="$issn">
+	  <div style="padding: 10px; margin-top: 5px; margin-bottom: 5px;">
+            <a href="/journal/{$issn}">More about <xsl:value-of select="$fullname"/></a>
+	  </div>
+	</xsl:if>
+	
         <xsl:variable name="embargoedDate"
                       select=".//dim:field[@element='date' and @qualifier='embargoedUntil']"/>
         <xsl:variable name="embargoType">


### PR DESCRIPTION
For now, links are at the bottom of the page. Will probably be moved after more usability analysis.
