### PR TITLE
Miscellaneous APU fixes

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/rest/legacymodels/LegacyManuscript.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/legacymodels/LegacyManuscript.java
@@ -39,12 +39,12 @@ public class LegacyManuscript {
         this.Submission_Metadata.Article_Title = manuscript.getTitle();
         this.Article_Status = manuscript.getLiteralStatus();
         for (Author author : manuscript.getAuthors().author) {
-            this.Authors.Author.add(author.fullName());
+            this.Authors.Author.add(author.getUnicodeFullName());
         }
         CorrespondingAuthor correspondingAuthor = manuscript.getCorrespondingAuthor();
         if(correspondingAuthor != null) {
             if(correspondingAuthor.author != null) {
-                this.Corresponding_Author = correspondingAuthor.author.fullName();
+                this.Corresponding_Author = correspondingAuthor.author.getUnicodeFullName();
             }
             this.Email = correspondingAuthor.email;
             if(correspondingAuthor.address != null) {

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Author.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Author.java
@@ -141,4 +141,8 @@ public class Author {
         return this.identifierType;
     }
 
+    public static String normalizeName(String name) {
+        return Normalizer.normalize(name, Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+    }
+
 }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Author.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Author.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.lang.String;
+import java.text.Normalizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -15,21 +16,21 @@ import java.util.regex.Pattern;
  */
 @XmlRootElement
 public class Author {
-    public String familyName;
-    public String givenNames;
-    public String identifier;
-    public String identifierType;
+    private String familyName;
+    private String givenNames;
+    private String identifier;
+    private String identifierType;
     public Author() {}
 
     public Author(String familyName, String givenNames) {
-        this.familyName = StringEscapeUtils.escapeHtml(familyName);
-        this.givenNames = StringEscapeUtils.escapeHtml(givenNames);
+        setFamilyName(familyName);
+        setGivenNames(givenNames);
     }
 
     public Author(String authorString) {
         // initialize to empty strings, in case there isn't actually anything in the authorString.
-        this.givenNames = "";
-        this.familyName = "";
+        setGivenNames("");
+        setFamilyName("");
         String suffix = "";
 
         if (authorString != null) {
@@ -52,8 +53,8 @@ public class Author {
                     // throw this away.
                     authorString = namepattern.group(1);
                 } else {
-                    this.givenNames = namepattern.group(2);
-                    this.familyName = namepattern.group(1);
+                    setGivenNames(namepattern.group(2));
+                    setFamilyName(namepattern.group(1));
                     return;
                 }
             }
@@ -61,22 +62,83 @@ public class Author {
             // if it's firstname lastname
             namepattern = Pattern.compile("^(.+) +(.*)$").matcher(authorString);
             if (namepattern.find()) {
-                this.givenNames = namepattern.group(1);
-                this.familyName = namepattern.group(2) + suffix;
+                setGivenNames(namepattern.group(1));
+                setFamilyName(namepattern.group(2) + suffix);
             } else {
                 // there is only one word in the name: assign it to the familyName?
-                this.familyName = authorString;
-                this.givenNames = "";
+                setGivenNames("");
+                setFamilyName(authorString);
             }
         }
         return;
     }
 
-    public final String fullName() {
-        String name = familyName;
-        if (!"".equals(givenNames)) {
-            name = familyName + ", " + givenNames;
+    public void setFamilyName(String familyName) {
+        this.familyName = StringEscapeUtils.escapeHtml(familyName);
+    }
+
+    public void setGivenNames(String givenNames) {
+        this.givenNames = StringEscapeUtils.escapeHtml(givenNames);
+    }
+
+    public final String getUnicodeFullName() {
+        String name = getUnicodeFamilyName();
+        if (!"".equals(getUnicodeGivenNames())) {
+            name = getUnicodeFamilyName() + ", " + getUnicodeGivenNames();
         }
         return name;
     }
+
+    public String getUnicodeFamilyName() {
+        return StringEscapeUtils.unescapeHtml(familyName);
+    }
+
+    public String getUnicodeGivenNames() {
+        return StringEscapeUtils.unescapeHtml(givenNames);
+    }
+
+    public final String getHTMLFullName() {
+        String name = getHTMLFamilyName();
+        if (!"".equals(getHTMLGivenNames())) {
+            name = getHTMLFamilyName() + ", " + getHTMLGivenNames();
+        }
+        return name;
+    }
+
+    public String getHTMLFamilyName() {
+        return StringEscapeUtils.unescapeHtml(familyName);
+    }
+
+    public String getHTMLGivenNames() {
+        return StringEscapeUtils.unescapeHtml(givenNames);
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getNormalizedFamilyName() {
+        return Normalizer.normalize(getUnicodeFamilyName(), Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+    }
+
+    public String getNormalizedGivenNames() {
+        return Normalizer.normalize(getUnicodeGivenNames(), Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+    }
+
+    public String getNormalizedFullName() {
+        return Normalizer.normalize(getUnicodeFullName(), Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+    }
+
+    public String getIdentifier() {
+        return this.identifier;
+    }
+
+    public void setIdentifierType(String identifierType) {
+        this.identifierType = identifierType;
+    }
+
+    public String getIdentifierType() {
+        return this.identifierType;
+    }
+
 }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
@@ -265,7 +265,7 @@ public class Manuscript {
     public String getCorrespondingAuthorFullName() {
         String fullname = null;
         if (this.correspondingAuthor != null && this.correspondingAuthor.author != null) {
-            fullname = this.correspondingAuthor.author.fullName();
+            fullname = this.correspondingAuthor.author.getHTMLFullName();
         }
         return fullname;
     }
@@ -615,13 +615,13 @@ public class Manuscript {
             ArrayList<String> authorStrings = new ArrayList<String>();
             for (Author a : authors.author) {
                 StringBuilder authorString = new StringBuilder();
-                String authorFamilyName = a.familyName;
+                String authorFamilyName = a.getHTMLFamilyName();
                 if (authorFamilyName == null) {
                     authorFamilyName = "";
                 }
                 authorString.append(authorFamilyName);
                 authorString.append(" ");
-                String authorGivenName = a.givenNames;
+                String authorGivenName = a.getHTMLGivenNames();
                 if (authorGivenName == null) {
                     authorGivenName = "";
                 }
@@ -731,7 +731,7 @@ public class Manuscript {
         addSingleMetadataValueFromJournal(context, item, Manuscript.SKIP_REVIEW, String.valueOf(this.isSkipReviewStep()));
         ArrayList<String> authors = new ArrayList<String>();
         for (Author a : this.authors.author) {
-            authors.add(a.fullName());
+            authors.add(a.getHTMLFullName());
         }
         addMultiMetadataValueFromJournal(context, item, Manuscript.AUTHORS, authors);
         addMultiMetadataValueFromJournal(context, item, Manuscript.CLASSIFICATION, keywords);
@@ -798,15 +798,11 @@ public class Manuscript {
     public void configureTestValues() {
         this.manuscript_abstract = "This is the abstract of the article";
         List<Author> localAuthors = new ArrayList<Author>();
-        Author author1 = new Author();
-        author1.familyName = "Smith";
-        author1.givenNames = "John";
-        author1.identifier = "0000-0000-0000-0000";
-        author1.identifierType = "orcid";
+        Author author1 = new Author("Smith", "John");
+        author1.setIdentifier("0000-0000-0000-0000");
+        author1.setIdentifierType("orcid");
         localAuthors.add(author1);
-        Author author2 = new Author();
-        author2.familyName = "Jones";
-        author2.givenNames = "Sally";
+        Author author2 = new Author("Jones", "Sally");
         localAuthors.add(author2);
         AuthorsList localAuthorsList = new AuthorsList();
         localAuthorsList.author = localAuthors;

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
@@ -715,7 +715,6 @@ public class Manuscript {
             journalConfidence = Choices.CF_ACCEPTED;
         }
         addSingleMetadataValueFromJournal(context, item, Manuscript.JOURNAL, journalConcept.getFullName(), journalConcept.getIdentifier(), journalConfidence);
-        addSingleMetadataValueFromJournal(context, item, Manuscript.JOURNAL_CODE, journalConcept.getJournalID());
         addSingleMetadataValueFromJournal(context, item, Manuscript.ISSN, journalConcept.getISSN());
 
         addSingleMetadataValueFromJournal(context, item, Manuscript.JOURNAL_VOLUME, this.getJournalVolume());
@@ -725,7 +724,6 @@ public class Manuscript {
         if (publicationDate != null) {
             addSingleMetadataValueFromJournal(context, item, Manuscript.PUBLICATION_DATE, sdf.format(publicationDate));
         }
-        addSingleMetadataValueFromJournal(context, item, Manuscript.JOURNAL_NUMBER, this.getJournalNumber());
         addSingleMetadataValueFromJournal(context, item, Manuscript.JOURNAL_PUBLISHER, this.getPublisher());
         addSingleMetadataValueFromJournal(context, item, Manuscript.MANUSCRIPT, this.getManuscriptId());
         addSingleMetadataValueFromJournal(context, item, Manuscript.SKIP_REVIEW, String.valueOf(this.isSkipReviewStep()));

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/storage/rdbms/ManuscriptDatabaseStorageImpl.java
@@ -216,7 +216,7 @@ public class ManuscriptDatabaseStorageImpl extends AbstractManuscriptStorage {
                 List<Author> authorList = manuscript.getAuthorList();
                 StringBuilder authorString = new StringBuilder();
                 for (Author author : authorList) {
-                    authorString.append(" and " + COLUMN_JSON_DATA + " like '%\"familyName\"%:%\"" + StringEscapeUtils.escapeSql(author.familyName) + "\"%' ");
+                    authorString.append(" and " + COLUMN_JSON_DATA + " like '%\"familyName\"%:%\"" + StringEscapeUtils.escapeSql(author.getUnicodeFamilyName()) + "\"%' ");
                 }
                 if (!"".equals(authorString.toString())) {
                     String query = "SELECT * FROM " + MANUSCRIPT_TABLE + " where " + COLUMN_JOURNAL_ID + " = ? and " + COLUMN_ACTIVE + " = ? " + authorString.toString();

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -427,7 +427,7 @@ public class JournalUtils {
             ArrayList<String> lastNames = new ArrayList<String>();
             for (Author a : queryManuscript.getAuthorList()) {
                 // replace any hyphens in the last names with spaces for tokenizing.
-                lastNames.add(a.familyName.replaceAll("-"," "));
+                lastNames.add(a.getNormalizedFamilyName().replaceAll("-"," "));
             }
             queryString.append(StringUtils.join(lastNames.toArray(), " ").replaceAll("[^a-zA-Z\\s]", ""));
             queryString.append(" ");

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -446,7 +446,7 @@ public class JournalUtils {
             if (itemsNode != null && itemsNode.isArray()) {
                 JsonNode bestItem = itemsNode.get(0);
                 float score = bestItem.path("score").floatValue();
-                if (score > 2.0) {
+                if (score > 3.0) {
                     matchedManuscript = manuscriptFromCrossRefJSON(bestItem, queryManuscript.getJournalConcept());
                 }
             } else {

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
@@ -311,9 +311,9 @@ public class WorkflowItem implements InProgressSubmission {
                         int numMatched = 0;
                         for (int j = 0; j < itemAuthors.length; j++) {
                             for (Author a : manuscript.getAuthorList()) {
-                                double score = JournalUtils.getHamrScore(itemAuthors[j].value, a.fullName());
+                                double score = JournalUtils.getHamrScore(itemAuthors[j].value, a.getUnicodeFullName());
                                 if (score > 0.7) {
-                                    log.debug("author " + itemAuthors[j].value + " matched " + a.fullName() + " with a score of " + score);
+                                    log.debug("author " + itemAuthors[j].value + " matched " + a.getUnicodeFullName() + " with a score of " + score);
                                     numMatched++;
                                     break;
                                 }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
@@ -311,7 +311,7 @@ public class WorkflowItem implements InProgressSubmission {
                         int numMatched = 0;
                         for (int j = 0; j < itemAuthors.length; j++) {
                             for (Author a : manuscript.getAuthorList()) {
-                                double score = JournalUtils.getHamrScore(itemAuthors[j].value, a.getUnicodeFullName());
+                                double score = JournalUtils.getHamrScore(Author.normalizeName(itemAuthors[j].value), a.getNormalizedFullName());
                                 if (score > 0.7) {
                                     log.debug("author " + itemAuthors[j].value + " matched " + a.getUnicodeFullName() + " with a score of " + score);
                                     numMatched++;

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
@@ -167,9 +167,9 @@ public class EmailParser {
         CorrespondingAuthor correspondingAuthor = manuscript.getCorrespondingAuthor();
         correspondingAuthor.author = new Author((String) dataForXML.remove(Manuscript.CORRESPONDING_AUTHOR));
         correspondingAuthor.email = parseEmailAddress((String) dataForXML.remove(Manuscript.EMAIL));
-        correspondingAuthor.author.identifier = (String) dataForXML.remove(Manuscript.CORRESPONDING_AUTHOR_ORCID);
-        if (correspondingAuthor.author.identifier != null) {
-            correspondingAuthor.author.identifierType = "ORCID";
+        correspondingAuthor.author.setIdentifier((String) dataForXML.remove(Manuscript.CORRESPONDING_AUTHOR_ORCID));
+        if (correspondingAuthor.author.getIdentifier() != null) {
+            correspondingAuthor.author.setIdentifierType("ORCID");
         }
 
         correspondingAuthor.address = new Address();

--- a/dspace/modules/journal-submit/src/test/java/org/datadryad/submission/EmailParserTest.java
+++ b/dspace/modules/journal-submit/src/test/java/org/datadryad/submission/EmailParserTest.java
@@ -67,85 +67,85 @@ public class EmailParserTest extends TestCase{
         List<Author> test1 = EmailParser.parseAuthorList("Pawel Lichocki; Dr. Danesh Tarapore; Laurent Keller, PhD; Dario Floreano, Ph.D.");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(4,test1.size());
-        assertEquals("Lichocki, Pawel",test1.get(0).fullName());
-        assertEquals("Tarapore, Danesh", test1.get(1).fullName());
-        assertEquals("Keller, Laurent", test1.get(2).fullName());
-        assertEquals("Floreano, Dario", test1.get(3).fullName());
+        assertEquals("Lichocki, Pawel",test1.get(0).getUnicodeFullName());
+        assertEquals("Tarapore, Danesh", test1.get(1).getUnicodeFullName());
+        assertEquals("Keller, Laurent", test1.get(2).getUnicodeFullName());
+        assertEquals("Floreano, Dario", test1.get(3).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("Wiens, Delbert; Slaton, Michele");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(2,test1.size());
-        assertEquals("Wiens, Delbert", test1.get(0).fullName());
-        assertEquals("Slaton, Michele",test1.get(1).fullName());
+        assertEquals("Wiens, Delbert", test1.get(0).getUnicodeFullName());
+        assertEquals("Slaton, Michele",test1.get(1).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("Thierry Brevault");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(1,test1.size());
-        assertEquals("Brevault, Thierry",test1.get(0).fullName());
+        assertEquals("Brevault, Thierry",test1.get(0).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("Riou, Samuel; Combreau, Olivier; Judas, Jacky; Lawrence, Mark; Pitra, Christian");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(5, test1.size());
-        assertEquals("Riou, Samuel",test1.get(0).fullName());
-        assertEquals("Combreau, Olivier",test1.get(1).fullName());
-        assertEquals("Judas, Jacky", test1.get(2).fullName());
-        assertEquals("Lawrence, Mark",test1.get(3).fullName());
-        assertEquals("Pitra, Christian",test1.get(4).fullName());
+        assertEquals("Riou, Samuel",test1.get(0).getUnicodeFullName());
+        assertEquals("Combreau, Olivier",test1.get(1).getUnicodeFullName());
+        assertEquals("Judas, Jacky", test1.get(2).getUnicodeFullName());
+        assertEquals("Lawrence, Mark",test1.get(3).getUnicodeFullName());
+        assertEquals("Pitra, Christian",test1.get(4).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("Veselin Kostadinov");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(1,test1.size());
-        assertEquals("Kostadinov, Veselin",test1.get(0).fullName());
+        assertEquals("Kostadinov, Veselin",test1.get(0).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("Elizabeth Garrett, Frances Parker, and Winslow Parker");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(3,test1.size());
-        assertEquals("Garrett, Elizabeth",test1.get(0).fullName());
-        assertEquals("Parker, Frances",test1.get(1).fullName());
-        assertEquals("Parker, Winslow", test1.get(2).fullName());
+        assertEquals("Garrett, Elizabeth",test1.get(0).getUnicodeFullName());
+        assertEquals("Parker, Frances",test1.get(1).getUnicodeFullName());
+        assertEquals("Parker, Winslow", test1.get(2).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("J. David");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(1,test1.size());
-        assertEquals("David, J.",test1.get(0).fullName());
+        assertEquals("David, J.",test1.get(0).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("Lacy, Robert");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(1,test1.size());
-        assertEquals("Lacy, Robert",test1.get(0).fullName());
+        assertEquals("Lacy, Robert",test1.get(0).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("Bono, Sonny; Cher");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(2,test1.size());
-        assertEquals("Bono, Sonny",test1.get(0).fullName());
-        assertEquals("Cher",test1.get(1).fullName());
+        assertEquals("Bono, Sonny",test1.get(0).getUnicodeFullName());
+        assertEquals("Cher",test1.get(1).getUnicodeFullName());
         test1 = EmailParser.parseAuthorList("Sonny Bono and Cher");
         assertNotNull(test1);
         for(Author a : test1) {
-            System.out.println("test1 has " + a.fullName());
+            System.out.println("test1 has " + a.getUnicodeFullName());
         }
         assertEquals(2,test1.size());
-        assertEquals("Bono, Sonny",test1.get(0).fullName());
-        assertEquals("Cher",test1.get(1).fullName());
+        assertEquals("Bono, Sonny",test1.get(0).getUnicodeFullName());
+        assertEquals("Cher",test1.get(1).getUnicodeFullName());
     }
 
 


### PR DESCRIPTION
When setting up search queries, use normalized characters, not unicode ones. Also, increase the relevancy score threshold to 3.0.