### PR TITLE
FIXED: Update Spring to 3.2.3

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>2.5.6</version>
+            <version>3.2.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>

--- a/dspace-api/src/main/resources/spring/spring-dspace-addon-authority-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-addon-authority-services.xml
@@ -12,9 +12,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+           http://www.springframework.org/schema/context/spring-context-3.2.xsd"
        default-autowire-candidates="*Service,*DAO,javax.sql.DataSource">
 
     <context:annotation-config /> <!-- allows us to use spring annotations in beans -->

--- a/dspace-discovery/dspace-discovery-provider/src/main/resources/spring/spring-dspace-addon-discovery-services.xml
+++ b/dspace-discovery/dspace-discovery-provider/src/main/resources/spring/spring-dspace-addon-discovery-services.xml
@@ -12,9 +12,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+           http://www.springframework.org/schema/context/spring-context-3.2.xsd"
     default-autowire-candidates="*Service,*DAO,javax.sql.DataSource">
 
     <context:annotation-config /> <!-- allows us to use spring annotations in beans -->

--- a/dspace-jspui/dspace-jspui-api/pom.xml
+++ b/dspace-jspui/dspace-jspui-api/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
          <groupId>org.springframework</groupId>
          <artifactId>spring-webmvc</artifactId>
-         <version>2.5.6</version>
+         <version>3.2.3.RELEASE</version>
          <type>jar</type>
       </dependency>
    </dependencies>

--- a/dspace-jspui/dspace-jspui-webapp/src/main/webapp/WEB-INF/spring/applicationContext.xml
+++ b/dspace-jspui/dspace-jspui-webapp/src/main/webapp/WEB-INF/spring/applicationContext.xml
@@ -12,8 +12,8 @@
     xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:util="http://www.springframework.org/schema/util"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd">
 
     <!-- Acquires the DSpace Utility Class with initialized Service Manager -->
     <bean id="dspace" class="org.dspace.utils.DSpace"/>

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/WEB-INF/spring/applicationContext.xml
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/WEB-INF/spring/applicationContext.xml
@@ -12,8 +12,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
     xmlns:configurator="http://cocoon.apache.org/schema/configurator"
     xmlns:avalon="http://cocoon.apache.org/schema/avalon" xmlns:servlet="http://cocoon.apache.org/schema/servlet"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd
                            http://cocoon.apache.org/schema/configurator http://cocoon.apache.org/schema/configurator/cocoon-configurator-1.0.1.xsd
                            http://cocoon.apache.org/schema/avalon http://cocoon.apache.org/schema/avalon/cocoon-avalon-1.0.xsd
                            http://cocoon.apache.org/schema/servlet http://cocoon.apache.org/schema/servlet/cocoon-servlet-1.0.xsd">

--- a/dspace/config/workflow-actions-xmlui.xml
+++ b/dspace/config/workflow-actions-xmlui.xml
@@ -3,8 +3,8 @@
         xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:util="http://www.springframework.org/schema/util"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd">
 
     <bean id="dryadAcceptEditRejectAction" class="org.dspace.app.xmlui.aspect.submission.workflow.actions.processingaction.EditMetadataActionXMLUI" scope="prototype"/>
     <bean id="acceptAction" class="org.dspace.app.xmlui.aspect.submission.workflow.actions.processingaction.AcceptActionXMLUI" scope="prototype"/>

--- a/dspace/config/workflow-actions.xml
+++ b/dspace/config/workflow-actions.xml
@@ -3,8 +3,8 @@
     xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:util="http://www.springframework.org/schema/util"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd">
     <bean id="completePaymentActionAPI" class="org.dspace.workflow.actions.processingaction.CompletePaymentAction"/>
     <bean id="finalPaymentActionAPI" class="org.dspace.workflow.actions.processingaction.FinalPaymentAction"/>
     <bean id="dryadAcceptRejectEditActionAPI" class="org.dspace.workflow.actions.processingaction.EditMetadataAction" scope="prototype"/>

--- a/dspace/modules/api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace/modules/api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -12,9 +12,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+           http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
     <bean class="org.dspace.versioning.DryadPackageVersionProvider" autowire="byType"/>
 

--- a/dspace/modules/doi/dspace-doi-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace/modules/doi/dspace-doi-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -12,9 +12,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+           http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
         <bean class="org.dspace.doi.Minter" autowire="byType" scope="singleton"/>
         <bean class="org.dspace.doi.PGDOIDatabase" autowire="byType" scope="singleton"/>

--- a/dspace/modules/identifier-services/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace/modules/identifier-services/src/main/resources/spring/spring-dspace-core-services.xml
@@ -12,9 +12,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+           http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
 
     <bean class="org.dspace.identifier.HandleIdentifierProvider" scope="singleton"/>

--- a/dspace/modules/payment-system/payment-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace/modules/payment-system/payment-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -12,9 +12,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+           http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
     <bean id="org.dspace.paymentsystem.PaymentService" class="org.dspace.paymentsystem.PaymentServiceImpl" autowire="byType"/>
     <bean id="org.dspace.paymentsystem.PaymentSystemService" class="org.dspace.paymentsystem.PaymentSystemImpl"  autowire="byType"/>

