### PR TITLE
Approval logging

### DIFF
--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -145,8 +145,8 @@ log4j.logger.org.dspace.utils=ERROR
 # Prevent page not loaded warnings from our page loading mechanism
 log4j.logger.org.apache.cocoon.components.xslt=ERROR
 
-# Detailed logging for items being archived
-log4j.logger.org.dspace.content.InstallItem=DEBUG
+# Logging for items being archived
+log4j.logger.org.dspace.content=INFO
 
 # Set Curate package to info-logging
 log4j.logger.org.dspace.curate=INFO

--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -145,6 +145,9 @@ log4j.logger.org.dspace.utils=ERROR
 # Prevent page not loaded warnings from our page loading mechanism
 log4j.logger.org.apache.cocoon.components.xslt=ERROR
 
+# Detailed logging for items being archived
+log4j.logger.org.dspace.content.InstallItem=DEBUG
+
 # Set Curate package to info-logging
 log4j.logger.org.dspace.curate=INFO
 

--- a/dspace/modules/api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/InstallItem.java
@@ -103,13 +103,13 @@ public class InstallItem
 
         
         DCValue[] doiMetadata = item.getMetadata(MetadataSchema.DC_SCHEMA, "identifier", null, Item.ANY);
-        log.info("Archiving item " + item.getID() + " with DOI " + doiMetadata);
+        log.info("Archiving item " + item.getID() + " with DOI " + doiMetadata[0].value);
         
         // this is really just to flush out fatal embargo metadata
         // problems before we set inArchive.
 //        DCDate liftDate = EmbargoManager.getEmbargoDate(c, item);
 
-        log.debug(" -- lifting embargos");
+        log.info(" -- lifting embargos");
         DCDate liftDate = null;
         //Get our embargo date !
         String embargoType = ConfigurationManager.getProperty("embargo.field.type");
@@ -165,7 +165,7 @@ public class InstallItem
         item.clearMetadata("internal", "submit", "showEmbargo", org.dspace.content.Item.ANY);
 
 
-        log.debug(" -- setting dates");
+        log.info(" -- setting dates");
         // create accession date
         DCDate now = DCDate.getCurrent();
         item.addDC("date", "accessioned", null, now.toString());
@@ -184,7 +184,7 @@ public class InstallItem
             item.addDC("date", "issued", null, issued.toString());
         }
 
-        log.debug(" -- setting handle");
+        log.info(" -- setting handle");
         if(item.getHandle() == null)
         {
         	// if no previous handle supplied, create one
@@ -224,7 +224,7 @@ public class InstallItem
                     + d.toString();
         }
 
-        log.debug(" -- adding provenance");
+        log.info(" -- adding provenance");
         // Add provenance description
         item.addDC("description", "provenance", "en", provDescription);
 
@@ -256,7 +256,7 @@ public class InstallItem
         }
         */
 
-        log.debug(" -- registering DOI");
+        log.info(" -- registering DOI");
         IdentifierService service = new DSpace().getSingletonService(IdentifierService.class);
         try {
             service.register(c, item);
@@ -264,7 +264,7 @@ public class InstallItem
             throw new IOException(e);
         }
 
-        log.debug(" -- updating collections and archived flag");
+        log.info(" -- updating collections and archived flag");
         // create collection2item mapping
         is.getCollection().addItem(item);
 
@@ -275,22 +275,22 @@ public class InstallItem
         item.setArchived(true);
 
         // save changes ;-)
-        log.debug(" -- saving item metadata");
+        log.info(" -- saving item metadata");
         item.update();
         c.addEvent(new Event(Event.INSTALL, Constants.ITEM, item.getID(), item.getHandle()));
 
         // remove in-progress submission
-        log.debug(" -- deleting in-progress submission");
+        log.info(" -- deleting in-progress submission");
         is.deleteWrapper();
 
         // remove the item's policies and replace them with
         // the defaults from the collection
 
-        log.debug(" -- updating item permissions");
+        log.info(" -- updating item permissions");
         item.inheritCollectionDefaultPolicies(is.getCollection());
 
         // set embargo lift date and take away read access if indicated.
-        log.debug(" -- final embargo processing");
+        log.info(" -- final embargo processing");
         if (liftDate != null)
             EmbargoManager.setEmbargo(c, item, liftDate);
 

--- a/dspace/modules/api/src/main/java/org/dspace/content/Item.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/Item.java
@@ -1732,7 +1732,7 @@ public class Item extends DSpaceObject
             AuthorizeManager.authorizeAction(ourContext, this, Constants.WRITE);
         }
 
-        log.info(LogManager.getHeader(ourContext, "update_item", "item_id="
+        log.debug(LogManager.getHeader(ourContext, "update_item", "item_id="
                 + internalItemId));
 
         // Set sequence IDs for bitstreams in item


### PR DESCRIPTION
Improve logging when items are approved into the archive. This should help with determining the cause of problems for https://trello.com/c/phWYUbcc

To test: approve an item into the archive. The dspace.log should contain statements indicating the steps the item goes through.

(Also removed an unused instantiation of the DSpace object)