### PR TITLE
Lower configured number of database connections

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -69,15 +69,17 @@ db.password = ${default.db.password}
 # Connection pool parameters
 
 # Maximum number of DB connections in pool
-db.maxconnections = 300
+# Set to 60 by ryan 2017-08-14. Previously 300.
+db.maxconnections = 60
 
 # Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
 db.maxwait = 10000
 
 # Maximum number of idle connections in pool (-1 = unlimited)
 # Set to 100 by dleehr 2014-08-04.  Previously unlimited.
+# Set to 50 by ryan 2017-08-14.
 # Limiting idle connections should limit idle postgres processes on server
-db.maxidle = 100
+db.maxidle = 50
 
 # Determine if prepared statement should be cached. (default is true)
 db.statementpool = false


### PR DESCRIPTION
Testing with JMeter indicates that in times of high traffic, the number of open database connections may be exceeding the available memory on the machine. This change reduces the number of database connections that will be created by DSpace, which allows the machine to continue functioning during high load (though with decreased response times).

Testing may be done using the JUnit test suite as described at https://github.com/datadryad/dryad-utils/tree/master/jmeter -- before the change, running the test suite will produce up to 100 "idle in transaction" connection on a standard VM, and the VM will frequently crash. After the change, the number of connections will remain under 60, and the VM will not crash.