### PR TITLE
Setting keywords seems to cause a freakout in ChoiceAuthorityManager

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -286,17 +286,17 @@ public class ApproveRejectReviewItem {
                 dataPackage.setManuscriptNumber(manuscript.getManuscriptId());
                 message.append(" " + MANUSCRIPT + " was updated from " + oldValue + ".");
             }
-            // union keywords
-            if (manuscript.getKeywords().size() > 0) {
-                ArrayList<String> unionKeywords = new ArrayList<String>();
-                unionKeywords.addAll(dataPackage.getKeywords());
-                for (String newKeyword : manuscript.getKeywords()) {
-                    if (!unionKeywords.contains(newKeyword)) {
-                        unionKeywords.add(newKeyword);
-                    }
-                }
-                dataPackage.setKeywords(unionKeywords);
-            }
+//            // union keywords
+//            if (manuscript.getKeywords().size() > 0) {
+//                ArrayList<String> unionKeywords = new ArrayList<String>();
+//                unionKeywords.addAll(dataPackage.getKeywords());
+//                for (String newKeyword : manuscript.getKeywords()) {
+//                    if (!unionKeywords.contains(newKeyword)) {
+//                        unionKeywords.add(newKeyword);
+//                    }
+//                }
+//                dataPackage.setKeywords(unionKeywords);
+//            }
             // set title
             if (!"".equals(manuscript.getTitle()) && !dataPackage.getItem().hasMetadataEqualTo(ARTICLE_TITLE, manuscript.getTitle())) {
                 String oldValue = dataPackage.getTitle();


### PR DESCRIPTION
Apparently this has been a problem for some time: in the journal-submit app, setting keywords causes the HIVE Authority thing to spew exceptions, while in the APU, it causes the SolrAuthority to spew a different exception. I don’t think we even care about the automated processes adding keywords.