### PR TITLE
Adjust database connections

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -69,17 +69,14 @@ db.password = ${default.db.password}
 # Connection pool parameters
 
 # Maximum number of DB connections in pool
-# Set to 60 by ryan 2017-08-14. Previously 300.
-db.maxconnections = 60
+db.maxconnections = 200
 
 # Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
 db.maxwait = 10000
 
 # Maximum number of idle connections in pool (-1 = unlimited)
-# Set to 100 by dleehr 2014-08-04.  Previously unlimited.
-# Set to 50 by ryan 2017-08-14.
 # Limiting idle connections should limit idle postgres processes on server
-db.maxidle = 50
+db.maxidle = 70
 
 # Determine if prepared statement should be cached. (default is true)
 db.statementpool = false


### PR DESCRIPTION
Previous settings worked poorly on the actual server. These settings are more robust.