### PR TITLE
match all authors

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
@@ -313,8 +313,8 @@ public class WorkflowItem implements InProgressSubmission {
         }
 
         if (!matched) {
-            // compare authors: if at least one matches, compare titles.
-            if (JournalUtils.compareItemAuthorsToManuscript(item, manuscript, result) > 0) {
+            // compare authors: if they all match, compare titles.
+            if (JournalUtils.compareItemAuthorsToManuscript(item, manuscript, result) == manuscript.getAuthorList().size()) {
                 // compare titles
                 DCValue[] titles = item.getMetadata("dc", "title", Item.ANY, Item.ANY);
                 if (titles != null && titles.length > 0) {


### PR DESCRIPTION
More ApproveReject tweaks: check all authors but require a loose match to title.

Verify this with a database preceding Aug 2. Resubmit the json data associated with msid ‘PONE-D-17-07112’. Item 190485 should not be touched.