### PR TITLE
Correct IsReferencedBy field for PMIDs

### DIFF
--- a/dspace/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl
@@ -143,12 +143,17 @@
 				        </relatedIdentifier>
 				    </xsl:for-each>
 				    <xsl:for-each select="dspace:field[@element='relation' and @qualifier='isreferencedby']">
-						<relatedIdentifier relatedIdentifierType="DOI" relationType="IsReferencedBy">
-							<xsl:variable name="id" select="."/>
-							<xsl:if test="starts-with($id,'doi')">
-								<xsl:value-of select="translate(substring-after($id,'doi:'), $smallcase, $uppercase)"/>
-							</xsl:if>
-						</relatedIdentifier>
+				      <xsl:variable name="id" select="."/>
+				      <xsl:if test="starts-with($id,'doi')">
+					<relatedIdentifier relatedIdentifierType="DOI" relationType="IsReferencedBy">
+					  <xsl:value-of select="translate(substring-after($id,'doi:'), $smallcase, $uppercase)"/>
+					</relatedIdentifier>
+				      </xsl:if>
+				      <xsl:if test="starts-with($id,'PMID')">
+					<relatedIdentifier relatedIdentifierType="PMID" relationType="IsReferencedBy">
+					  <xsl:value-of select="translate(substring-after($id,'PMID:'), $smallcase, $uppercase)"/>
+					</relatedIdentifier>
+				      </xsl:if>
 				    </xsl:for-each>
 				</relatedIdentifiers>
 			</xsl:if>

--- a/dspace/config/crosswalks/DIM2DATACITE.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE.xsl
@@ -216,12 +216,17 @@
 				        </relatedIdentifier>
 				    </xsl:for-each>
 				    <xsl:for-each select="dspace:field[@element='relation' and @qualifier='isreferencedby']">
-						<relatedIdentifier relatedIdentifierType="DOI" relationType="IsReferencedBy">
-							<xsl:variable name="id" select="."/>
-							<xsl:if test="starts-with($id,'doi')">
-								<xsl:value-of select="translate(substring-after($id,'doi:'), $smallcase, $uppercase)"/>
-							</xsl:if>
-						</relatedIdentifier>
+				      <xsl:variable name="id" select="."/>
+				      <xsl:if test="starts-with($id,'doi')">
+					<relatedIdentifier relatedIdentifierType="DOI" relationType="IsReferencedBy">
+					  <xsl:value-of select="translate(substring-after($id,'doi:'), $smallcase, $uppercase)"/>
+					</relatedIdentifier>
+				      </xsl:if>
+				      <xsl:if test="starts-with($id,'PMID')">
+					<relatedIdentifier relatedIdentifierType="PMID" relationType="IsReferencedBy">
+					  <xsl:value-of select="translate(substring-after($id,'PMID:'), $smallcase, $uppercase)"/>
+					</relatedIdentifier>
+				      </xsl:if>
 				    </xsl:for-each>
 					<xsl:if test="$version > 1">
 						<xsl:variable name="canonical-doi">


### PR DESCRIPTION
When an item contains a PMID, the DataCite transforms were creating an empty
element with an IsReferencedBy attribute. This will produce the desired PMID entry.

Corrects issue noted in https://trello.com/c/PvjexKls

To verify:
```
    curl http://datadryad.org/resource/doi:10.5061/dryad.20/mets.xml >item.xml
    xsltproc -o datacite.xml /opt/dryad/config/crosswalks/DIM2DATACITE.xsl item.xml
```
Before this change the datacite.xml will contain a blank IsReferencedBy relation; after the change it will correctly contain a relation with the PMID.
