### PR TITLE
Reorder embargo options

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStepUtils.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStepUtils.java
@@ -378,9 +378,9 @@ public class DescribeStepUtils extends AbstractDSpaceTransformer {
             select.addOption("none", "Publish immediately");
         }
 
+        select.addOption("untilArticleAppears", "Embargo until article appears");
         select.addOption("oneyear", "1 year embargo");
         select.addOption("custom", "Custom length embargo (approved by journal editor)");
-        select.addOption("untilArticleAppears", "Embargo until article appears");
 
 
         // Setup the field's pre-selected values


### PR DESCRIPTION
Sometimes, when the “none” option is not available, e.g. blackout journals, the dropdown defaults to displaying the next item on the list. This item should be the next-defaultest option, “until article appears.”

The order is now “publish immediately,” “until article appears,” “one year embargo,” “custom embargo.”

Addresses https://trello.com/c/sqJQGzq1/592-bug-external-links-in-the-submission-system-have-one-year-embargo-option-only