### PR TITLE
APU fixes

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -607,7 +607,8 @@ public class JournalUtils {
         }
         JsonNode titleNode = jsonNode.path("title");
         if (titleNode.isArray()) {
-            manuscript.setTitle(titleNode.elements().next().textValue().replace("\n", " "));
+            String trimmedTitle = titleNode.elements().next().textValue().replace("\n", " ").replaceAll("\\s+", " ");
+            manuscript.setTitle(trimmedTitle);
         }
         if (jsonNode.path("publisher") != null) {
             manuscript.setPublisher(jsonNode.path("publisher").textValue());

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -607,7 +607,7 @@ public class JournalUtils {
         }
         JsonNode titleNode = jsonNode.path("title");
         if (titleNode.isArray()) {
-            manuscript.setTitle(titleNode.elements().next().textValue());
+            manuscript.setTitle(titleNode.elements().next().textValue().replace("\n", " "));
         }
         if (jsonNode.path("publisher") != null) {
             manuscript.setPublisher(jsonNode.path("publisher").textValue());

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -546,8 +546,10 @@ public class JournalUtils {
             matchedManuscript.optionalProperties.put("crossref-score", String.valueOf(matchScore));
             // for now, scores greater than 0.5 seem to be a match. Keep an eye on this.
             if (matchScore < 0.5) {
-                resultString.append("\"" + queryManuscript.getTitle() + "\" matched \"" + matchedManuscript.getTitle() + "\" with score " + matchScore);
+                resultString.append("BAD MATCH: \"" + queryManuscript.getTitle() + "\" matched \"" + matchedManuscript.getTitle() + "\" with score " + matchScore);
                 return null;
+            } else {
+                resultString.append("GOOD MATCH: \"" + queryManuscript.getTitle() + "\" matched \"" + matchedManuscript.getTitle() + "\" with score " + matchScore);
             }
         }
         return matchedManuscript;

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -496,7 +496,6 @@ public class PublicationUpdater extends HttpServlet {
 
         DCValue[] itemPubDOIs = item.getMetadata(PUBLICATION_DOI);
         if (itemPubDOIs != null && itemPubDOIs.length > 0 && !"".equals(itemPubDOIs[0].value)) {
-//            LOGGER.debug("found a DOI <" + itemPubDOIs[0].value + ">");
             queryManuscript.setPublicationDOI(itemPubDOIs[0].value);
         }
         return queryManuscript;
@@ -504,7 +503,7 @@ public class PublicationUpdater extends HttpServlet {
 
     private boolean updateItemMetadataFromManuscript(Item item, Manuscript manuscript, Context context, StringBuilder provenance) {
         HashSet<String> fieldsChanged = new HashSet<String>();
-        LOGGER.debug("updating metadata for item " + item.getID() + " to manuscript " + manuscript.toString());
+        LOGGER.debug("comparing metadata for item " + item.getID() + " to manuscript " + manuscript.toString());
         // first, check to see if this is one of the known mismatches:
         if (isManuscriptMismatchForItem(item, manuscript)) {
             LOGGER.error("pub " + manuscript.getPublicationDOI() + " is known to be a mismatch for " + item.getID());

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -496,7 +496,7 @@ public class PublicationUpdater extends HttpServlet {
 
         DCValue[] itemPubDOIs = item.getMetadata(PUBLICATION_DOI);
         if (itemPubDOIs != null && itemPubDOIs.length > 0 && !"".equals(itemPubDOIs[0].value)) {
-            LOGGER.debug("found a DOI <" + itemPubDOIs[0].value + ">");
+//            LOGGER.debug("found a DOI <" + itemPubDOIs[0].value + ">");
             queryManuscript.setPublicationDOI(itemPubDOIs[0].value);
         }
         return queryManuscript;

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -210,6 +210,8 @@ public class PublicationUpdater extends HttpServlet {
                 LocalDate dateItemModified = item.getLastModified().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
                 if (dateItemModified.isAfter(twoYearsAgo)) {
                     items.add(wfi);
+                } else {
+                    LOGGER.debug("skipping item " + item.getID() + " because it's too old");
                 }
             }
             LOGGER.debug("processing " + items.size() + " items");

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -300,20 +300,25 @@ public class PublicationUpdater extends HttpServlet {
             String score = matchedManuscript.optionalProperties.get("crossref-score");
             if (!"".equals(queryManuscript.getPublicationDOI())){
                 LOGGER.debug("matching with given publication DOI " + queryManuscript.getPublicationDOI());
-            }
-            LOGGER.debug("Item \"" + queryManuscript.getTitle() + "\" matched a title \"" + matchedManuscript.getTitle() + "\" with score " + score);
-            LOGGER.debug("matched publication DOI is " + matchedManuscript.getPublicationDOI());
-            // does the matched manuscript have the same authors?
-            StringBuilder authormatches = new StringBuilder();
-            if (JournalUtils.compareItemAuthorsToManuscript(item, matchedManuscript, authormatches)) {
-                LOGGER.debug("same authors");
-                // update the item's metadata
-                StringBuilder provenance = new StringBuilder("Associated publication (match score " + score + ") was found: \"" + matchedManuscript.getTitle() + "\".");
+                StringBuilder provenance = new StringBuilder("Associated publication for doi " + queryManuscript.getPublicationDOI() + " was found: \"" + matchedManuscript.getTitle() + "\".");
                 if (updateItemMetadataFromManuscript(item, matchedManuscript, context, provenance)) {
                     message = provenance;
                 }
             } else {
-                LOGGER.debug("different authors: " + authormatches);
+                LOGGER.debug("Item \"" + queryManuscript.getTitle() + "\" matched a title \"" + matchedManuscript.getTitle() + "\" with score " + score);
+                LOGGER.debug("matched publication DOI is " + matchedManuscript.getPublicationDOI());
+                // does the matched manuscript have the same authors?
+                StringBuilder authormatches = new StringBuilder();
+                if (JournalUtils.compareItemAuthorsToManuscript(item, matchedManuscript, authormatches)) {
+                    LOGGER.debug("same authors");
+                    // update the item's metadata
+                    StringBuilder provenance = new StringBuilder("Associated publication (match score " + score + ") was found: \"" + matchedManuscript.getTitle() + "\".");
+                    if (updateItemMetadataFromManuscript(item, matchedManuscript, context, provenance)) {
+                        message = provenance;
+                    }
+                } else {
+                    LOGGER.debug("different authors: " + authormatches);
+                }
             }
         } else {
             LOGGER.debug("Item \"" + queryManuscript.getTitle() + "\" didn't match anything in crossref");

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -307,17 +307,25 @@ public class PublicationUpdater extends HttpServlet {
             } else {
                 LOGGER.debug("Item \"" + queryManuscript.getTitle() + "\" matched a title \"" + matchedManuscript.getTitle() + "\" with score " + score);
                 LOGGER.debug("matched publication DOI is " + matchedManuscript.getPublicationDOI());
-                // does the matched manuscript have the same authors?
-                StringBuilder authormatches = new StringBuilder();
-                if (JournalUtils.compareItemAuthorsToManuscript(item, matchedManuscript, authormatches)) {
-                    LOGGER.debug("same authors");
-                    // update the item's metadata
-                    StringBuilder provenance = new StringBuilder("Associated publication (match score " + score + ") was found: \"" + matchedManuscript.getTitle() + "\".");
+                if (Double.valueOf(score) < 1.0) {
+                    // does the matched manuscript have the same authors?
+                    StringBuilder authormatches = new StringBuilder();
+                    if (JournalUtils.compareItemAuthorsToManuscript(item, matchedManuscript, authormatches)) {
+                        LOGGER.debug("same authors");
+                        // update the item's metadata
+                        StringBuilder provenance = new StringBuilder("Associated publication (match score " + score + ") was found: \"" + matchedManuscript.getTitle() + "\".");
+                        if (updateItemMetadataFromManuscript(item, matchedManuscript, context, provenance)) {
+                            message = provenance;
+                        }
+                    } else {
+                        LOGGER.debug("different authors: " + authormatches);
+                    }
+                } else {
+                    LOGGER.debug("perfect title match");
+                    StringBuilder provenance = new StringBuilder("Associated publication with perfect title match was found: \"" + matchedManuscript.getTitle() + "\".");
                     if (updateItemMetadataFromManuscript(item, matchedManuscript, context, provenance)) {
                         message = provenance;
                     }
-                } else {
-                    LOGGER.debug("different authors: " + authormatches);
                 }
             }
         } else {

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -539,7 +539,7 @@ public class PublicationUpdater extends HttpServlet {
             LOGGER.debug("old citation was: " + itemCitation);
             LOGGER.debug("new citation is: " + manuscript.getFullCitation());
             LOGGER.debug("citation match score is " + score);
-            if (score < 0.9) {
+            if (score < 0.95) {
                 fieldsChanged.add(FULL_CITATION);
                 item.clearMetadata(FULL_CITATION);
                 item.addMetadata(FULL_CITATION, null, manuscript.getFullCitation(), null, -1);

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -30,6 +30,8 @@ import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -202,7 +204,14 @@ public class PublicationUpdater extends HttpServlet {
         LOGGER.debug("finding workflow items");
         try {
             WorkflowItem[] itemArray = WorkflowItem.findAllByISSN(context, dryadJournalConcept.getISSN());
-            items.addAll(Arrays.asList(itemArray));
+            for (WorkflowItem wfi : itemArray) {
+                Item item = wfi.getItem();
+                LocalDate twoYearsAgo = LocalDate.now().minusYears(2);
+                LocalDate dateItemModified = item.getLastModified().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+                if (dateItemModified.isAfter(twoYearsAgo)) {
+                    items.add(wfi);
+                }
+            }
             LOGGER.debug("processing " + items.size() + " items");
         } catch (Exception e) {
             LOGGER.error("couldn't find workflowItems for journal " + dryadJournalConcept.getJournalID());


### PR DESCRIPTION
* if match is based on a known pub DOI, don’t perform additional comparisons, just let it go.
* Increase similarity threshold for citations being equivalent from 0.9 to 0.95.
* Clean up crossref titles that have messy newlines or extra spaces.
