### PR TITLE
Schema.org JSON-LD support for packages

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -11,9 +11,13 @@ import java.sql.SQLException;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.datadryad.rest.models.Author;
+import org.datadryad.rest.models.Package;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
@@ -562,6 +566,18 @@ public class DryadDataPackage extends DryadObject {
         VersioningService versioningService = new DSpace().getSingletonService(VersioningService.class);
         VersionHistory history = versioningService.findVersionHistory(c, item.getID());
         return history;
+    }
+
+    // Convenience method to access a properly serialized JSON-LD string, formatted for Schema.org.
+    public String getSchemaDotOrgJSON() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            mapper.registerModule(new SimpleModule().addSerializer(Author.class, new Author.SchemaDotOrgSerializer()));
+            mapper.registerModule(new SimpleModule().addSerializer(Package.class, new Package.SchemaDotOrgSerializer()));
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(new Package(this));
+        } catch (Exception e) {
+            return "";
+        }
     }
 
 }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
@@ -164,6 +164,7 @@ public class Package {
             jGen.writeStringField("@context", "http://schema.org/");
             jGen.writeStringField("@type", "Dataset");
             jGen.writeStringField("@id", DOIIdentifierProvider.getFullDOIURL(dataPackage.getDryadDOI()));
+            jGen.writeStringField("url", DOIIdentifierProvider.getFullDOIURL(dataPackage.getDryadDOI()));
             jGen.writeStringField("name", dataPackage.getTitle());
             jGen.writeObjectField("author", dataPackage.getAuthorList());
             jGen.writeStringField("datePublished", dataPackage.getPublicationDate());

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
@@ -176,6 +176,14 @@ public class Package {
                 jGen.writeObjectField("keywords", dataPackage.getKeywords());
             }
             jGen.writeStringField("citation", dataPackage.getPublicationDOI());
+
+            // write Dryad Digital Repository Organization object:
+            jGen.writeObjectFieldStart("publisher");
+            jGen.writeStringField("@type", "Organization");
+            jGen.writeStringField("name", "Dryad Digital Repository");
+            jGen.writeStringField("url", "https://datadryad.org");
+            jGen.writeEndObject();
+
             jGen.writeEndObject();
         }
     }

--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -25,6 +25,7 @@ import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.util.HashUtil;
 import org.apache.excalibur.source.SourceValidity;
 import org.apache.log4j.Logger;
+import org.datadryad.api.DryadDataPackage;
 import org.datadryad.api.DryadJournalConcept;
 import org.dspace.JournalUtils;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
@@ -58,10 +59,8 @@ import org.dspace.utils.DSpace;
 import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
 import org.dspace.versioning.VersioningService;
-import org.dspace.workflow.ClaimedTask;
 import org.dspace.workflow.DryadWorkflowUtils;
 import org.dspace.workflow.WorkflowItem;
-import org.dspace.workflow.WorkflowManager;
 import org.jdom.Element;
 import org.jdom.output.XMLOutputter;
 import org.xml.sax.SAXException;
@@ -334,7 +333,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
             // THIS IS A PACKAGE ITEM
 
             pageMeta.addMetadata("authors", "package").addContent(DryadWorkflowUtils.getAuthors(item));
-
+            pageMeta.addMetadata("metadata","json-ld").addContent(new DryadDataPackage(item).getSchemaDotOrgJSON());
             DCValue[] values;
 
             if ((values = item.getMetadata("prism.publicationName")).length != 0) {

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -563,6 +563,7 @@
                     </xsl:if>
                 </div>
             </div>
+            <xsl:call-template name="format-json-ld-metadata"/>
         </xsl:if>
         <!-- package metadata -->
         <div class="ds-static-div primary">
@@ -1250,6 +1251,12 @@
                 <td><xsl:value-of select="./@language"/></td>
             </tr>
         </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="format-json-ld-metadata">
+        <script type="application/ld+json">
+            <xsl:value-of select="$meta[@element='metadata'][@qualifier='json-ld']"/>
+        </script>
     </xsl:template>
 
     <xsl:template name="format-author-names">


### PR DESCRIPTION
JSON-LD metadata is now included in the page source on package pages. Addresses https://trello.com/c/s9fGlCTS/582-feat-support-schemaorg-dataset-profile