### PR TITLE
Remove "ms dryad id" as a matching field for manuscript ID

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
@@ -43,7 +43,7 @@ public class EmailParser {
         fieldToXMLTagMap.put("journal code", Manuscript.JOURNAL_CODE);
         fieldToXMLTagMap.put("article status", Manuscript.ARTICLE_STATUS);
         fieldToXMLTagMap.put("manuscript number", Manuscript.MANUSCRIPT);
-        fieldToXMLTagMap.put("ms dryad id", Manuscript.MANUSCRIPT);
+//        fieldToXMLTagMap.put("ms dryad id", Manuscript.MANUSCRIPT);
         fieldToXMLTagMap.put("ms reference number", Manuscript.MANUSCRIPT);
         fieldToXMLTagMap.put("ms title", Manuscript.ARTICLE_TITLE);
         fieldToXMLTagMap.put("article title", Manuscript.ARTICLE_TITLE);


### PR DESCRIPTION
Tiny change. Probably doesn’t need testing.