### PR TITLE
Use md5 explicitly as checksum for S3 bitstreams

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
@@ -12,13 +12,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.net.URL;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import org.apache.log4j.Logger;
 import org.dspace.checker.BitstreamInfoDAO;
@@ -571,8 +570,11 @@ public class BitstreamStorageManager
             String key = getFullS3Key(sInternalId + "");
             log.debug("retrieving item " + key + " from Amazon S3 bucket " + s3BucketName);
             try {
-                S3Object object = s3Service.getObject(new GetObjectRequest(s3BucketName, key));
-                resultInputStream = (object != null) ? object.getObjectContent() : null;
+                //get tomorrow's date:
+                Calendar calendar = Calendar.getInstance();
+                calendar.add(Calendar.DAY_OF_YEAR, 1);
+                URL url = s3Service.generatePresignedUrl(s3BucketName, key, calendar.getTime());
+                resultInputStream = url.openStream();
             } catch (Exception e) {
                 log.error("Unable to get S3 item " + key + " from bucket " + s3BucketName, e);
                 throw new IOException(e);

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
@@ -350,7 +350,20 @@ public class BitstreamStorageManager
         }
 
         String storedLocation;
-        
+
+        // Read through a digest input stream that will work out the MD5
+        DigestInputStream dis = null;
+        try {
+            dis = new DigestInputStream(is, MessageDigest.getInstance("MD5"));
+        } catch (NoSuchAlgorithmException nsae) {
+            // Should never happen
+            log.warn("Caught NoSuchAlgorithmException", nsae);
+        }
+
+        if (dis == null) {
+            throw new IOException("couldn't create DigestInputStream");
+        }
+
         if(incoming == S3_ASSETSTORE) {
             String key = getFullS3Key(id);
             //Copy input stream to temp file, and send the file to S3 with some metadata
@@ -389,16 +402,6 @@ public class BitstreamStorageManager
             // Create the corresponding file and open it
             file.createNewFile();
             FileOutputStream fos = new FileOutputStream(file);
-
-            // Read through a digest input stream that will work out the MD5
-            DigestInputStream dis = null;
-
-            try {
-                dis = new DigestInputStream(is, MessageDigest.getInstance("MD5"));
-            } catch (NoSuchAlgorithmException nsae) {
-                // Should never happen
-                log.warn("Caught NoSuchAlgorithmException", nsae);
-            }
 
             Utils.bufferedCopy(dis, fos);
             fos.close();

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
@@ -19,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
 import java.util.*;
 
+import com.amazonaws.services.s3.transfer.TransferManager;
 import org.apache.log4j.Logger;
 import org.dspace.checker.BitstreamInfoDAO;
 import org.dspace.core.ConfigurationManager;
@@ -378,7 +379,8 @@ public class BitstreamStorageManager
                 objectMetadata.addUserMetadata(MD5_TAG, md5);
 
                 PutObjectRequest putObjectRequest = new PutObjectRequest(s3BucketName, key, scratchFile).withMetadata(objectMetadata);
-                PutObjectResult putObjectResult = s3Service.putObject(putObjectRequest);
+                TransferManager transferManager = new TransferManager();
+                transferManager.upload(putObjectRequest);
 
                 bitstream.setColumn("checksum", md5);
                 bitstream.setColumn("checksum_algorithm", CSA);

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
@@ -192,18 +192,6 @@ public class BitstreamStorageManager
             log.warn("S3 BucketName is not configured, setting default: " + s3BucketName);
         }
 
-        try {
-            if (! s3Service.doesBucketExist(s3BucketName)) {
-                s3Service.createBucket(s3BucketName);
-                log.info("Creating new S3 Bucket: " + s3BucketName);
-            }
-        }
-        catch (Exception e)
-            {
-                log.error(e);
-                throw new IOException(e);
-            }
-
         // region
         if (awsRegionName != null && awsRegionName.length() > 0) {
             try {
@@ -214,6 +202,18 @@ public class BitstreamStorageManager
             } catch (IllegalArgumentException e) {
                 log.warn("Invalid aws_region: " + awsRegionName);
             }
+        }
+
+        try {
+            if (! s3Service.doesBucketExist(s3BucketName)) {
+                s3Service.createBucket(s3BucketName);
+                log.info("Creating new S3 Bucket: " + s3BucketName);
+            }
+        }
+        catch (Exception e)
+        {
+            log.error(e);
+            throw new IOException(e);
         }
 
         log.info("AWS S3 Assetstore ready to go! bucket:" + s3BucketName);

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
@@ -19,7 +19,6 @@ import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
 import java.util.*;
 
-import com.amazonaws.services.s3.transfer.TransferManager;
 import org.apache.log4j.Logger;
 import org.dspace.checker.BitstreamInfoDAO;
 import org.dspace.core.ConfigurationManager;
@@ -379,8 +378,7 @@ public class BitstreamStorageManager
                 objectMetadata.addUserMetadata(MD5_TAG, md5);
 
                 PutObjectRequest putObjectRequest = new PutObjectRequest(s3BucketName, key, scratchFile).withMetadata(objectMetadata);
-                TransferManager transferManager = new TransferManager();
-                transferManager.upload(putObjectRequest);
+                PutObjectResult putObjectResult = s3Service.putObject(putObjectRequest);
 
                 bitstream.setColumn("checksum", md5);
                 bitstream.setColumn("checksum_algorithm", CSA);

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
@@ -407,12 +407,10 @@ public class BitstreamStorageManager
             fos.close();
             is.close();
 
-            if (dis != null) {
-                bitstream.setColumn("checksum", Utils.toHex(dis.getMessageDigest()
-                                                            .digest()));
-                bitstream.setColumn("checksum_algorithm", "MD5");
-                bitstream.setColumn("size_bytes", file.length());
-            }
+            bitstream.setColumn("checksum", Utils.toHex(dis.getMessageDigest()
+                                                        .digest()));
+            bitstream.setColumn("checksum_algorithm", "MD5");
+            bitstream.setColumn("size_bytes", file.length());
 
             storedLocation = file.getAbsolutePath();
         }


### PR DESCRIPTION
Also add the md5 as metadata to the uploaded S3 object.

Fixes part of https://trello.com/c/VcJyZI19/591-urgent-make-sure-etags-and-md5s-are-clearly-marked-on-s3-objects