### PR TITLE
Auth token for APU

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2663,3 +2663,5 @@ landing-page.stats.query.pool-size=3
 landing-page.stats.query.timeout=10000
 landing-page.stats.item-count = 50
 
+### PUBLICATION UPDATER CONFIGURATION
+publication.updater.token = ${default.publication.updater.token}

--- a/dspace/modules/publication-updater/pom.xml
+++ b/dspace/modules/publication-updater/pom.xml
@@ -132,6 +132,12 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.3.4</version>
+		</dependency>
+
 	</dependencies>
 	<properties>
 		<jackson.version>2.6.4</jackson.version>

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -1,6 +1,7 @@
 package org.datadryad.publication;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.NameValuePair;
 import org.apache.log4j.Logger;
 import org.datadryad.rest.models.*;
 import org.dspace.content.*;
@@ -25,10 +26,12 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.*;
 import java.lang.RuntimeException;
+import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import org.apache.http.client.utils.URLEncodedUtils;
 
 /**
  * Updates items' associated publication metadata with the latest metadata from either journal-provided metadata or from CrossRef.
@@ -65,21 +68,59 @@ public class PublicationUpdater extends HttpServlet {
             LOGGER.info("manually checking publications");
             String queryString = aRequest.getQueryString();
             if (queryString != null) {
-                DryadJournalConcept journalConcept = JournalUtils.getJournalConceptByJournalID(queryString);
-                if (journalConcept == null) {
-                    journalConcept = JournalUtils.getJournalConceptByISSN(queryString);
+                List<NameValuePair> queryParams = null;
+                try {
+                    queryParams = URLEncodedUtils.parse(queryString, Charset.defaultCharset());
+                } catch (Exception e) {
+                    aResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "could not parse query string");
                 }
-                if (journalConcept != null) {
-                    checkSinglePublication(journalConcept);
+                if (isAuthorized(queryParams)) {
+                    String issn = getISSN(queryParams);
+                    if (issn != null) {
+                        DryadJournalConcept journalConcept = JournalUtils.getJournalConceptByJournalID(issn);
+                        if (journalConcept == null) {
+                            journalConcept = JournalUtils.getJournalConceptByISSN(issn);
+                        }
+                        if (journalConcept != null) {
+                            checkSinglePublication(journalConcept);
+                        } else {
+                            aResponse.sendError(HttpServletResponse.SC_NOT_FOUND, "no journal concept found by the identifier " + issn);
+                        }
+                    } else {
+                        checkPublications();
+                    }
                 } else {
-                    aResponse.sendError(HttpServletResponse.SC_NOT_FOUND, "no journal concept found by the identifier " + queryString);
+                    aResponse.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "no or incorrect authorization token provided");
                 }
-            } else {
-                checkPublications();
             }
         } else {
             aResponse.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "parameter not available for GET");
         }
+    }
+
+    private boolean isAuthorized(List<NameValuePair> queryParams) {
+        for (NameValuePair param : queryParams) {
+            if (param.getName().equals("auth")) {
+                String token = ConfigurationManager.getProperty("publication.updater.token");
+                if (token != null && param.getValue() != null) {
+                    if (token.equals(param.getValue())) {
+                        return true;
+                    }
+                } else {
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
+
+    private String getISSN(List<NameValuePair> queryParams) {
+        for (NameValuePair param : queryParams) {
+            if (param.getName().equals("issn")) {
+                return param.getValue();
+            }
+        }
+        return null;
     }
 
     private void checkPublications() {

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -65,8 +65,8 @@ public class PublicationUpdater extends HttpServlet {
                          HttpServletResponse aResponse) throws ServletException, IOException {
         String requestURI = aRequest.getRequestURI();
         if (requestURI.contains("retrieve")) {
-            LOGGER.info("manually checking publications");
             String queryString = aRequest.getQueryString();
+            LOGGER.info("Automatic Publication Updater running with query " + queryString);
             if (queryString != null) {
                 List<NameValuePair> queryParams = null;
                 try {
@@ -93,6 +93,7 @@ public class PublicationUpdater extends HttpServlet {
                     aResponse.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "no or incorrect authorization token provided");
                 }
             }
+            LOGGER.info("Automatic Publication Updater finished");
         } else {
             aResponse.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "parameter not available for GET");
         }


### PR DESCRIPTION
Set default.publication.updater.token in your machine’s maven settings. Then you should be able to run publication-updater/retrieve?auth=<your token>. Without the token, it won’t work.