### PR TITLE
Context cleanup

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/AuthorityItemConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/AuthorityItemConsumer.java
@@ -75,7 +75,7 @@ public class AuthorityItemConsumer implements Consumer {
             }
         }
         catch (Exception e) {
-            ctx.abort();
+            log.error("Exception was thrown: " + e.getMessage());
         }
 
     }

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -391,6 +391,7 @@ public class Context
     {
         ArrayList<Event> eventArrayList = new ArrayList<>();
         eventArrayList.addAll(events);
+        events = null;
         return eventArrayList;
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -9,13 +9,7 @@ package org.dspace.core;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.EmptyStackException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Stack;
+import java.util.*;
 
 import org.apache.log4j.Logger;
 import org.dspace.eperson.EPerson;
@@ -77,7 +71,7 @@ public class Context
     private List<Integer> specialGroups;
 
     /** Content events */
-    private List<Event> events = null;
+    private Set<Event> events = null;
 
     /** Event dispatcher name */
     private String dispName = null;
@@ -377,7 +371,7 @@ public class Context
     {
         if (events == null)
         {
-            events = new ArrayList<Event>();
+            events = new HashSet<>();
         }
 
         events.add(event);
@@ -395,7 +389,9 @@ public class Context
      */
     public List<Event> getEvents()
     {
-        return events;
+        ArrayList<Event> eventArrayList = new ArrayList<>();
+        eventArrayList.addAll(events);
+        return eventArrayList;
     }
 
     /**

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/storage/rdbms/JournalConceptDatabaseStorageImpl.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/storage/rdbms/JournalConceptDatabaseStorageImpl.java
@@ -42,7 +42,6 @@ public class JournalConceptDatabaseStorageImpl extends AbstractOrganizationConce
             context.complete();
         } catch (SQLException e) {
             log.error("couldn't find metadata fields");
-            context.abort();
         }
     }
 

--- a/dspace/modules/api/src/main/java/org/dspace/content/ItemModificationConsumer.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/ItemModificationConsumer.java
@@ -55,7 +55,7 @@ public class ItemModificationConsumer implements Consumer {
                 break;
             }
         } catch (Exception e) {
-            ctx.abort();
+            log.error("Exception consuming event: " + e.getMessage());
         }
     }
 }

--- a/dspace/modules/api/src/main/java/org/dspace/content/ItemModificationConsumer.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/ItemModificationConsumer.java
@@ -28,7 +28,6 @@ public class ItemModificationConsumer implements Consumer {
         int st = event.getSubjectType();
 
         try {
-            ctx = new Context();
             ctx.turnOffAuthorisationSystem();
 
             switch (st) {

--- a/dspace/modules/api/src/main/java/org/dspace/content/ItemModificationConsumer.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/ItemModificationConsumer.java
@@ -54,7 +54,6 @@ public class ItemModificationConsumer implements Consumer {
                 }
                 break;
             }
-            ctx.complete();
         } catch (Exception e) {
             ctx.abort();
         }

--- a/dspace/modules/api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace/modules/api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -514,9 +514,6 @@ public class DOIIdentifierProvider extends IdentifierProvider implements org.spr
             } catch (ClassCastException details) {
                 throw new RuntimeException(details);
             } catch (SQLException details) {
-                if (context != null) {
-                    context.abort();
-                }
                 throw new RuntimeException(details);
             } catch (Exception details) {
                 throw new RuntimeException(details);

--- a/dspace/modules/api/src/main/java/org/dspace/versioning/VersioningConsumer.java
+++ b/dspace/modules/api/src/main/java/org/dspace/versioning/VersioningConsumer.java
@@ -83,7 +83,6 @@ public class VersioningConsumer implements Consumer {
                 }
                 break;
             }
-            ctx.complete();
         }
         catch (Exception e) {
             ctx.abort();

--- a/dspace/modules/api/src/main/java/org/dspace/versioning/VersioningConsumer.java
+++ b/dspace/modules/api/src/main/java/org/dspace/versioning/VersioningConsumer.java
@@ -55,7 +55,6 @@ public class VersioningConsumer implements Consumer {
         int et = event.getEventType();
 
         try {
-            ctx = new Context();
             ctx.turnOffAuthorisationSystem();
 
             switch (st) {

--- a/dspace/modules/api/src/main/java/org/dspace/versioning/VersioningConsumer.java
+++ b/dspace/modules/api/src/main/java/org/dspace/versioning/VersioningConsumer.java
@@ -85,7 +85,7 @@ public class VersioningConsumer implements Consumer {
             }
         }
         catch (Exception e) {
-            ctx.abort();
+            log.error("Exception consuming event: " + e.getMessage());
         }
     }
 

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
@@ -74,9 +74,6 @@ public class CDLDataCiteConsumer implements Consumer {
             ctx.abort();
 	    log.error("Problem updating DataCite settings for an item based on event " + event, e);
         }
-        finally {
-            ctx.complete();
-        }
 
     }
 

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
@@ -34,7 +34,6 @@ public class CDLDataCiteConsumer implements Consumer {
         int et = event.getEventType();
 
         try {
-            ctx = new Context();
             ctx.turnOffAuthorisationSystem();
             switch (st) {
 

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
@@ -62,13 +62,12 @@ public class CDLDataCiteConsumer implements Consumer {
 
                             if(response.contains("error"))
                                 log.error("Problem during the Item synchronization against DataCite : " + response);
-
-                            ctx.commit();
                         }
                     }
                     break;
                 }
             }
+            ctx.restoreAuthSystemState();
         }
         catch (Exception e) {
             log.error("Problem updating DataCite settings for an item based on event " + event, e);

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
@@ -71,8 +71,7 @@ public class CDLDataCiteConsumer implements Consumer {
             }
         }
         catch (Exception e) {
-            ctx.abort();
-	    log.error("Problem updating DataCite settings for an item based on event " + event, e);
+            log.error("Problem updating DataCite settings for an item based on event " + event, e);
         }
 
     }

--- a/dspace/modules/versioning/versioning-api/src/main/java/org/dspace/versioning/PluggableVersioningService.java
+++ b/dspace/modules/versioning/versioning-api/src/main/java/org/dspace/versioning/PluggableVersioningService.java
@@ -111,7 +111,6 @@ public class PluggableVersioningService implements VersioningService{
                 versionDAO.delete(c, previous.getVersionId());
             }
         }catch (Exception e) {
-            c.abort();
             throw new RuntimeException(e.getMessage(), e);
         }
     }

--- a/dspace/modules/versioning/versioning-webapp/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionManager.java
+++ b/dspace/modules/versioning/versioning-webapp/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionManager.java
@@ -74,7 +74,6 @@ public class VersionManager {
 
                 }
             } catch (Exception ex) {
-                context.abort();
                 throw new RuntimeException(ex);
             }
         }
@@ -116,7 +115,6 @@ public class VersionManager {
                 result.setParameter("summary", summary);
             }
         } catch (Exception ex) {
-            context.abort();
             throw new RuntimeException(ex);
         }
         return result;
@@ -146,7 +144,6 @@ public class VersionManager {
             result.setMessage(T_version_restored);
 
         } catch (Exception ex) {
-            context.abort();
             throw new RuntimeException(ex);
         }
         return result;
@@ -177,7 +174,6 @@ public class VersionManager {
             result.setMessage(T_version_delete);
 
         } catch (Exception ex) {
-            context.abort();
             throw new RuntimeException(ex);
         }
         return result;


### PR DESCRIPTION
Clean up context handling:
1) Consumer classes shouldn’t create new contexts, as contexts should be passed in for the event that is being consumed.
2) Similarly, those contexts that are used in the consumer classes should not be completed either, as they are still being used by the event dispatcher.
3) More generally, when there is an exception thrown for a method that is passed in a context, the context should not be aborted, as the passing class won’t know that the context is gone.
4) CDLDataCiteConsumer doesn’t need to commit the context because consume() only gets called during a commit and this causes a weird loop of commits.
5) Context.events should be a Set instead of a List, since you don’t need to dispatch a series of identical events that only differ by timestamp (and the equals() method of Event does not consider timestamp).
6) After the dispatcher gets the events, set the events to null (so as not to process them multiple times).