### PR TITLE
Improve alignment for headings on journal pages

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
@@ -15,7 +15,7 @@
 h1 {
     font-size: 182%;
     color: #333;
-    text-align: justify;
+    text-align: left;
 }
 
 h2{


### PR DESCRIPTION
On some journal pages, the "justify" style setting produces ugly spacing. For example: 

* http://datadryad.org/journal/1869-4241
* https://datadryad.org/journal/2332-7812

This PR sets all H1 headings to left-justified, which is typical for headings, and corrects the ugliness observed for journals with long names.