### PR TITLE
Remove Elementa from the Lookup table and Membership List

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/static/json/journal-lookup.json
+++ b/dspace/modules/xmlui/src/main/webapp/static/json/journal-lookup.json
@@ -254,15 +254,6 @@
      },
      {
         "integrated" : "Y",
-        "submission" : "A",
-        "issn" : "2325-1026",
-        "embargo" : "Y",
-        "hidden" : "Y",
-        "title" : "Elementa: Science of the Anthropocene",
-        "sponsor" : "BioOne"
-     },
-     {
-        "integrated" : "Y",
         "hidden" : "Y",
         "submission" : "R",
         "issn" : "2050-084X",

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipOverview.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/membershipOverview.xhtml
@@ -122,8 +122,6 @@
             <li><a href="http://www.britishecologicalsociety.org/">British Ecological Society</a> <span class="charter-mark">*</span></li>
             <li><a href="http:///bmjopen.bmj.com">BMJ Publishing Group, Ltd.</a><span class="charter-mark">*</span></li>
             <li><a href="http://www.cambridge.org/">Cambridge University Press</a></li>
-            <li><a href="http://elementascience.org/">Elementa: Science of the Anthropocene</a></li>
-
             <li><a href="http://www.eseb.org/">European Society for Evolutionary Biology</a> <span class="charter-mark">*</span></li>
             <li><a href="http://www.nature.com/hdy/">The Genetics Society</a><span class="charter-mark">*</span></li>
             <li><a href="http://www.zbmed.de/en/">German National Libary of Medicine</a></li>


### PR DESCRIPTION
Remove 'Elementa: Science of the Anthropocene' from 'Look up your journal' (http://datadryad.org/pages/journalLookup) and 'Dryad Membership: Members' (http://datadryad.org/pages/membershipOverview) to reflect that they are no longer integrated or sponsored (https://trello.com/c/K34v1jWa/8-elementa).