### PR TITLE
Labels shouldn't have pointer cursors

### DIFF
--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/Mirage/lib/css/base.css
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/Mirage/lib/css/base.css
@@ -57,7 +57,7 @@ input[type="checkbox"] { vertical-align: bottom; *vertical-align: baseline; }
 .ie6 input { vertical-align: text-bottom; }
 
 /* hand cursor on clickable input elements */
-label, input[type=button], input[type=submit], button { cursor: pointer; }
+input[type=button], input[type=submit], button { cursor: pointer; }
 
 
 /* These selection declarations have to be separate.


### PR DESCRIPTION
I don’t know why this was ever a thing. Labels aren’t clickable.

Examples of labels: on the select pub step, the Accepted > “Enter your journal title” and “Enter your manuscript number” text, as well as the Published > “Enter publication's DOI or PubMed ID” text.