### PR TITLE
Only add funding info if the confidence is 'ACCEPTED'

### DIFF
--- a/dspace/config/crosswalks/DIM2DATACITE.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE.xsl
@@ -133,19 +133,22 @@
 	            </subjects>
 	        </xsl:if>
 			<!-- ************ Funding information ************** -->
-			<xsl:if test="dspace:field[@element='fundingEntity']">
+			<xsl:if test="dspace:field[@element='fundingEntity' and @confidence='ACCEPTED']">
 				<contributors>
 					<xsl:for-each select="dspace:field[@element='fundingEntity']">
 						<xsl:variable name="funderName" select="substring-after(.,'@')"/>
 						<xsl:variable name="funderID" select="substring-after(./@authority, 'http://dx.doi.org/')"/>
-						<contributor contributorType="Funder">
-							<contributorName>
-								<xsl:value-of select="$funderName"/>
-							</contributorName>
-							<nameIdentifier nameIdentifierScheme="FundRef">
-								<xsl:value-of select="$funderID"/>
-							</nameIdentifier>
-						</contributor>
+						<xsl:variable name="confidence" select="./@confidence"/>
+						<xsl:if test="$confidence='ACCEPTED'">
+							<contributor contributorType="Funder">
+								<contributorName>
+									<xsl:value-of select="$funderName"/>
+								</contributorName>
+								<nameIdentifier nameIdentifierScheme="FundRef">
+									<xsl:value-of select="$funderID"/>
+								</nameIdentifier>
+							</contributor>
+						</xsl:if>
 					</xsl:for-each>
 				</contributors>
 			</xsl:if>


### PR DESCRIPTION
To test, validate a package with good funding information through the xsl crosswalk, and validate a package with bad funding info. Good funding info will be in the datacite metadata, bad funding info won't.

Good funding info: http://datadryad.org/resource/doi:10.5061/dryad.5c1tj
Bad funding info: http://datadryad.org/resource/doi:10.5061/dryad.7vt36