### PR TITLE
ApproveReject null pointer

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -331,7 +331,7 @@ public class ApproveRejectReviewItem {
                 SimpleDateFormat dateIso = new SimpleDateFormat("yyyy-MM-dd");
                 String dateString = dateIso.format(manuscript.getPublicationDate());
                 String oldValue = dataPackage.getPublicationDate();
-                if (!oldValue.equals(dateString)) {
+                if (!dateString.equals(oldValue)) {
                     dataPackage.setPublicationDate(dateString);
                     message.append(" " + PUBLICATION_DATE + " was updated from " + oldValue + ".");
                 }


### PR DESCRIPTION
There is a null pointer exception that can be thrown if the package doesn’t have a publication date yet.