### PR TITLE
Add caveat to "2 business days" for large/complex submissions

### DIFF
--- a/dspace/config/emails/submit_datapackage_confirm
+++ b/dspace/config/emails/submit_datapackage_confirm
@@ -12,7 +12,7 @@
 #
 Subject: Dryad submission now in curation
 
-Your submission to the Dryad repository titled "{0}" is now being processed by the curatorial team. They will contact you with an update within two business days.
+Your submission to the Dryad repository titled "{0}" is now being processed by the curatorial team. You should receive an update within two business days. (Large or complex submissions may require a longer response time).
 
 YOUR DRYAD DOI
 

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DepositConfirmedStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DepositConfirmedStep.java
@@ -49,7 +49,7 @@ public class DepositConfirmedStep extends AbstractSubmissionStep{
 
         Division dataPackageDiv = actionsDiv.addDivision("puboverviewdivision", "odd subdiv");
 
-        dataPackageDiv.addPara().addContent("Thank you for your submission! Your data package has been forwarded to Dryad curation staff, and you have been sent a confirmation email containing a provisional DOI for your data package. Once your submission has been reviewed and approved, the DOI becomes permanent and can be used to cite your data package. You will hear from us within two business days.");
+        dataPackageDiv.addPara().addContent("Thank you for your submission! Your data package has been forwarded to Dryad curation staff, and you have been sent a confirmation email containing a provisional DOI for your data package. Once your submission has been reviewed and approved, the DOI becomes permanent and can be used to cite your data package. You should hear from us within two business days. (Large or complex submissions may require a longer response time).");
 
 	dataPackageDiv.addPara("data-label", "bold").addContent(item.getName());
 


### PR DESCRIPTION
I hope I did this right. I *thought* there was another email notification that is sent when a submission moves from review to curation, but I couldn't find that. If there is a separate notification, please add the "(Large or complex submissions may require a longer response time)" language to that too. Thanks! 