### PR TITLE
More int journal fixes

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -338,9 +338,15 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
                 pageMeta.addMetadata("publicationName").addContent(values[0].value);
                 DryadJournalConcept journalConcept = JournalUtils.getJournalConceptByJournalName(values[0].value);
                 if (journalConcept != null) {
-                    pageMeta.addMetadata("journal", "cover").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getCoverImage());
-                    pageMeta.addMetadata("journal", "website").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getWebsite());
-                    pageMeta.addMetadata("journal", "issn").addContent(JournalUtils.getJournalConceptByJournalName(values[0].value).getISSN());
+                    if (!"".equals(journalConcept.getCoverImage())) {
+                        pageMeta.addMetadata("journal", "cover").addContent(journalConcept.getCoverImage());
+                    }
+                    if (!"".equals(journalConcept.getWebsite())) {
+                        pageMeta.addMetadata("journal", "website").addContent(journalConcept.getWebsite());
+                    }
+                    if (!"".equals(journalConcept.getISSN())) {
+                        pageMeta.addMetadata("journal", "issn").addContent(journalConcept.getISSN());
+                    }
                 }
             }
 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -1033,15 +1033,6 @@
             </div>
         </xsl:if>
 
-	<!-- Link to journal pages -->
-        <xsl:variable name="issn" select="$meta[@element='journal'][@qualifier='issn']" />
-	<xsl:variable name="fullname" select=".//dim:field[@element='publicationName']" />
-        <xsl:if test="$issn">
-	  <div style="padding: 10px; margin-top: 5px; margin-bottom: 5px;">
-            <a href="/journal/{$issn}">More about <xsl:value-of select="$fullname"/></a>
-	  </div>
-	</xsl:if>
-	
         <xsl:variable name="embargoedDate"
                       select=".//dim:field[@element='date' and @qualifier='embargoedUntil']"/>
         <xsl:variable name="embargoType">


### PR DESCRIPTION
Removes the journal page link at the bottom of package pages, and also doesn’t add metadata if the value for that field is empty or null.
