### PR TITLE
reduce logging for spider loading

### DIFF
--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -206,7 +206,7 @@ log4j.logger.org.dspace.submit.utils = INFO
 
 # Logging for statistics management
 log4j.logger.org.dspace.statistics = DEBUG
-log4j.logger.org.dspace.statistics.util = DEBUG
+log4j.logger.org.dspace.statistics.util = INFO
 
 # widget api debugging
 log4j.logger.org.dspace.app.xmlui.aspect.dryadwidgets.display = ERROR


### PR DESCRIPTION
I’m sick of seeing giant piles of log messages about the specific spiders we’ve loaded.