### PR TITLE
Disable Java-based timer for journal-submit

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2465,9 +2465,6 @@ solr.default.filter.override=location
 # This configuration is set by the Maven profiles:
 submit.journal.config=${default.submit.journal.config}
 
-# this sets the frequency of the email harvester, in number of seconds.
-submit.journal.email.timer = ${default.submit.journal.email.timer}
-
 # Settings for Gmail account and associated OAuth stuff
 submit.journal.credential.dir = ${dspace.dir}/submission/credential
 submit.journal.email = ${default.submit.journal.email}

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -42,10 +42,6 @@ public class DryadEmailSubmission extends HttpServlet {
     private static String PROPERTIES_PROPERTY = "dryad.properties.filename";
 
     private static String EMAIL_TEMPLATE = "journal_submit_error";
-
-    // Timer for scheduled harvesting of emails
-    private Timer myEmailHarvester;
-
     private static DryadGmailService dryadGmailService;
 
     /**
@@ -212,12 +208,6 @@ public class DryadEmailSubmission extends HttpServlet {
 
             dryadGmailService = new DryadGmailService();
         }
-
-//        LOGGER.debug("scheduling email harvesting");
-//        myEmailHarvester = new Timer();
-//        // schedule email harvesting to happen once an hour
-//        int timerInterval = Integer.parseInt(ConfigurationManager.getProperty("submit.journal.email.timer"));
-//        myEmailHarvester.schedule(new DryadEmailSubmissionHarvester(), 0, 1000 * timerInterval);
     }
 
     private void processMimeMessage (MimeMessage mime) throws Exception {
@@ -419,12 +409,5 @@ public class DryadEmailSubmission extends HttpServlet {
             throws IOException {
         aResponse.setContentType("xml/application; charset=UTF-8");
         return aResponse.getWriter();
-    }
-
-    private class DryadEmailSubmissionHarvester extends TimerTask {
-        @Override
-        public void run() {
-            retrieveMail();
-        }
     }
 }

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -213,11 +213,11 @@ public class DryadEmailSubmission extends HttpServlet {
             dryadGmailService = new DryadGmailService();
         }
 
-        LOGGER.debug("scheduling email harvesting");
-        myEmailHarvester = new Timer();
-        // schedule email harvesting to happen once an hour
-        int timerInterval = Integer.parseInt(ConfigurationManager.getProperty("submit.journal.email.timer"));
-        myEmailHarvester.schedule(new DryadEmailSubmissionHarvester(), 0, 1000 * timerInterval);
+//        LOGGER.debug("scheduling email harvesting");
+//        myEmailHarvester = new Timer();
+//        // schedule email harvesting to happen once an hour
+//        int timerInterval = Integer.parseInt(ConfigurationManager.getProperty("submit.journal.email.timer"));
+//        myEmailHarvester.schedule(new DryadEmailSubmissionHarvester(), 0, 1000 * timerInterval);
     }
 
     private void processMimeMessage (MimeMessage mime) throws Exception {


### PR DESCRIPTION
It’ll be easier and less error-prone to set this using curls and crontab.