### PR TITLE
Funding display fix

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -40,6 +40,7 @@ import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.app.xmlui.wing.element.Para;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
+import org.dspace.content.authority.Choices;
 import org.dspace.content.crosswalk.CrosswalkException;
 import org.dspace.content.crosswalk.DisseminationCrosswalk;
 import org.dspace.core.ConfigurationManager;
@@ -351,7 +352,9 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
             }
 
             for (DCValue metadata : item.getMetadata("dryad.fundingEntity")) {
-                pageMeta.addMetadata("dryad", "fundingEntity").addContent(metadata.value);
+                if (metadata.confidence == Choices.CF_ACCEPTED) {
+                    pageMeta.addMetadata("dryad", "fundingEntity").addContent(metadata.value);
+                }
             }
             // Data file metadata included on data package items (integrated view)
             for (DCValue metadata : item.getMetadata("dc.relation.haspart")) {

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/InternalItemTransformer.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/InternalItemTransformer.java
@@ -15,6 +15,7 @@ import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.*;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.content.authority.Choices;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
@@ -106,7 +107,9 @@ public class InternalItemTransformer extends AbstractDSpaceTransformer {
         pageMeta.addTrail().addContent(T_internal_trail);
         pageMeta.addMetadata("authors", "package").addContent(DryadWorkflowUtils.getAuthors(item));
         for (DCValue metadata : item.getMetadata("dryad.fundingEntity")) {
-            pageMeta.addMetadata("dryad", "fundingEntity").addContent(metadata.value);
+            if (metadata.confidence == Choices.CF_ACCEPTED) {
+                pageMeta.addMetadata("dryad", "fundingEntity").addContent(metadata.value);
+            }
         }
     }
 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -609,7 +609,7 @@
                         <xsl:if test="$funder">
                             <tr>
                                 <xsl:call-template name="make-funding-string">
-                                    <xsl:with-param name="funder" select="$funder"/>
+                                    <xsl:with-param name="InputString" select="$funder"/>
                                 </xsl:call-template>
                             </tr>
                         </xsl:if>
@@ -3015,41 +3015,18 @@
     </xsl:template>
 
     <xsl:template name="make-funding-string">
-        <xsl:param name="funder"/>
-        <!-- the funder@fundingEntity node is packed by DryadWorkflowUtils.getAuthors()-->
-        <!-- format is @12345678@#National Science Foundation (United States)#,@12345678@#National Science Foundation (United States)#-->
-        <!-- comma-delimited, with each name offset by @ and orcid offset by #, tailing comma-->
-        <xsl:call-template name="format-funding-strings">
-            <xsl:with-param name="InputString" select="$funder"/>
-        </xsl:call-template>
-    </xsl:template>
-
-    <xsl:template name="format-funding-strings">
-        <!--@12345678@#National Science Foundation (United States)#,@12345678@#National Science Foundation (United States)#-->
+        <!-- Funding strings are in the format 'grantnumber@FunderName (country)'-->
         <xsl:param name="InputString"/>
         <xsl:choose>
-            <xsl:when test="contains($InputString, ',')">
-                <xsl:choose>
-                    <!-- There is only one name, but there's still a comma after-->
-                    <xsl:when test="substring-after($InputString,',') = ''">
-                        <xsl:call-template name="format-funding-strings">
-                            <xsl:with-param name="InputString" select="substring-before($InputString,',')"/>
-                        </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <!-- There are multiple names -->
-                        <xsl:call-template name="format-single-funder">
-                            <xsl:with-param name="nameString" select="substring-before($InputString,',')"/>
-                        </xsl:call-template>
-                        <xsl:call-template name="format-funding-strings">
-                            <xsl:with-param name="InputString" select="substring-after($InputString,',')"/>
-                        </xsl:call-template>
-                    </xsl:otherwise>
-                </xsl:choose>
+            <!-- This test is for pre-DryadFundingConcept packages: they don't have the funder packed into the metadata; we assumed that US NSF was the only funder.-->
+            <xsl:when test="contains($InputString, '@')">
+                <xsl:call-template name="format-single-funder">
+                    <xsl:with-param name="nameString" select="$InputString"/>
+                </xsl:call-template>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:call-template name="format-single-funder">
-                    <xsl:with-param name="nameString" select="$InputString"/>
+                    <xsl:with-param name="nameString" select="concat($InputString,'@National Science Foundation (United States)')"/>
                 </xsl:call-template>
             </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
I just realized that #1209 will badly display already-existing funding metadata, because it is not formatted as expected for DryadFunderConcepts. In addition, we probably don’t want to display funding information for items that have non-verifiable funding info entered, like nonsense strings or non-NSF grants (because we haven’t allowed for a mechanism to enter those yet). This PR fixes these issues until we can go back and fix up the metadata of all of the packages that we received during the pilot study.