### PR TITLE
Increase length of newly-generated DOIs

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -319,7 +319,7 @@ doi.username = dryad
 
 doi.password = ${default.doi.password}
 
-doi.suffix.length = 5
+doi.suffix.length = 7
 
 doi.localpart.suffix = dryad.
 


### PR DESCRIPTION
The old value limited the space of DOIs to a few million. The new
value allows for many billions, making the DOIs more future-proof, and
making the review URLs less guessable.