### PR TITLE
Remove launcher mention of a nonexistent class

### DIFF
--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -388,15 +388,7 @@
             <class>org.dspace.workflow.CheckPendingDeletions</class>
         </step>
     </command>
-
-    <command>
-        <name>update-authority-index</name>
-        <description>Update Authority Solr Index</description>
-        <step>
-            <class>com.atmire.authority.IndexClient</class>
-        </step>
-    </command>
-
+	
     <command>
         <name>journal-stats</name>
         <description>Generate statistics by journal</description>


### PR DESCRIPTION
Removes alias to update-authority-index/com.atmire.authority.IndexClient