### PR TITLE
don't add json-ld metadata tag if there isn't any content for it.

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -333,7 +333,10 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
             // THIS IS A PACKAGE ITEM
 
             pageMeta.addMetadata("authors", "package").addContent(DryadWorkflowUtils.getAuthors(item));
-            pageMeta.addMetadata("metadata","json-ld").addContent(new DryadDataPackage(item).getSchemaDotOrgJSON());
+            String jsonData = new DryadDataPackage(item).getSchemaDotOrgJSON();
+            if (!jsonData.isEmpty()) {
+                pageMeta.addMetadata("metadata", "json-ld").addContent(new DryadDataPackage(item).getSchemaDotOrgJSON());
+            }
             DCValue[] values;
 
             if ((values = item.getMetadata("prism.publicationName")).length != 0) {

--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -335,7 +335,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
             pageMeta.addMetadata("authors", "package").addContent(DryadWorkflowUtils.getAuthors(item));
             String jsonData = new DryadDataPackage(item).getSchemaDotOrgJSON();
             if (!jsonData.isEmpty()) {
-                pageMeta.addMetadata("metadata", "json-ld").addContent(new DryadDataPackage(item).getSchemaDotOrgJSON());
+                pageMeta.addMetadata("metadata", "json-ld").addContent(jsonData);
             }
             DCValue[] values;
 


### PR DESCRIPTION
One last fix: don’t bother adding the metadata to the page at all if there’s no content for it. This should fix internal-item rendering for https://trello.com/c/s9fGlCTS/582-feat-support-schemaorg-dataset-profile