### PR TITLE
Correct reading of parameters in AssociationAnywhere command line 

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/anywhere/AssociationAnywhere.java
@@ -55,7 +55,7 @@ public class AssociationAnywhere {
         Options options = new Options();
 
         options.addOption("i", "customer id", true, "customer id");
-        options.addOption("p", "data package id", false, "package id");
+        options.addOption("p", "data package DOI", true, "data package DOI, in the form doi:10.5016/dryad.abc123");
         options.addOption("u", "update customer settings", false, "update customer settings");
         options.addOption("t", "tally credit", false, "tally credit");
         options.addOption("l", "list customer", false, "list customer");


### PR DESCRIPTION
As documented on http://wiki.datadryad.org/FASEB, the AssociationAnywhere commandline client takes an option "p" to specify a data package identifier. 

This corrects a bug in the code that was not accepting the package identifier, since it was assuming the "p" option took no arguments.

To test, you can run
`/opt/dryad/bin/dspace association-anywhere -t -i 1230681 -p "doi:10.5061/dryad.0hf76"`
on a machine that is configured to used AssociationAnywhere (currently only the production and dev servers are allowed through the AA firewall, any other machine will receive an exception due to the response from AA being not valid XML).
