### PR TITLE
Update version of Pdfbox

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -192,16 +192,17 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
+	    <version>2.0.1</version>
         </dependency>
         <dependency>
            <groupId>org.apache.pdfbox</groupId>
            <artifactId>fontbox</artifactId>
-           <version>1.2.1</version>
+           <version>2.0.1</version>
         </dependency>
         <dependency>
            <groupId>org.apache.pdfbox</groupId>
            <artifactId>jempbox</artifactId>
-           <version>1.2.1</version>
+           <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -192,17 +192,17 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-	    <version>2.0.1</version>
+	    <version>1.8.12</version>
         </dependency>
         <dependency>
            <groupId>org.apache.pdfbox</groupId>
            <artifactId>fontbox</artifactId>
-           <version>2.0.1</version>
+           <version>1.8.12</version>
         </dependency>
         <dependency>
            <groupId>org.apache.pdfbox</groupId>
            <artifactId>jempbox</artifactId>
-           <version>2.0.1</version>
+           <version>1.8.12</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This is to prevent a security vulnerability, as reported
in https://jira.duraspace.org/browse/DS-3309

We're not actually using the DSpace pieces that use pdfbox, so I don't know whether this is testable. But it seems good to update to a non-vulnerable version regardless.
