### PR TITLE
Rejected funding metadata

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1148,6 +1148,7 @@ webui.licence_bundle.show = false
 metadata.hide.dc.description.provenance = true
 metadata.hide.internal.payment.transactionID = true
 metadata.hide.internal.payment.charge = true
+metadata.hide.dryad.citationInProgress = true
 ##### Settings for Submission Process #####
 
 # Should the submit UI block submissions marked as theses?


### PR DESCRIPTION
Addresses https://trello.com/c/KXsP3y5z/178-do-not-display-rejected-funding-info-in-full-metadata-view

This was a bit hacky to implement, because this is the only case that I know of where we don’t want to view a field on mets.xml *only* if the confidence has a certain value. Therefore, I had to basically turn it off for all mets.xml pages, regardless of the user’s permissions, because I wasn’t sure how else I could neatly intervene.

http://dx.doi.org/10.5061/dryad.7vt36 is an example of an item with both dryad.citationInProgress and a rejected dryad.fundingEntity field.