### PR TITLE
add getters for GivenNames and FamilyName

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Author.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Author.java
@@ -107,6 +107,15 @@ public class Author {
         return getUnicodeFullName();
     }
 
+    public String getFamilyName() {
+        return getUnicodeFamilyName();
+    }
+
+    public String getGivenNames() {
+        return getUnicodeGivenNames();
+    }
+
+
     @JsonIgnore
     public final String getHTMLFullName() {
         String name = getHTMLFamilyName();


### PR DESCRIPTION
This should fix https://trello.com/c/EaYLy9h7/501-article-metadata-for-integrated-journals-not-pre-populating.