### PR TITLE
Schema.org JSON-LD fix

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -1254,9 +1254,11 @@
     </xsl:template>
 
     <xsl:template name="format-json-ld-metadata">
-        <script type="application/ld+json">
+        <xsl:if test="$meta[@element='metadata'][@qualifier='json-ld']">
+          <script type="application/ld+json">
             <xsl:value-of select="$meta[@element='metadata'][@qualifier='json-ld']"/>
-        </script>
+          </script>
+	</xsl:if>
     </xsl:template>
 
     <xsl:template name="format-author-names">


### PR DESCRIPTION
Fixes the json-ld generation so there is not an empty <script /> element
on curator pages. This empty element was throwing off the page rendering,
preventing shopping carts and curation task buttons from displaying.