### PR TITLE
Add getVersionHistory to the data package class

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -565,3 +565,4 @@ public class DryadDataPackage extends DryadObject {
     }
 
 }
+

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -30,6 +30,9 @@ import org.dspace.identifier.IdentifierService;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
 import org.dspace.utils.DSpace;
+import org.dspace.versioning.Version;
+import org.dspace.versioning.VersionHistory;
+import org.dspace.versioning.VersioningService;
 import org.dspace.workflow.WorkflowItem;
 
 /**
@@ -553,6 +556,12 @@ public class DryadDataPackage extends DryadObject {
             authors.add(new Author(dcValue));
         }
         return authors;
+    }
+
+    public VersionHistory getVersionHistory(Context c) {
+        VersioningService versioningService = new DSpace().getSingletonService(VersioningService.class);
+        VersionHistory history = versioningService.findVersionHistory(c, item.getID());
+        return history;
     }
 
 }


### PR DESCRIPTION
This has no visible changes for Dryad proper. It is here to make the version history more easily accessible to the DANS exporter, as well as future tools that work with data packages.