### PR TITLE
fix for non-int journals

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -25,6 +25,7 @@ import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.util.HashUtil;
 import org.apache.excalibur.source.SourceValidity;
 import org.apache.log4j.Logger;
+import org.datadryad.api.DryadJournalConcept;
 import org.dspace.JournalUtils;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
 import org.dspace.app.xmlui.utils.DSpaceValidity;
@@ -335,9 +336,12 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
 
             if ((values = item.getMetadata("prism.publicationName")).length != 0) {
                 pageMeta.addMetadata("publicationName").addContent(values[0].value);
-                pageMeta.addMetadata("journal", "cover").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getCoverImage());
-                pageMeta.addMetadata("journal", "website").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getWebsite());
-                pageMeta.addMetadata("journal", "issn").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getISSN());
+                DryadJournalConcept journalConcept = JournalUtils.getJournalConceptByJournalName(values[0].value);
+                if (journalConcept != null) {
+                    pageMeta.addMetadata("journal", "cover").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getCoverImage());
+                    pageMeta.addMetadata("journal", "website").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getWebsite());
+                    pageMeta.addMetadata("journal", "issn").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getISSN());
+                }
             }
 
             // Data file metadata included on data package items (integrated view)

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -1320,27 +1320,28 @@
         <xsl:param name="cover"/>
         <xsl:param name="website"/>
         <xsl:param name="article-doi"/>
-        <a target="_blank">
-            <xsl:attribute name="href">
-                <xsl:choose>
-                    <xsl:when test="contains($article-doi,'doi:')">
-                        <xsl:value-of
-                                select="concat('http://dx.doi.org/', substring-after($article-doi, 'doi:'))"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of
-                                select="$website"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:attribute>
-            <xsl:if test="$cover">
-                <img class="pub-cover" id="journal-logo">
-                    <xsl:attribute name="src"><xsl:value-of select="$cover"/></xsl:attribute>
-                    <xsl:attribute name="alt"><xsl:value-of select="$fullname"/></xsl:attribute>
-                </img>
-            </xsl:if>
-        </a>
-
+        <xsl:if test="$cover">
+            <a target="_blank">
+                <xsl:attribute name="href">
+                    <xsl:choose>
+                        <xsl:when test="contains($article-doi,'doi:')">
+                            <xsl:value-of
+                                    select="concat('http://dx.doi.org/', substring-after($article-doi, 'doi:'))"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of
+                                    select="$website"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:attribute>
+                <xsl:if test="$cover">
+                    <img class="pub-cover" id="journal-logo">
+                        <xsl:attribute name="src"><xsl:value-of select="$cover"/></xsl:attribute>
+                        <xsl:attribute name="alt"><xsl:value-of select="$fullname"/></xsl:attribute>
+                    </img>
+                </xsl:if>
+            </a>
+        </xsl:if>
     </xsl:template>
     <!-- Override metadata field rendering to hide manuscript number -->
     <xsl:template match="dim:field" mode="itemDetailView-DIM">


### PR DESCRIPTION
Journals that aren’t in the JournalUtils list of concepts will throw a NullPointerException when you try to look them up by name.
