### PR TITLE
EmailParser needs per-instance field map

### DIFF
--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParser.java
@@ -33,9 +33,10 @@ public class EmailParser {
     public static final String UNNECESSARY = "Unnecessary";
 
     // The field to XML-tag mapping table.
-    protected static Map<String, String> fieldToXMLTagMap = new LinkedHashMap<String,String>();
+    protected Map<String, String> fieldToXMLTagMap;
 
-    static {
+    EmailParser() {
+        fieldToXMLTagMap = new LinkedHashMap<String,String>();
         // commonly-used field names for required tags for Manuscript
         fieldToXMLTagMap.put("abstract", Manuscript.ABSTRACT);
         fieldToXMLTagMap.put("journal", Manuscript.JOURNAL);

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForAmNat.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForAmNat.java
@@ -10,7 +10,8 @@ import org.datadryad.rest.models.Manuscript;
  */
 public class EmailParserForAmNat extends EmailParser {
 
-	static {
+	EmailParserForAmNat() {
+		super();
 		// corresponding author information is parsed in a separate chunk
 		fieldToXMLTagMap.put("first name", "Corr_Auth_First_Name");
 		fieldToXMLTagMap.put("middle name", "Corr_Auth_Middle_Name");

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForBmcEvoBio.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForBmcEvoBio.java
@@ -9,7 +9,8 @@ import org.datadryad.rest.models.Manuscript;
 public class EmailParserForBmcEvoBio extends EmailParserForManuscriptCentral {
     
     // static block
-    static {
+    EmailParserForBmcEvoBio() {
+        super();
         fieldToXMLTagMap.put("Author Name",  Manuscript.CORRESPONDING_AUTHOR);
         fieldToXMLTagMap.put("Author Email",  Manuscript.EMAIL);
     }

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForEcoApp.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForEcoApp.java
@@ -6,7 +6,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class EmailParserForEcoApp extends EmailParser {
-	static {
+	EmailParserForEcoApp() {
+		super();
 		// corresponding author tags are parsed separately from the "contact author and address" field
 		fieldToXMLTagMap.put("Contact Author and Address", "Corresponding_Author_Address");
 

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForMSDryadID.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForMSDryadID.java
@@ -7,7 +7,8 @@ import org.datadryad.rest.models.Manuscript;
  * Dryad internal ms numbers instead of the standard MS Reference Number.
  */
 public class EmailParserForMSDryadID extends EmailParserForManuscriptCentral {
-    static {
+    EmailParserForMSDryadID() {
+        super();
         fieldToXMLTagMap.put("ms reference number", UNNECESSARY);
         fieldToXMLTagMap.put("ms dryad id", Manuscript.MANUSCRIPT);
     }

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForManuscriptCentral.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/EmailParserForManuscriptCentral.java
@@ -6,7 +6,8 @@ import org.datadryad.rest.models.Manuscript;
  * The Class EmailParserForManuscriptCentral. Rewritten by Daisie Huang.
  */
 public class EmailParserForManuscriptCentral extends EmailParser {
-    static {
+    EmailParserForManuscriptCentral() {
+        super();
         // optional XML tags
         fieldToXMLTagMap.put("print issn", Manuscript.ISSN);
         fieldToXMLTagMap.put("publication doi", Manuscript.PUBLICATION_DOI);


### PR DESCRIPTION
The EmailParser classes can’t all share the same static field map…each instance should have its own.