### PR TITLE
Pub DOIs should be validated as matching the listed journal

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/RESTModelException.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/RESTModelException.java
@@ -1,0 +1,21 @@
+/*
+ */
+package org.datadryad.rest.models;
+
+public class RESTModelException extends Exception {
+    public RESTModelException() {
+        super();
+    }
+
+    public RESTModelException(String message) {
+        super(message);
+    }
+
+    public RESTModelException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    public RESTModelException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -9,6 +9,7 @@ import org.datadryad.api.DryadJournalConcept;
 import org.datadryad.rest.converters.ManuscriptToLegacyXMLConverter;
 import org.datadryad.rest.models.Author;
 import org.datadryad.rest.models.Manuscript;
+import org.datadryad.rest.models.RESTModelException;
 import org.datadryad.rest.storage.StorageException;
 import org.datadryad.rest.storage.StoragePath;
 import org.datadryad.rest.storage.rdbms.ManuscriptDatabaseStorageImpl;
@@ -482,7 +483,7 @@ public class JournalUtils {
         return items;
     }
 
-    public static Manuscript getCrossRefManuscriptMatchingManuscript(Manuscript queryManuscript, StringBuilder resultString) {
+    public static Manuscript getCrossRefManuscriptMatchingManuscript(Manuscript queryManuscript, StringBuilder resultString) throws RESTModelException {
         String crossRefURL = null;
         if (resultString == null) {
             resultString = new StringBuilder();
@@ -530,6 +531,8 @@ public class JournalUtils {
             log.debug("No matches returned for URL " + crossRefURL);
         } catch (FileNotFoundException e) {
             log.debug("CrossRef does not have data for URL " + crossRefURL);
+        } catch (RESTModelException e) {
+            throw e;
         } catch (Exception e) {
             StringBuilder sb = new StringBuilder();
             for (StackTraceElement element : e.getStackTrace()) {
@@ -582,12 +585,11 @@ public class JournalUtils {
         return numMatched;
     }
 
-    public static Manuscript manuscriptFromCrossRefJSON(JsonNode jsonNode, DryadJournalConcept dryadJournalConcept) {
+    public static Manuscript manuscriptFromCrossRefJSON(JsonNode jsonNode, DryadJournalConcept dryadJournalConcept) throws RESTModelException {
         // manuscripts should only be returned if the crossref match is of type "journal-article"
         if (jsonNode.path("type") != null) {
             if (!"journal-article".equals(jsonNode.path("type").textValue())) {
-                log.error("crossref result is not of type journal-article: " + jsonNode.path("type").textValue());
-                return null;
+                throw new RESTModelException("crossref result is not of type journal-article: " + jsonNode.path("type").textValue());
             }
         }
 

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -550,7 +550,7 @@ public class JournalUtils {
                 return null;
             }
             if (!queryManuscript.getJournalISSN().equals(matchedManuscript.getJournalISSN())) {
-                return null;
+                throw new RESTModelException("publication DOI listed for item does not belong to the correct journal");
             }
         }
         return matchedManuscript;

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -583,6 +583,14 @@ public class JournalUtils {
     }
 
     public static Manuscript manuscriptFromCrossRefJSON(JsonNode jsonNode, DryadJournalConcept dryadJournalConcept) {
+        // manuscripts should only be returned if the crossref match is of type "journal-article"
+        if (jsonNode.path("type") != null) {
+            if (!"journal-article".equals(jsonNode.path("type").textValue())) {
+                log.error("crossref result is not of type journal-article: " + jsonNode.path("type").textValue());
+                return null;
+            }
+        }
+
         Manuscript manuscript = new Manuscript();
         if (jsonNode.path("DOI") != null) {
             manuscript.setPublicationDOI(jsonNode.path("DOI").textValue());

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -549,6 +549,9 @@ public class JournalUtils {
             if (!compareTitleToManuscript(queryManuscript.getTitle(), matchedManuscript, 0.5, resultString)) {
                 return null;
             }
+            if (!queryManuscript.getJournalISSN().equals(matchedManuscript.getJournalISSN())) {
+                return null;
+            }
         }
         return matchedManuscript;
     }


### PR DESCRIPTION
Fixes https://trello.com/c/cIMKJ1jj/580-bug-apu-needs-to-verify-that-an-items-associated-pub-doi-is-from-the-correct-journal

Test with a DOI for a preprint article and with a DOI for a journal that is not the one that is listed in the package’s metadata.

If you’re testing a bad journal match, make sure you replace the title of the item with the title of the DOI’s article; otherwise you’ll just get a bad title match.