### PR TITLE
Special parser for MS Dryad ID instead of MS Reference Number

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForMSDryadID.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForMSDryadID.java
@@ -3,10 +3,10 @@ package org.datadryad.submission;
 import org.datadryad.rest.models.Manuscript;
 
 /**
- * Modifies EmailParserForManuscriptCentral for certain Wiley journals that use MS Dryad ID for
+ * Modifies EmailParserForManuscriptCentral for certain journals that use MS Dryad ID for
  * Dryad internal ms numbers instead of the standard MS Reference Number.
  */
-public class EmailParserForWiley extends EmailParserForManuscriptCentral {
+public class EmailParserForMSDryadID extends EmailParserForManuscriptCentral {
     static {
         fieldToXMLTagMap.put("ms reference number", UNNECESSARY);
         fieldToXMLTagMap.put("ms dryad id", Manuscript.MANUSCRIPT);

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForWiley.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForWiley.java
@@ -1,0 +1,14 @@
+package org.datadryad.submission;
+
+import org.datadryad.rest.models.Manuscript;
+
+/**
+ * Modifies EmailParserForManuscriptCentral for certain Wiley journals that use MS Dryad ID for
+ * Dryad internal ms numbers instead of the standard MS Reference Number.
+ */
+public class EmailParserForWiley extends EmailParserForManuscriptCentral {
+    static {
+        fieldToXMLTagMap.put("ms reference number", UNNECESSARY);
+        fieldToXMLTagMap.put("ms dryad id", Manuscript.MANUSCRIPT);
+    }
+}


### PR DESCRIPTION
JEB and BJLS use the MS Dryad ID field for their msid that they use in their links, so we need to use that too. 

When this is deployed, update the concepts for those journals so that they use `.*?(\d+BJLS-\d+).*?` as the journal.canonicalManuscriptNumberPattern and `MSDryadID` for journal.parsingScheme. Some manuscript database entries may need to be updated as well.