### PR TITLE
Add dryad.citationMismatchedDOI

### DIFF
--- a/dspace/config/registries/dryad-types.xml
+++ b/dspace/config/registries/dryad-types.xml
@@ -34,6 +34,10 @@
     </dc-type>
     <dc-type>
         <schema>dryad</schema>
+        <element>citationMismatchedDOI</element>
+    </dc-type>
+    <dc-type>
+        <schema>dryad</schema>
         <element>fundingEntity</element>
     </dc-type>
     <dc-type>


### PR DESCRIPTION
Already installed on production, but should be in the codebase.