### PR TITLE
Add class AutoReturnReviewItem to return old review items to submitters

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2334,6 +2334,12 @@ plugin.named.org.dspace.sword.SWORDIngester = \
 publication.updater.timer = ${default.publication.updater.timer}
 publication.updater.token = ${default.publication.updater.token}
 
+#---------------------------------------------------------------#
+#---------------AUTORETURNREVIEW CONFIGURATIONS-----------------#
+#---------------------------------------------------------------#
+
+# this sets the length of time for AutoReturnReview processor to return old items, in years.
+autoreturnreview.olderthan = ${default.autoreturnreview.olderthan}
 
 #---------------------------------------------------------------#
 #--------------OAI HARVESTING CONFIGURATIONS--------------------#

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -381,6 +381,14 @@
         </step>
     </command>
 
+	<command>
+		<name>purge-review-item</name>
+		<description>Returns old items in review to their submitters' workspaces</description>
+		<step>
+			<class>org.dspace.workflow.AutoReturnReviewItem</class>
+		</step>
+	</command>
+
     <command>
         <name>pending-delete</name>
         <description>Deletes all the workflow items that have been in the pending deletion state for one month, and have not been resubmitted</description>

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
@@ -94,7 +94,8 @@ public class Manuscript {
     );
 
     public static final List<String> ACCEPTED_STATUSES = Arrays.asList(
-            STATUS_ACCEPTED
+            STATUS_ACCEPTED,
+            STATUS_PUBLISHED
     );
 
     public static final List<String> REJECTED_STATUSES = Arrays.asList(

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -105,7 +105,7 @@ public class ApproveRejectReviewItem {
             List<Manuscript> storedManuscripts = manuscriptDatabaseStorage.getManuscriptsMatchingManuscript(manuscript);
             if (storedManuscripts != null && storedManuscripts.size() > 0) {
                 log.info("found stored manuscript " + storedManuscripts.get(0).getManuscriptId() + " with status " + storedManuscripts.get(0).getLiteralStatus());
-                reviewItem(storedManuscripts.get(0).isAccepted(), workflowItem.getID());
+                reviewItem(statusIsApproved(storedManuscripts.get(0).getStatus()), workflowItem.getID());
             }
         } catch (Exception e) {
             log.error("couldn't process review workflowitem " + workflowItem.getID());

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -61,7 +61,8 @@ public class ApproveRejectReviewItem {
         if (line.hasOption('h'))
         {
             HelpFormatter myhelp = new HelpFormatter();
-            myhelp.printHelp("ItemImport\n", options);
+            myhelp.printHelp("dspace review-item\n", options);
+            System.exit(1);
         }
         Boolean approved;
 

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -97,13 +97,14 @@ public class ApproveRejectReviewItem {
         }
     }
 
-    public static void reviewItem(WorkflowItem workflowItem) {
+    static void reviewItem(WorkflowItem workflowItem) {
         Item item = workflowItem.getItem();
         Manuscript manuscript = new Manuscript(item);
         ManuscriptDatabaseStorageImpl manuscriptDatabaseStorage = new ManuscriptDatabaseStorageImpl();
         try {
             List<Manuscript> storedManuscripts = manuscriptDatabaseStorage.getManuscriptsMatchingManuscript(manuscript);
             if (storedManuscripts != null && storedManuscripts.size() > 0) {
+                log.info("found stored manuscript " + storedManuscripts.get(0).getManuscriptId() + " with status " + storedManuscripts.get(0).getLiteralStatus());
                 reviewItem(storedManuscripts.get(0).isAccepted(), workflowItem.getID());
             }
         } catch (Exception e) {

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -108,7 +108,7 @@ public class ApproveRejectReviewItem {
                 reviewItem(statusIsApproved(storedManuscripts.get(0).getStatus()), workflowItem.getID());
             }
         } catch (Exception e) {
-            log.error("couldn't process review workflowitem " + workflowItem.getID());
+            log.error("couldn't process review workflowitem " + workflowItem.getID() + ": " + e.getMessage());
         }
     }
 

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -5,6 +5,7 @@ import org.apache.log4j.Logger;
 import org.datadryad.api.DryadDataPackage;
 import org.datadryad.api.DryadJournalConcept;
 import org.datadryad.rest.models.Manuscript;
+import org.datadryad.rest.storage.rdbms.ManuscriptDatabaseStorageImpl;
 import org.dspace.JournalUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DCDate;
@@ -93,7 +94,20 @@ public class ApproveRejectReviewItem {
         } else {
             System.out.println("No manuscript number or workflow ID was given. One of these must be provided to identify the correct item in the review stage.");
             System.exit(1);
-            return;
+        }
+    }
+
+    public static void reviewItem(WorkflowItem workflowItem) {
+        Item item = workflowItem.getItem();
+        Manuscript manuscript = new Manuscript(item);
+        ManuscriptDatabaseStorageImpl manuscriptDatabaseStorage = new ManuscriptDatabaseStorageImpl();
+        try {
+            List<Manuscript> storedManuscripts = manuscriptDatabaseStorage.getManuscriptsMatchingManuscript(manuscript);
+            if (storedManuscripts != null && storedManuscripts.size() > 0) {
+                reviewItem(storedManuscripts.get(0).isAccepted(), workflowItem.getID());
+            }
+        } catch (Exception e) {
+            log.error("couldn't process review workflowitem " + workflowItem.getID());
         }
     }
 

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
@@ -1,0 +1,176 @@
+package org.dspace.workflow;
+
+import org.apache.commons.cli.*;
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.DCValue;
+import org.dspace.content.Item;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * User: Daisie Huang
+ *
+ * An executable class which determines if a review item is old enough to be purged.
+ * Old items are returned to the submitter's workspace.
+ *
+ */
+public class AutoReturnReviewItem {
+    private static Date olderThanDate;
+    private static Integer olderThan = ConfigurationManager.getIntProperty("autoreturnreview.olderthan");
+
+    private static final Logger log = Logger.getLogger(AutoReturnReviewItem.class);
+
+    static {
+        setOlderThanDate();
+    }
+
+    public static void main(String[] args) throws ApproveRejectReviewItemException, ParseException {
+        // create an options object and populate it
+        CommandLineParser parser = new PosixParser();
+
+        Options options = new Options();
+
+        options.addOption("i", "wfitemid", true, "The workflow item id");
+        options.addOption("a", "all", false, "Process all review items");
+        options.addOption("h", "help", false, "help");
+
+        setOlderThanDate();
+
+        CommandLine line = parser.parse(options, args);
+        if (line.hasOption('h'))
+        {
+            HelpFormatter myhelp = new HelpFormatter();
+            myhelp.printHelp("ItemImport\n", options);
+        }
+
+        if(line.hasOption('i')) {
+            // get a WorkflowItem using a workflow ID
+            Integer workflowItemId = Integer.parseInt(line.getOptionValue('i'));
+            Context c = null;
+            try {
+                c = new Context();
+                WorkflowItem wfi = WorkflowItem.find(c, workflowItemId);
+                purgeOldItem(c, wfi);
+            } catch (SQLException ex) {
+                throw new ApproveRejectReviewItemException(ex);
+            } catch (AuthorizeException ex) {
+                throw new ApproveRejectReviewItemException(ex);
+            } catch (IOException ex) {
+                throw new ApproveRejectReviewItemException(ex);
+            } finally {
+                if (c != null) {
+                    try {
+                        c.complete();
+                    } catch (SQLException ex) {
+                        // Swallow it
+                    } finally {
+                        c = null;
+                    }
+                }
+            }
+        } else if (line.hasOption('a')) {
+            purgeOldItems();
+        } else {
+            System.out.println("No manuscript number or workflow ID was given. One of these must be provided to identify the correct item in the review stage.");
+            System.exit(1);
+        }
+    }
+
+    private static void purgeOldItems() {
+        Context c = null;
+        try {
+            c = new Context();
+            List<ClaimedTask> claimedTasks = ClaimedTask.findAllInStep(c, "reviewStep");
+            for (ClaimedTask task : claimedTasks) {
+                int wfiID = task.getWorkflowItemID();
+                WorkflowItem wfi = WorkflowItem.find(c, wfiID);
+                purgeOldItem(c, wfi);
+            }
+            c.complete();
+        } catch (Exception ex) {
+            log.error("Couldn't purge old items");
+            if (c != null) {
+                c.abort();
+            }
+        }
+    }
+
+    private static void purgeOldItem(Context context, WorkflowItem wfi) {
+	// get a List of ClaimedTasks, using the WorkflowItem
+        List<ClaimedTask> claimedTasks = null;
+        try {
+            if (wfi != null) {
+                claimedTasks = ClaimedTask.findByWorkflowId(context, wfi.getID());
+                //Check for a valid task
+                // There must be a claimedTask & it must be in the review stage, else it isn't a review workflowitem
+                Item item = wfi.getItem();
+                if (claimedTasks == null || claimedTasks.isEmpty() || !claimedTasks.get(0).getActionID().equals("reviewAction")) {
+                    log.debug("Item " + item.getID() + " not found or not in review");
+                } else {
+                    if (itemIsOldItemInReview(item)) {
+                        context.turnOffAuthorisationSystem();
+                        String reason = "Since this submission has been in review for more than " + olderThan + " years, we assume it is no longer needed. Feel free to delete it from your workspace.";
+                        log.debug("returning item " + item.getID());
+                        EPerson ePerson = EPerson.findByEmail(context, ConfigurationManager.getProperty("system.curator.account"));
+                        //Also return all the data files
+                        Item[] dataFiles = DryadWorkflowUtils.getDataFiles(context, wfi.getItem());
+                        for (Item dataFile : dataFiles) {
+                            try {
+                                WorkflowManager.rejectWorkflowItem(context, WorkflowItem.findByItemId(context, dataFile.getID()), ePerson, null, reason, false);
+                            } catch (Exception e) {
+                                throw new IOException(e);
+                            }
+                        }
+                        WorkflowManager.rejectWorkflowItem(context, wfi, ePerson, null, reason, true);
+
+                        context.restoreAuthSystemState();
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            log.error("couldn't purge review workflowitem " + wfi.getID());
+        }
+    }
+
+    private static boolean itemIsOldItemInReview(Item item) {
+        DCValue[] provenanceValues = item.getMetadata("dc.description.provenance");
+        if (provenanceValues != null && provenanceValues.length > 0) {
+            for (DCValue provenanceValue : provenanceValues) {
+                //Submitted by Ricardo Rodríguez (ricardo_eyre@yahoo.es) on 2014-01-30T12:35:00Z workflow start=Step: requiresReviewStep - action:noUserSelectionAction\r
+                String provenance = provenanceValue.value;
+                Pattern pattern = Pattern.compile(".* on (.+?)Z.+requiresReviewStep.*");
+                Matcher matcher = pattern.matcher(provenance);
+                if (matcher.find()) {
+                    String dateString = matcher.group(1);
+                    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+                    Date reviewDate = null;
+                    try {
+                        reviewDate = sdf.parse(dateString);
+                        log.debug("item " + item.getID() + " entered review on " + reviewDate.toString());
+                        return reviewDate.before(olderThanDate);
+                    } catch (Exception e) {
+                        log.error("couldn't find date in provenance for item " + item.getID() + ": " + dateString);
+                        return false;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void setOlderThanDate() {
+        Calendar calendar = new GregorianCalendar();
+        calendar.roll(Calendar.YEAR, -olderThan);
+
+        olderThanDate = calendar.getTime();
+    }
+}

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
@@ -49,10 +49,8 @@ public class AutoReturnReviewItem {
         if (line.hasOption('h'))
         {
             HelpFormatter myhelp = new HelpFormatter();
-            myhelp.printHelp("ItemImport\n", options);
-        }
-
-        if(line.hasOption('i')) {
+            myhelp.printHelp("dspace purge-review-item\n", options);
+        } else if(line.hasOption('i')) {
             // get a WorkflowItem using a workflow ID
             Integer workflowItemId = Integer.parseInt(line.getOptionValue('i'));
             Context c = null;
@@ -80,7 +78,7 @@ public class AutoReturnReviewItem {
         } else if (line.hasOption('a')) {
             purgeOldItems();
         } else {
-            System.out.println("No manuscript number or workflow ID was given. One of these must be provided to identify the correct item in the review stage.");
+            System.out.println("No option was provided.");
             System.exit(1);
         }
     }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
@@ -109,6 +109,8 @@ public class AutoReturnReviewItem {
         List<ClaimedTask> claimedTasks = null;
         try {
             if (wfi != null) {
+                // make sure that this item is updated according to the ApproveReject mechanism:
+                ApproveRejectReviewItem.reviewItem(wfi);
                 claimedTasks = ClaimedTask.findByWorkflowId(context, wfi.getID());
                 //Check for a valid task
                 // There must be a claimedTask & it must be in the review stage, else it isn't a review workflowitem
@@ -119,7 +121,7 @@ public class AutoReturnReviewItem {
                     if (itemIsOldItemInReview(item)) {
                         context.turnOffAuthorisationSystem();
                         String reason = "Since this submission has been in review for more than " + olderThan + " years, we assume it is no longer needed. Feel free to delete it from your workspace.";
-                        log.debug("returning item " + item.getID());
+                        log.info("returning item " + item.getID());
                         EPerson ePerson = EPerson.findByEmail(context, ConfigurationManager.getProperty("system.curator.account"));
                         //Also return all the data files
                         Item[] dataFiles = DryadWorkflowUtils.getDataFiles(context, wfi.getItem());
@@ -155,7 +157,7 @@ public class AutoReturnReviewItem {
                     Date reviewDate = null;
                     try {
                         reviewDate = sdf.parse(dateString);
-                        log.debug("item " + item.getID() + " entered review on " + reviewDate.toString());
+                        log.info("item " + item.getID() + " entered review on " + reviewDate.toString());
                         return reviewDate.before(olderThanDate);
                     } catch (Exception e) {
                         log.error("couldn't find date in provenance for item " + item.getID() + ": " + dateString);


### PR DESCRIPTION
Implements https://trello.com/c/mE0kCHf0/572-process-for-returning-old-items-in-review

Test by running `dspace purge-review-item -a` and observing that items older than the amount set in settings.xml are returned to workspace.