--- a/dspace/modules/payment-system/payment-webapp/pom.xml
+++ b/dspace/modules/payment-system/payment-webapp/pom.xml
@@ -143,21 +143,6 @@
             <version>1.0.3</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.dspace</groupId>
-            <artifactId>dspace-services-impl</artifactId>
-            <version>2.0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dspace</groupId>
-            <artifactId>dspace-services-api</artifactId>
-            <version>2.0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dspace</groupId>
-            <artifactId>dspace-services-utils</artifactId>
-            <version>2.0.3</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -54,17 +54,17 @@
                <dependency>
                    <groupId>org.dspace</groupId>
                    <artifactId>dspace-services-api</artifactId>
-                   <version>2.0.3</version>
+                   <version>2.0.5-SNAPSHOT</version>
                </dependency>
                 <dependency>
                    <groupId>org.dspace</groupId>
                    <artifactId>dspace-services-impl</artifactId>
-                   <version>2.0.3</version>
+                   <version>2.0.5-SNAPSHOT</version>
                </dependency>
                            <dependency>
                    <groupId>org.dspace</groupId>
                    <artifactId>dspace-services-utils</artifactId>
-                   <version>2.0.3</version>
+                   <version>2.0.5-SNAPSHOT</version>
                </dependency>
 
 
@@ -108,13 +108,6 @@
                    <version>${pom.version}</version>
                    <type>war</type>
                </dependency>
-
-               <dependency>
-                   <groupId>org.dspace.modules</groupId>
-                   <artifactId>versioning-api</artifactId>
-                   <version>${pom.version}</version>
-               </dependency>
-
 
                <dependency>
                    <groupId>org.dspace.modules</groupId>

--- a/dspace/modules/versioning/versioning-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace/modules/versioning/versioning-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -12,9 +12,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+           http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
 
     <bean class="org.dspace.versioning.DefaultItemVersionProvider" />

--- a/dspace/modules/xmlui/pom.xml
+++ b/dspace/modules/xmlui/pom.xml
@@ -377,7 +377,7 @@
        <dependency>
            <groupId>org.springframework</groupId>
            <artifactId>spring-webmvc</artifactId>
-           <version>3.0.5.RELEASE</version>
+           <version>3.2.3.RELEASE</version>
        </dependency>
 
        <dependency>

--- a/dspace/modules/xmlui/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/dspace/modules/xmlui/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -8,15 +8,15 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans
-       http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+       http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
        http://www.springframework.org/schema/context
-       http://www.springframework.org/schema/context/spring-context-3.0.xsd
+       http://www.springframework.org/schema/context/spring-context-3.2.xsd
        http://www.springframework.org/schema/mvc
-       http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+       http://www.springframework.org/schema/mvc/spring-mvc-3.2.xsd
        http://www.springframework.org/schema/aop
-       http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/aop/spring-aop-3.2.xsd
        http://www.springframework.org/schema/tx
-       http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+       http://www.springframework.org/schema/tx/spring-tx-3.2.xsd">
  
   <!-- Use @Component annotations for bean definitions -->
   <context:component-scan base-package="org.dspace.springmvc"/>

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -819,17 +819,17 @@
                 <dependency>
                     <groupId>org.dspace</groupId>
                     <artifactId>dspace-services-api</artifactId>
-                    <version>2.0.3</version>
+                    <version>2.0.5-SNAPSHOT</version>
                 </dependency>
                  <dependency>
                     <groupId>org.dspace</groupId>
                     <artifactId>dspace-services-impl</artifactId>
-                    <version>2.0.3</version>
+                    <version>2.0.5-SNAPSHOT</version>
                 </dependency>
                             <dependency>
                     <groupId>org.dspace</groupId>
                     <artifactId>dspace-services-utils</artifactId>
-                    <version>2.0.3</version>
+                    <version>2.0.5-SNAPSHOT</version>
                 </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -272,17 +272,17 @@
          <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-services-impl</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.5-SNAPSHOT</version>
          </dependency>
          <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-services-api</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.5-SNAPSHOT</version>
          </dependency>
          <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-services-utils</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.5-SNAPSHOT</version>
          </dependency>
          <dependency>
             <groupId>org.dspace</groupId>

--- a/test/config/workflow-actions.xml
+++ b/test/config/workflow-actions.xml
@@ -3,8 +3,8 @@
     xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:util="http://www.springframework.org/schema/util"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd">
     <bean id="completePaymentActionAPI" class="org.dspace.workflow.actions.processingaction.CompletePaymentAction"/>
     <bean id="finalPaymentActionAPI" class="org.dspace.workflow.actions.processingaction.FinalPaymentAction"/>
     <bean id="dryadAcceptRejectEditActionAPI" class="org.dspace.workflow.actions.processingaction.EditMetadataAction" scope="prototype"/>


### PR DESCRIPTION
Spring 2.5.6 didn’t understand that Java 8 existed, so we need to upgrade to Spring 3.2.3. Not only do the local poms need to be updated, we also need to update the dspace-services poms to use 3.2.3. Clone https://github.com/datadryad/dspace-services/tree/spring-3.2.3 and mvn install it on the server before redeploying this pull request.