### PR TITLE
Authority indexing improvements

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/AuthorityMetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/AuthorityMetadataValue.java
@@ -77,8 +77,7 @@ public class AuthorityMetadataValue {
      * @param row database row to use for contents
      */
 
-    public AuthorityMetadataValue(TableRow row)
-    {
+    public AuthorityMetadataValue(TableRow row) {
         if (row != null)
         {
             tableName = row.getTable();
@@ -92,10 +91,6 @@ public class AuthorityMetadataValue {
             confidence = row.getIntColumn("confidence");
             this.row = row;
         }
-    }
-
-    public AuthorityMetadataValue(Context context, TableRow row) {
-        this(row);
         try {
             MetadataField field = MetadataField.find(fieldId);
             MetadataSchema thisSchema = MetadataSchema.find(field.getSchemaID());

--- a/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
@@ -250,6 +250,17 @@ public abstract class AuthorityObject extends DSpaceObject {
         return resultList;
     }
 
+    void initializeCachedMetadata(TableRow tableRow) {
+        if (cachedMetadataValues == null) {
+            cachedMetadataValues = new HashMap<>();
+        }
+        AuthorityMetadataValue amv = new AuthorityMetadataValue(tableRow);
+        if (cachedMetadataValues.get(amv.fieldId) == null) {
+            cachedMetadataValues.put(amv.fieldId, new ArrayList<>());
+        }
+        cachedMetadataValues.get(amv.fieldId).add(amv);
+    }
+
     // get all metadata associated with an AuthorityObject
     private HashMap<Integer, ArrayList<AuthorityMetadataValue>> getCachedMetadata() {
         // if cached values present, return cache
@@ -258,7 +269,7 @@ public abstract class AuthorityObject extends DSpaceObject {
         }
 
         // otherwise, refresh cache
-        cachedMetadataValues = new HashMap<Integer, ArrayList<AuthorityMetadataValue>>();
+        cachedMetadataValues = new HashMap<>();
         Context context = getContext();
         try {
             TableRowIterator tri = DatabaseManager.queryTable(context, this.getMetadataTable() ,
@@ -269,11 +280,7 @@ public abstract class AuthorityObject extends DSpaceObject {
                 try {
                     while (tri.hasNext()) {
                         TableRow resultRow = tri.next();
-                        AuthorityMetadataValue amv = new AuthorityMetadataValue(context, resultRow);
-                        if (cachedMetadataValues.get(amv.fieldId) == null) {
-                            cachedMetadataValues.put(amv.fieldId, new ArrayList<AuthorityMetadataValue>());
-                        }
-                        cachedMetadataValues.get(amv.fieldId).add(amv);
+                        initializeCachedMetadata(resultRow);
                     }
                 } finally {
                     // close the TableRowIterator to free up resources

--- a/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
@@ -229,8 +229,9 @@ public abstract class AuthorityObject extends DSpaceObject {
                 if (field == null) {
                     throw new SQLException("no such field " + schemaName + "." + element + "." + qualifier);
                 } else {
-                    if (getCachedMetadata().get(field.getFieldID()) != null) {
-                        resultMetadataValues.addAll(getCachedMetadata().get(field.getFieldID()));
+                    ArrayList<AuthorityMetadataValue> amvs = getCachedMetadata().get(field.getFieldID());
+                    if (amvs != null) {
+                        resultMetadataValues.addAll(amvs);
                     }
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/content/authority/Scheme.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/Scheme.java
@@ -534,8 +534,11 @@ public class Scheme extends AuthorityObject
                 }
             }
             for (Concept concept : concepts) {
-                for (TableRow tr : metadataMap.get(concept.getID())) {
-                    concept.initializeCachedMetadata(tr);
+                List<TableRow> conceptRows = metadataMap.get(concept.getID());
+                if (conceptRows != null) {
+                    for (TableRow tr : metadataMap.get(concept.getID())) {
+                        concept.initializeCachedMetadata(tr);
+                    }
                 }
             }
         }

--- a/dspace/modules/api/src/main/java/org/datadryad/authority/JournalConceptIndexer.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/authority/JournalConceptIndexer.java
@@ -18,22 +18,23 @@ import org.dspace.JournalUtils;
  */
 public class JournalConceptIndexer implements AuthorityIndexerInterface {
 
-    protected String SOURCE="JOURNALCONCEPTS";
     protected AuthorityValue nextValue;
 
-    protected LinkedList<AuthorityValue> authorities = new LinkedList();
-
-
-    public String FIELD_NAME = "prism_publicationName";
+    protected LinkedList<AuthorityValue> authorities = null;
+    private static Boolean journals_cached = false;
 
     public void init() {
-        DryadJournalConcept[] dryadJournalConcepts = JournalUtils.getAllJournalConcepts();
-        for (DryadJournalConcept concept : dryadJournalConcepts) {
-            if (concept.isAccepted()) {
-                for (AuthorityValue doc : createAuthorityValues(concept)) {
-                    authorities.add(doc);
+        if (authorities == null) {
+            authorities = new LinkedList<AuthorityValue>();
+        }
+        if (!journals_cached) {
+            DryadJournalConcept[] dryadJournalConcepts = JournalUtils.getAllJournalConcepts();
+            for (DryadJournalConcept concept : dryadJournalConcepts) {
+                if (concept.isAccepted()) {
+                    authorities.addAll(createAuthorityValues(concept));
                 }
             }
+            journals_cached = true;
         }
     }
 
@@ -75,8 +76,8 @@ public class JournalConceptIndexer implements AuthorityIndexerInterface {
         for (String name : names) {
             AuthorityValue authorityValue = new AuthorityValue();
             authorityValue.setId(String.valueOf(concept.getConceptID()));
-            authorityValue.setSource(SOURCE);
-            authorityValue.setField(FIELD_NAME);
+            authorityValue.setSource(getSource());
+            authorityValue.setField(getField());
             authorityValue.setValue(concept.getFullName());
             // full-text field is for searching, so index it with no spaces.
             authorityValue.setFullText(name.replaceAll("\\s", ""));
@@ -92,7 +93,11 @@ public class JournalConceptIndexer implements AuthorityIndexerInterface {
     }
 
     public String getSource() {
-        return SOURCE;
+        return "JOURNALCONCEPTS";
+    }
+
+    public String getField() {
+        return "prism_publicationName";
     }
 }
 

--- a/dspace/modules/api/src/main/java/org/datadryad/authority/JournalConceptIndexer.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/authority/JournalConceptIndexer.java
@@ -20,13 +20,28 @@ public class JournalConceptIndexer implements AuthorityIndexerInterface {
 
     protected AuthorityValue nextValue;
 
-    protected LinkedList<AuthorityValue> authorities = null;
+    protected LinkedList<AuthorityValue> authorities = new LinkedList<AuthorityValue>();
     private static Boolean journals_cached = false;
 
     public void init() {
-        if (authorities == null) {
-            authorities = new LinkedList<AuthorityValue>();
+    }
+
+    @Override
+    public void init(Context context, Item item) {
+        DCValue[] dcValues = item.getMetadata("prism.publicationName");
+        if (dcValues != null && dcValues.length > 0) {
+            // look up concept by name:
+            DryadJournalConcept journalConcept = JournalUtils.getJournalConceptByJournalName(dcValues[0].value);
+            if (journalConcept != null) {
+                if (journalConcept.isAccepted()) {
+                    authorities.addAll(createAuthorityValues(journalConcept));
+                }
+            }
         }
+    }
+
+    @Override
+    public void init(Context context) {
         if (!journals_cached) {
             DryadJournalConcept[] dryadJournalConcepts = JournalUtils.getAllJournalConcepts();
             for (DryadJournalConcept concept : dryadJournalConcepts) {
@@ -36,18 +51,6 @@ public class JournalConceptIndexer implements AuthorityIndexerInterface {
             }
             journals_cached = true;
         }
-    }
-
-    @Override
-    public void init(Context context, Item item) {
-        init();
-        //To change body of implemented methods use File | Settings | File Templates.
-    }
-
-    @Override
-    public void init(Context context) {
-        init();
-        //To change body of implemented methods use File | Settings | File Templates.
     }
 
     @Override

--- a/dspace/modules/api/src/main/java/org/datadryad/authority/SponsorIndexer.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/authority/SponsorIndexer.java
@@ -19,12 +19,10 @@ public class SponsorIndexer extends JournalConceptIndexer implements AuthorityIn
     private static Boolean sponsors_cached = false;
 
     @Override
-    public void init() {
-        super.init();
+    public void init(Context context) {
+        super.init(context);
         if (!sponsors_cached) {
-            Context context = null;
             try {
-                context = new Context();
                 Concept[] concepts = Concept.findAll(context, AuthorityObject.ID);
                 for (Concept concept : concepts) {
                     DryadOrganizationConcept organizationConcept = DryadOrganizationConcept.getOrganizationConceptMatchingConceptID(context, concept.getID());
@@ -32,11 +30,8 @@ public class SponsorIndexer extends JournalConceptIndexer implements AuthorityIn
                         authorities.addAll(createAuthorityValues(organizationConcept));
                     }
                 }
-                context.complete();
             } catch (SQLException e) {
-                if (context != null) {
-                    context.abort();
-                }
+
             }
             sponsors_cached = true;
         }

--- a/dspace/modules/api/src/main/java/org/dspace/content/ItemModificationConsumer.java
+++ b/dspace/modules/api/src/main/java/org/dspace/content/ItemModificationConsumer.java
@@ -28,7 +28,6 @@ public class ItemModificationConsumer implements Consumer {
         int st = event.getSubjectType();
 
         try {
-            ctx = new Context();
             ctx.turnOffAuthorisationSystem();
 
             switch (st) {

--- a/dspace/modules/api/src/main/java/org/dspace/versioning/VersioningConsumer.java
+++ b/dspace/modules/api/src/main/java/org/dspace/versioning/VersioningConsumer.java
@@ -55,7 +55,6 @@ public class VersioningConsumer implements Consumer {
         int et = event.getEventType();
 
         try {
-            ctx = new Context();
             ctx.turnOffAuthorisationSystem();
 
             switch (st) {

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteConsumer.java
@@ -34,7 +34,6 @@ public class CDLDataCiteConsumer implements Consumer {
         int et = event.getEventType();
 
         try {
-            ctx = new Context();
             ctx.turnOffAuthorisationSystem();
             switch (st) {
 


### PR DESCRIPTION
These changes should help with caching of metadata in the authority system, allowing for one bulk query of the DB to get all of the concept metadata for initializing the live system. I’ve also corrected some functionality of the various init() methods in the Indexer classes that I didn’t fully understand before.