### PR TITLE
display file authors on file item pages

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -261,6 +261,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
                     }
 
                     pageMeta.addMetadata("authors", "package").addContent(DryadWorkflowUtils.getAuthors(pkg));
+                    pageMeta.addMetadata("authors", "item").addContent(DryadWorkflowUtils.getAuthors(item));
                     pageMeta.addMetadata("title", "package").addContent(
                             pkgTitle.endsWith(".") ? pkgTitle + " " : pkgTitle
                                     + ". ");

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -93,7 +93,18 @@
                 <xsl:value-of select="$title"/>
             </p>
             <p class="pub-authors">
-                <xsl:call-template name="make-author-string"/>
+                <xsl:choose>
+                    <xsl:when test="$meta[@element='author'][@qualifier='item']">
+                        <xsl:call-template name="make-author-string">
+                            <xsl:with-param name="authorType" select="'item'"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="make-author-string">
+                            <xsl:with-param name="authorType" select="'package'"/>
+                        </xsl:call-template>
+                    </xsl:otherwise>
+                </xsl:choose>
             </p>
             <xsl:if test=".//dim:field[@element='date' and @qualifier='accessioned']">
                 <p>
@@ -178,7 +189,9 @@
                         <i18n:text>xmlui.DryadItemSummary.pleaseCite</i18n:text>
                     </p>
                     <div class="citation-sample">
-                        <xsl:call-template name="make-author-string"/>
+                        <xsl:call-template name="make-author-string">
+                            <xsl:with-param name="authorType" select="'package'"/>
+                        </xsl:call-template>
                         <xsl:call-template name="package-citation">
                             <xsl:with-param name="package_doi">
                                 <xsl:call-template name="package-doi">
@@ -409,7 +422,9 @@
                             <i18n:text>xmlui.DryadItemSummary.pleaseCite</i18n:text>
                         </p>
                         <div class="citation-sample">
-                            <xsl:call-template name="make-author-string"/>
+                            <xsl:call-template name="make-author-string">
+                                <xsl:with-param name="authorType" select="'package'"/>
+                            </xsl:call-template>
                             <xsl:call-template name="package-citation">
                                 <xsl:with-param name="date" select=".//dim:field[@element='date'][@qualifier='issued']"/>
                                 <xsl:with-param name="title" select=".//dim:field[@element='title']"/>
@@ -1372,14 +1387,15 @@
 
 
     <xsl:template name="make-author-string">
+        <xsl:param name="authorType"/>
         <xsl:variable name="authors">
             <!-- the authors@packages node is packed by DryadWorkflowUtils.getAuthors()-->
             <!-- format is @Doe J@#0000-0000-0000-0000#,@Smith L@#0000-0000-0000-0000#,-->
             <!-- comma-delimited, with each name offset by @ and orcid offset by #, tailing comma-->
             <!-- if this metadata is not available, construct it from the component dc metadata fields.-->
             <xsl:choose>
-                <xsl:when test="$meta[@element='authors'][@qualifier='package']">
-                    <xsl:value-of select="$meta[@element='authors'][@qualifier='package']"/>
+                <xsl:when test="$meta[@element='authors'][@qualifier=$authorType]">
+                    <xsl:value-of select="$meta[@element='authors'][@qualifier=$authorType]"/>
                 </xsl:when>
                 <xsl:when test=".//dim:field[@element='contributor'][@qualifier='author']">
                     <xsl:for-each select=".//dim:field[@element='contributor'][@qualifier='author']">

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -94,7 +94,7 @@
             </p>
             <p class="pub-authors">
                 <xsl:choose>
-                    <xsl:when test="$meta[@element='author'][@qualifier='item']">
+                    <xsl:when test="$meta[@element='authors'][@qualifier='item']">
                         <xsl:call-template name="make-author-string">
                             <xsl:with-param name="authorType" select="'item'"/>
                         </xsl:call-template>


### PR DESCRIPTION
Display file’s authors on file item pages (but keep package authors for citation sample, even on file page).

Addresses https://trello.com/c/5sVqhZ3V/578-author-list-in-top-gray-box-for-data-file-pages-doesnt-match-authors-for-data-file