### PR TITLE
Fixes for funder info at datacite

### DIFF
--- a/dspace/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl
@@ -73,6 +73,13 @@
 				<xsl:text>0000</xsl:text>
 			</publicationYear>
 
+			<!-- ************ Subjects ************** -->
+			<subjects>
+				<subject>
+					<xsl:text>(:tba)</xsl:text>
+				</subject>
+			</subjects>
+
 			<!-- ************ Funding information ************** -->
 			<xsl:if test="dspace:field[@element='fundingEntity']">
 				<contributors>
@@ -90,13 +97,6 @@
 					</xsl:for-each>
 				</contributors>
 			</xsl:if>
-
-			<!-- ************ Subjects ************** -->
-			<subjects>
-				<subject>
-					<xsl:text>(:tba)</xsl:text>
-				</subject>
-			</subjects>
 
 			<!-- ************ Dates - Only for Data Files ************** -->
 			<xsl:if test="$datatype='DataFile'">

--- a/dspace/config/crosswalks/DIM2DATACITE.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE.xsl
@@ -95,24 +95,6 @@
 	            </xsl:for-each>
 	        </xsl:if>
 
-			<!-- ************ Funding information ************** -->
-			<xsl:if test="dspace:field[@element='fundingEntity']">
-				<contributors>
-					<xsl:for-each select="dspace:field[@element='fundingEntity']">
-						<xsl:variable name="funderName" select="substring-after(.,'@')"/>
-						<xsl:variable name="funderID" select="substring-after(./@authority, 'http://dx.doi.org/')"/>
-						<contributor contributorType="Funder">
-							<contributorName>
-								<xsl:value-of select="$funderName"/>
-							</contributorName>
-							<nameIdentifier nameIdentifierScheme="FundRef">
-								<xsl:value-of select="$funderID"/>
-							</nameIdentifier>
-						</contributor>
-					</xsl:for-each>
-				</contributors>
-			</xsl:if>
-	
 		    <!-- ************ Subjects ************** -->
 	        <xsl:if test="dspace:field[@element ='subject' or @element='coverage']">
 	            <subjects>
@@ -133,6 +115,24 @@
 	                </xsl:for-each>
 	            </subjects>
 	        </xsl:if>
+			<!-- ************ Funding information ************** -->
+			<xsl:if test="dspace:field[@element='fundingEntity']">
+				<contributors>
+					<xsl:for-each select="dspace:field[@element='fundingEntity']">
+						<xsl:variable name="funderName" select="substring-after(.,'@')"/>
+						<xsl:variable name="funderID" select="substring-after(./@authority, 'http://dx.doi.org/')"/>
+						<contributor contributorType="Funder">
+							<contributorName>
+								<xsl:value-of select="$funderName"/>
+							</contributorName>
+							<nameIdentifier nameIdentifierScheme="FundRef">
+								<xsl:value-of select="$funderID"/>
+							</nameIdentifier>
+						</contributor>
+					</xsl:for-each>
+				</contributors>
+			</xsl:if>
+
 			<!-- ************ Dates - Only for Data Files ************** -->
 			<xsl:if test="$datatype='DataFile'">
 				<dates>

--- a/dspace/etc/upgrades/funder-updates.py
+++ b/dspace/etc/upgrades/funder-updates.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# Updates conceptmetadatavalue table to use the latest schemas as of August 2016.
+
+__author__ = 'daisieh'
+
+import re
+import os
+import sys
+import shutil
+import hashlib
+
+def rows_from_query(sql):
+    # Now execute it
+    cmd = "psql -A -U dryad_app dryad_repo -c \"%s\"" % sql
+    output = [line.strip().split('|') for line in os.popen(cmd).readlines()]
+    if len(output) <= 2: # the output should have at least 3 lines: header, body rows, number of rows
+        return None
+    else:
+        return output[1:-1]
+
+def update_funder(metadata_value_id, fundingEntity):
+    m = re.search('(.*)@National Science Foundation \(United States\)', fundingEntity)
+    if m is None:
+        new_val = fundingEntity + "@National Science Foundation (United States)"
+#         print new_val
+        sql = "update metadatavalue set text_value = '%s' where metadata_value_id =%s" % (new_val, metadata_value_id)
+        cmd = "psql -U dryad_app dryad_repo -c \"%s\"" % sql
+        print os.popen(cmd).read()
+
+def main():
+    fundingEntities = rows_from_query("select text_value, metadata_value_id from metadatavalue where metadata_field_id = 146")
+    for funder in fundingEntities:
+        update_funder(funder[1], funder[0])
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
The python script updates the database entries for old dryad.fundingEntity entries. The crosswalk fixes are because subjects have to come before contributors.

This has already been implemented on production, so it def works.