### PR TITLE
cover image shouldn't show if there isn't one

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadJournalConcept.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadJournalConcept.java
@@ -220,7 +220,7 @@ public class DryadJournalConcept extends DryadOrganizationConcept {
 
     public String getCoverImage() {
         String coverImagePath = getConceptMetadataValue(metadataProperties.getProperty(COVER_IMAGE));
-        if (coverImagePath != null) {
+        if (!"".equals(coverImagePath)) {
             File coverImageFile = new File(coverImagePath);
             return "https://s3.amazonaws.com/dryad-web-assets/coverimages/" + coverImageFile.getName();
         }


### PR DESCRIPTION
Fixes https://trello.com/c/fenLkvxm/610-bug-data-package-pages-for-non-integrated-journals-displaying-broken-image-for-journal-cover