### PR TITLE
Approve reject fixes

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -76,6 +76,10 @@ public class DryadDataPackage extends DryadObject {
     private static final String AUTHOR_ELEMENT = "contributor";
     private static final String AUTHOR_QUALIFIER = "author";
 
+    private final static String PUBLICATION_DATE_SCHEMA = "dc";
+    private final static String PUBLICATION_DATE_ELEMENT = "date";
+    private final static String PUBLICATION_DATE_QUALIFIER = "issued";
+
     private Set<DryadDataFile> dataFiles;
     private static Logger log = Logger.getLogger(DryadDataPackage.class);
 
@@ -292,6 +296,13 @@ public class DryadDataPackage extends DryadObject {
         return foundIndex;
     }
 
+    public String getPublicationDate() throws SQLException {
+        return getSingleMetadataValue(PUBLICATION_DATE_SCHEMA, PUBLICATION_DATE_ELEMENT, PUBLICATION_DATE_QUALIFIER);
+    }
+
+    public void setPublicationDate(String publicationDate) throws SQLException {
+        addSingleMetadataValue(Boolean.TRUE, PUBLICATION_DATE_SCHEMA, PUBLICATION_DATE_ELEMENT, PUBLICATION_DATE_QUALIFIER, publicationDate);
+    }
 
     public String getPublicationName() throws SQLException {
         return getSingleMetadataValue(PUBLICATION_NAME_SCHEMA, PUBLICATION_NAME_ELEMENT, PUBLICATION_NAME_QUALIFIER);

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -542,17 +542,24 @@ public class JournalUtils {
 
         // sanity check:
         if (matchedManuscript != null) {
-            double matchScore = getHamrScore(queryManuscript.getTitle().toLowerCase(), matchedManuscript.getTitle().toLowerCase());
-            matchedManuscript.optionalProperties.put("crossref-score", String.valueOf(matchScore));
-            // for now, scores greater than 0.5 seem to be a match. Keep an eye on this.
-            if (matchScore < 0.5) {
-                resultString.append("BAD MATCH: \"" + queryManuscript.getTitle() + "\" matched \"" + matchedManuscript.getTitle() + "\" with score " + matchScore);
+            if (!compareTitleToManuscript(queryManuscript.getTitle(), matchedManuscript, resultString)) {
                 return null;
-            } else {
-                resultString.append("GOOD MATCH: \"" + queryManuscript.getTitle() + "\" matched \"" + matchedManuscript.getTitle() + "\" with score " + matchScore);
             }
         }
         return matchedManuscript;
+    }
+
+    public static boolean compareTitleToManuscript(String title, Manuscript matchedManuscript, StringBuilder resultString) {
+        double matchScore = getHamrScore(title.toLowerCase(), matchedManuscript.getTitle().toLowerCase());
+        matchedManuscript.optionalProperties.put("crossref-score", String.valueOf(matchScore));
+        // for now, scores greater than 0.5 seem to be a match. Keep an eye on this.
+        if (matchScore < 0.5) {
+            resultString.append("BAD MATCH: \"" + title + "\" matched \"" + matchedManuscript.getTitle() + "\" with score " + matchScore);
+            return false;
+        } else {
+            resultString.append("GOOD MATCH: \"" + title + "\" matched \"" + matchedManuscript.getTitle() + "\" with score " + matchScore);
+        }
+        return true;
     }
 
     public static boolean compareItemAuthorsToManuscript(Item item, Manuscript manuscript, StringBuilder result) {

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -133,6 +133,14 @@ public class ApproveRejectReviewItem {
         }
     }
 
+    public static void processWorkflowItemWithManuscript(Context context, WorkflowItem wfi, Manuscript manuscript) {
+        try {
+            reviewItem(context, statusIsApproved(manuscript.getStatus()), wfi, manuscript);
+        } catch (ApproveRejectReviewItemException e) {
+            log.error("Exception caught while reviewing item " + wfi.getItem().getID() + ": " + e.getMessage());
+        }
+    }
+
     public static void reviewManuscript(Manuscript manuscript) throws ApproveRejectReviewItemException {
         Context c = null;
         try {

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -16,12 +16,12 @@ import org.dspace.core.Context;
 import org.dspace.discovery.SearchService;
 import org.dspace.eperson.EPerson;
 import org.dspace.utils.DSpace;
-import org.dspace.workflow.WorkflowItem;
 import org.dspace.workflow.actions.WorkflowActionConfig;
 
 import javax.mail.MessagingException;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +36,12 @@ import java.util.List;
  * Updated by dcl9 (dan.leehr@nescent.org) 04-Sep-2014 - exposing reviewItem as static methods
  */
 public class ApproveRejectReviewItem {
+    private static final String PUBLICATION_DOI = "dc.relation.isreferencedby";
+    private static final String MANUSCRIPT = "dc.identifier.manuscriptNumber";
+    private static final String ARTICLE_TITLE = "dc.title";
+    private static final String ABSTRACT = "dc.description";
+    private static final String PUBLICATION_DATE = "dc.date.issued";
+
     private static final Logger log = Logger.getLogger(ApproveRejectReviewItem.class);
     public static void main(String[] args) throws ApproveRejectReviewItemException, ParseException {
         // create an options object and populate it
@@ -191,7 +197,8 @@ public class ApproveRejectReviewItem {
             // There must be a claimedTask & it must be in the review stage, else it isn't a review workflowitem
             Item item = wfi.getItem();
             DryadDataPackage dataPackage = DryadDataPackage.findByWorkflowItemId(c, wfi.getID());
-            associateWithManuscript(dataPackage, manuscript);
+            StringBuilder provenance = new StringBuilder();
+            associateWithManuscript(dataPackage, manuscript, provenance);
             if (claimedTasks == null || claimedTasks.isEmpty() || !claimedTasks.get(0).getActionID().equals("reviewAction")) {
                 log.debug ("Item " + item.getID() + " not found or not in review");
             } else {
@@ -209,7 +216,7 @@ public class ApproveRejectReviewItem {
                     if (manuscript != null) {
                         manuscriptNumber = manuscript.getManuscriptId();
                     }
-                    item.addMetadata(MetadataSchema.DC_SCHEMA, "description", "provenance", "en", "Approved by ApproveRejectReviewItem based on metadata for " + manuscriptNumber + " on " + DCDate.getCurrent().toString() + " (GMT)");
+                    item.addMetadata(MetadataSchema.DC_SCHEMA, "description", "provenance", "en", "Approved by ApproveRejectReviewItem based on metadata for " + manuscriptNumber + " on " + DCDate.getCurrent().toString() + " (GMT)" + provenance.toString());
                     item.update();
                 } else { // reject
                     String reason = "The journal with which your data submission is associated has notified us that your manuscript is no longer being considered for publication. If you feel this has happened in error or wish to re-submit your data associated with a different journal, please contact us at help@datadryad.org.";
@@ -254,17 +261,22 @@ public class ApproveRejectReviewItem {
      * Copies manuscript metadata into a dryad data package
      * @param dataPackage
      * @param manuscript
+     * @param message
      * @throws SQLException
      */
-    private static void associateWithManuscript(DryadDataPackage dataPackage, Manuscript manuscript) throws SQLException {
+    private static void associateWithManuscript(DryadDataPackage dataPackage, Manuscript manuscript, StringBuilder message) throws SQLException {
         if (manuscript != null) {
             // set publication DOI
-            if (manuscript.getPublicationDOI() != null) {
+            if (!"".equals(manuscript.getPublicationDOI()) && !dataPackage.getItem().hasMetadataEqualTo(PUBLICATION_DOI, manuscript.getPublicationDOI())) {
+                String oldValue = dataPackage.getPublicationDOI();
                 dataPackage.setPublicationDOI(manuscript.getPublicationDOI());
+                message.append(" " + PUBLICATION_DOI + " was updated from " + oldValue + ".");
             }
             // set Manuscript ID
-            if (manuscript.getManuscriptId() != null) {
+            if (!"".equals(manuscript.getManuscriptId()) && !dataPackage.getItem().hasMetadataEqualTo(MANUSCRIPT, manuscript.getManuscriptId())) {
+                String oldValue = dataPackage.getManuscriptNumber();
                 dataPackage.setManuscriptNumber(manuscript.getManuscriptId());
+                message.append(" " + MANUSCRIPT + " was updated from " + oldValue + ".");
             }
             // union keywords
             if (manuscript.getKeywords().size() > 0) {
@@ -278,16 +290,24 @@ public class ApproveRejectReviewItem {
                 dataPackage.setKeywords(unionKeywords);
             }
             // set title
-            if (manuscript.getTitle() != null) {
-                dataPackage.setTitle(prefixTitle(manuscript.getTitle()));
+            if (!"".equals(manuscript.getTitle()) && !dataPackage.getItem().hasMetadataEqualTo(ARTICLE_TITLE, manuscript.getTitle())) {
+                String oldValue = dataPackage.getTitle();
+                dataPackage.setTitle(manuscript.getTitle());
+                message.append(" " + ARTICLE_TITLE + " was updated from " + oldValue + ".");
             }
             // set abstract
-            if (manuscript.getAbstract() != null) {
+            if (!"".equals(manuscript.getAbstract()) && !dataPackage.getItem().hasMetadataEqualTo(ABSTRACT, manuscript.getAbstract())) {
+                String oldValue = dataPackage.getAbstract();
                 dataPackage.setAbstract(manuscript.getAbstract());
+                message.append(" " + ABSTRACT + " was updated from " + oldValue + ".");
             }
             // set publicationDate
-            if (manuscript.getPublicationDate() != null) {
-                dataPackage.setBlackoutUntilDate(manuscript.getPublicationDate());
+            SimpleDateFormat dateIso = new SimpleDateFormat("yyyy-MM-dd");
+            String dateString = dateIso.format(manuscript.getPublicationDate());
+            if (!"".equals(manuscript.getPublicationDate()) && !dataPackage.getItem().hasMetadataEqualTo(PUBLICATION_DATE, dateString)) {
+                String oldValue = dataPackage.getPublicationDate();
+                dataPackage.setPublicationDate(dateString);
+                message.append(" " + PUBLICATION_DATE + " was updated from " + oldValue + ".");
             }
         }
     }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -292,22 +292,23 @@ public class ApproveRejectReviewItem {
             // set title
             if (!"".equals(manuscript.getTitle()) && !dataPackage.getItem().hasMetadataEqualTo(ARTICLE_TITLE, manuscript.getTitle())) {
                 String oldValue = dataPackage.getTitle();
-                dataPackage.setTitle(manuscript.getTitle());
-                message.append(" " + ARTICLE_TITLE + " was updated from " + oldValue + ".");
+                dataPackage.setTitle(prefixTitle(manuscript.getTitle()));
+                message.append(" " + ARTICLE_TITLE + " was updated from \"" + oldValue + "\".");
             }
             // set abstract
             if (!"".equals(manuscript.getAbstract()) && !dataPackage.getItem().hasMetadataEqualTo(ABSTRACT, manuscript.getAbstract())) {
-                String oldValue = dataPackage.getAbstract();
                 dataPackage.setAbstract(manuscript.getAbstract());
-                message.append(" " + ABSTRACT + " was updated from " + oldValue + ".");
+                message.append(" " + ABSTRACT + " was updated.");
             }
             // set publicationDate
-            SimpleDateFormat dateIso = new SimpleDateFormat("yyyy-MM-dd");
-            String dateString = dateIso.format(manuscript.getPublicationDate());
-            if (!"".equals(manuscript.getPublicationDate()) && !dataPackage.getItem().hasMetadataEqualTo(PUBLICATION_DATE, dateString)) {
+            if (manuscript.getPublicationDate() != null) {
+                SimpleDateFormat dateIso = new SimpleDateFormat("yyyy-MM-dd");
+                String dateString = dateIso.format(manuscript.getPublicationDate());
                 String oldValue = dataPackage.getPublicationDate();
-                dataPackage.setPublicationDate(dateString);
-                message.append(" " + PUBLICATION_DATE + " was updated from " + oldValue + ".");
+                if (!oldValue.equals(dateString)) {
+                    dataPackage.setPublicationDate(dateString);
+                    message.append(" " + PUBLICATION_DATE + " was updated from " + oldValue + ".");
+                }
             }
         }
     }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
@@ -319,7 +319,7 @@ public class WorkflowItem implements InProgressSubmission {
                 DCValue[] titles = item.getMetadata("dc", "title", Item.ANY, Item.ANY);
                 if (titles != null && titles.length > 0) {
                     DCValue title = titles[0];
-                    matched = JournalUtils.compareTitleToManuscript(title.value, manuscript, 0.3, result);
+                    matched = JournalUtils.compareTitleToManuscript(title.value.replace("Data from: ", ""), manuscript, 0.4, result);
                 }
             }
         }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
@@ -303,9 +303,22 @@ public class WorkflowItem implements InProgressSubmission {
                     }
                 }
 
-                if (matched == false) {
-                    StringBuilder authormatches = new StringBuilder();
-                    matched = JournalUtils.compareItemAuthorsToManuscript(item, manuscript, authormatches);
+                if (!matched) {
+                    // compare titles
+                    // check to see if this matches by msid:
+                    DCValue[] titles = item.getMetadata("dc", "title", Item.ANY, Item.ANY);
+                    if (titles != null && titles.length > 0) {
+                        DCValue title = titles[0];
+                        StringBuilder titleMatches = new StringBuilder();
+                        matched = JournalUtils.compareTitleToManuscript(title.value, manuscript, titleMatches);
+                        log.debug("comparing titles: " + titleMatches.toString());
+                        if (matched) {
+                            // compare authors
+                            StringBuilder authormatches = new StringBuilder();
+                            matched = JournalUtils.compareItemAuthorsToManuscript(item, manuscript, authormatches);
+                            log.debug("comparing authors: " + authormatches.toString());
+                        }
+                    }
                 }
 
                 if (matched) {

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -14,6 +14,7 @@ import org.dspace.core.I18nUtil;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
 import org.dspace.storage.rdbms.TableRowIterator;
+import org.dspace.workflow.ApproveRejectReviewItem;
 import org.dspace.workflow.ClaimedTask;
 import org.dspace.workflow.DryadWorkflowUtils;
 import org.dspace.workflow.WorkflowItem;
@@ -250,6 +251,10 @@ public class PublicationUpdater extends HttpServlet {
                                 StringBuilder provenance = new StringBuilder("Journal-provided metadata for msid " + databaseManuscript.getManuscriptId() + " with title '" + databaseManuscript.getTitle() + "' was added. ");
                                 if (updateItemMetadataFromManuscript(item, databaseManuscript, context, provenance)) {
                                     message = provenance;
+                                }
+                                if (databaseManuscript.isAccepted()) {
+                                    // see if this can be pushed out of review
+                                    ApproveRejectReviewItem.processWorkflowItemWithManuscript(context, wfi, databaseManuscript);
                                 }
                             }
                         }

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -321,7 +321,7 @@ public class PublicationUpdater extends HttpServlet {
                 if (Double.valueOf(score) < 1.0) {
                     // does the matched manuscript have the same authors?
                     StringBuilder authormatches = new StringBuilder();
-                    if (JournalUtils.compareItemAuthorsToManuscript(item, matchedManuscript, authormatches)) {
+                    if (matchedManuscript.getAuthorList().size() == JournalUtils.compareItemAuthorsToManuscript(item, matchedManuscript, authormatches)) {
                         LOGGER.debug("same authors");
                         // update the item's metadata
                         StringBuilder provenance = new StringBuilder("Associated publication (match score " + score + ") was found: \"" + matchedManuscript.getTitle() + "\".");


### PR DESCRIPTION
Incremental improvements for https://trello.com/c/c3m2vVRH/483-improve-matching-of-accept-reject-notices-to-dryad-items

Compares titles with a weak match (score of > 0.4) to see if it’s even a little bit alike.

Adds provenance message explaining which values were changed.