### PR TITLE
Add former manuscript number metadata field

### DIFF
--- a/dspace/config/registries/dryad-types.xml
+++ b/dspace/config/registries/dryad-types.xml
@@ -48,5 +48,9 @@
         <schema>dryad</schema>
         <element>duplicateItem</element>
     </dc-type>
+    <dc-type>
+        <schema>dryad</schema>
+        <element>formerManuscriptNumber</element>
+    </dc-type>
 
 </dspace-dc-types>

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -59,6 +59,10 @@ public class DryadDataPackage extends DryadObject {
     private static final String MANUSCRIPT_NUMBER_ELEMENT = "identifier";
     private static final String MANUSCRIPT_NUMBER_QUALIFIER = "manuscriptNumber";
 
+    private static final String FORMER_MANUSCRIPT_NUMBER_SCHEMA = "dryad";
+    private static final String FORMER_MANUSCRIPT_NUMBER_ELEMENT = "formerManuscriptNumber";
+    private static final String FORMER_MANUSCRIPT_NUMBER_QUALIFIER = null;
+
     private static final String BLACKOUT_UNTIL_SCHEMA = "dc";
     private static final String BLACKOUT_UNTIL_ELEMENT = "date";
     private static final String BLACKOUT_UNTIL_QUALIFIER = "blackoutUntil";
@@ -476,6 +480,13 @@ public class DryadDataPackage extends DryadObject {
         addSingleMetadataValue(Boolean.TRUE, MANUSCRIPT_NUMBER_SCHEMA, MANUSCRIPT_NUMBER_ELEMENT, MANUSCRIPT_NUMBER_QUALIFIER, manuscriptNumber);
     }
 
+    public String getFormerManuscriptNumber() throws SQLException {
+        return getSingleMetadataValue(MANUSCRIPT_NUMBER_SCHEMA, MANUSCRIPT_NUMBER_ELEMENT, MANUSCRIPT_NUMBER_QUALIFIER);
+    }
+
+    public void setFormerManuscriptNumber(String manuscriptNumber) throws SQLException {
+        addSingleMetadataValue(Boolean.TRUE, FORMER_MANUSCRIPT_NUMBER_SCHEMA, FORMER_MANUSCRIPT_NUMBER_ELEMENT, FORMER_MANUSCRIPT_NUMBER_QUALIFIER, manuscriptNumber);
+    }
     public void setBlackoutUntilDate(Date blackoutUntilDate) throws SQLException {
         String dateString = null;
         if(blackoutUntilDate != null)  {

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -246,8 +246,7 @@ public class JournalUtils {
                 if (manuscriptMatcher.find()) {
                     canonicalID = manuscriptMatcher.group(1);
                 } else {
-                    log.error("Manuscript " + manuscriptId + " does not match with the regex provided for " + journalConcept.getFullName() + ": '" + journalConcept.getCanonicalManuscriptNumberPattern() + "'");
-                    throw new ParseException("'" + manuscriptId + "' does not match regex '" + journalConcept.getCanonicalManuscriptNumberPattern() + "'", 0);
+                    log.info("Manuscript " + manuscriptId + " does not match with the regex provided for " + journalConcept.getFullName() + ": '" + journalConcept.getCanonicalManuscriptNumberPattern() + "'");
                 }
             } else {
                 // there is no regex specified, just use the manuscript.

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -382,8 +382,24 @@ public class JournalUtils {
         return null;
     }
 
+    public static boolean manuscriptIsKnownFormerManuscriptNumber(Item item, Manuscript manuscript) {
+        if (manuscript.getManuscriptId() == null) {
+            return false;
+        }
+        // is this manuscript one of this package's former msids?
+        DCValue[] formerMSIDs = item.getMetadata("dryad.formerManuscriptNumber");
+        if (formerMSIDs != null && formerMSIDs.length > 0) {
+            for (DCValue formerMSID : formerMSIDs) {
+                if (formerMSID.value.equalsIgnoreCase(manuscript.getManuscriptId())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     // NOTE: identifier can be either journalCode or ISSN
-    public static List<Manuscript> getManuscriptsMatchingID(DryadJournalConcept journalConcept, String manuscriptId) {
+    private static List<Manuscript> getManuscriptsMatchingID(DryadJournalConcept journalConcept, String manuscriptId) {
         ArrayList<Manuscript> manuscripts = new ArrayList<Manuscript>();
         try {
             StoragePath storagePath = StoragePath.createManuscriptPath(journalConcept.getISSN(), getCanonicalManuscriptID(manuscriptId, journalConcept));

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -349,6 +349,8 @@ public class ApproveRejectReviewItem {
         if (manuscript != null) {
             // clear publication DOI
             dataPackage.setPublicationDOI(null);
+            // If there is a manuscript number, move it to former msid
+            dataPackage.setFormerManuscriptNumber(dataPackage.getManuscriptNumber());
             // clear Manuscript ID
             dataPackage.setManuscriptNumber(null);
             // disjoin keywords

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -224,7 +224,7 @@ public class ApproveRejectReviewItem {
             //Check for a valid task
             // There must be a claimedTask & it must be in the review stage, else it isn't a review workflowitem
             Item item = wfi.getItem();
-            DryadDataPackage dataPackage = DryadDataPackage.findByWorkflowItemId(c, wfi.getID());
+            DryadDataPackage dataPackage = new DryadDataPackage(item);
             StringBuilder provenance = new StringBuilder();
             c.turnOffAuthorisationSystem();
             // update duplicate submission metadata for this item.

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -104,7 +104,7 @@ public class ApproveRejectReviewItem {
         ManuscriptDatabaseStorageImpl manuscriptDatabaseStorage = new ManuscriptDatabaseStorageImpl();
         try {
             List<Manuscript> storedManuscripts = manuscriptDatabaseStorage.getManuscriptsMatchingManuscript(manuscript);
-            if (storedManuscripts != null && storedManuscripts.size() > 0) {
+            if (storedManuscripts != null && storedManuscripts.size() > 0 && !JournalUtils.manuscriptIsKnownFormerManuscriptNumber(item, storedManuscripts.get(0))) {
                 log.info("found stored manuscript " + storedManuscripts.get(0).getManuscriptId() + " with status " + storedManuscripts.get(0).getLiteralStatus());
                 reviewItem(statusIsApproved(storedManuscripts.get(0).getStatus()), workflowItem.getID());
             }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -224,7 +224,6 @@ public class ApproveRejectReviewItem {
             Item item = wfi.getItem();
             DryadDataPackage dataPackage = DryadDataPackage.findByWorkflowItemId(c, wfi.getID());
             StringBuilder provenance = new StringBuilder();
-            associateWithManuscript(dataPackage, manuscript, provenance);
             // update duplicate submission metadata for this item.
             item.checkForDuplicateItems(c);
             if (claimedTasks == null || claimedTasks.isEmpty() || !claimedTasks.get(0).getActionID().equals("reviewAction")) {
@@ -232,6 +231,7 @@ public class ApproveRejectReviewItem {
             } else {
                 ClaimedTask claimedTask = claimedTasks.get(0);
                 c.turnOffAuthorisationSystem();
+                associateWithManuscript(dataPackage, manuscript, provenance);
                 if (statusIsApproved(manuscript.getStatus())) { // approve
                     Workflow workflow = WorkflowFactory.getWorkflow(wfi.getCollection());
                     WorkflowActionConfig actionConfig = workflow.getStep(claimedTask.getStepID()).getActionConfig(claimedTask.getActionID());

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -104,9 +104,13 @@ public class ApproveRejectReviewItem {
         ManuscriptDatabaseStorageImpl manuscriptDatabaseStorage = new ManuscriptDatabaseStorageImpl();
         try {
             List<Manuscript> storedManuscripts = manuscriptDatabaseStorage.getManuscriptsMatchingManuscript(manuscript);
-            if (storedManuscripts != null && storedManuscripts.size() > 0 && !JournalUtils.manuscriptIsKnownFormerManuscriptNumber(item, storedManuscripts.get(0))) {
+            if (storedManuscripts != null && storedManuscripts.size() > 0) {
                 log.info("found stored manuscript " + storedManuscripts.get(0).getManuscriptId() + " with status " + storedManuscripts.get(0).getLiteralStatus());
-                reviewItem(statusIsApproved(storedManuscripts.get(0).getStatus()), workflowItem.getID());
+                if (!JournalUtils.manuscriptIsKnownFormerManuscriptNumber(item, storedManuscripts.get(0))) {
+                    reviewItem(statusIsApproved(storedManuscripts.get(0).getStatus()), workflowItem.getID());
+                } else {
+                    log.info("stored manuscript match was a known former manuscript number");
+                }
             }
         } catch (Exception e) {
             log.error("couldn't process review workflowitem " + workflowItem.getID() + ": " + e.getMessage());

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/ApproveRejectReviewItem.java
@@ -105,9 +105,10 @@ public class ApproveRejectReviewItem {
         try {
             List<Manuscript> storedManuscripts = manuscriptDatabaseStorage.getManuscriptsMatchingManuscript(manuscript);
             if (storedManuscripts != null && storedManuscripts.size() > 0) {
-                log.info("found stored manuscript " + storedManuscripts.get(0).getManuscriptId() + " with status " + storedManuscripts.get(0).getLiteralStatus());
-                if (!JournalUtils.manuscriptIsKnownFormerManuscriptNumber(item, storedManuscripts.get(0))) {
-                    reviewItem(statusIsApproved(storedManuscripts.get(0).getStatus()), workflowItem.getID());
+                Manuscript storedManuscript = storedManuscripts.get(0);
+                log.info("found stored manuscript " + storedManuscript.getManuscriptId() + " with status " + storedManuscript.getLiteralStatus());
+                if (!JournalUtils.manuscriptIsKnownFormerManuscriptNumber(item, storedManuscript)) {
+                    reviewItem(statusIsApproved(storedManuscript.getStatus()), workflowItem.getID());
                 } else {
                     log.info("stored manuscript match was a known former manuscript number");
                 }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
@@ -126,7 +126,7 @@ public class AutoReturnReviewItem {
                     // make sure that this item is updated according to the ApproveReject mechanism:
                     if (!testMode) {
                         log.info("check to see if item " + item.getID() + " is approved or rejected");
-                        ApproveRejectReviewItem.reviewItem(wfi);
+                        ApproveRejectReviewItem.lookupReviewItem(wfi);
                     }
                     if (itemIsOldItemInReview(item)) {
                         if (testMode) {

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
@@ -116,10 +116,6 @@ public class AutoReturnReviewItem {
         List<ClaimedTask> claimedTasks = null;
         try {
             if (wfi != null) {
-                // make sure that this item is updated according to the ApproveReject mechanism:
-                if (!testMode) {
-                    ApproveRejectReviewItem.reviewItem(wfi);
-                }
                 claimedTasks = ClaimedTask.findByWorkflowId(context, wfi.getID());
                 //Check for a valid task
                 // There must be a claimedTask & it must be in the review stage, else it isn't a review workflowitem
@@ -127,6 +123,11 @@ public class AutoReturnReviewItem {
                 if (claimedTasks == null || claimedTasks.isEmpty() || !claimedTasks.get(0).getActionID().equals("reviewAction")) {
                     log.debug("Item " + item.getID() + " not found or not in review");
                 } else {
+                    // make sure that this item is updated according to the ApproveReject mechanism:
+                    if (!testMode) {
+                        log.info("check to see if item " + item.getID() + " is approved or rejected");
+                        ApproveRejectReviewItem.reviewItem(wfi);
+                    }
                     if (itemIsOldItemInReview(item)) {
                         if (testMode) {
                             log.info("TEST: return item " + item.getID());

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
@@ -299,7 +299,7 @@ public class WorkflowItem implements InProgressSubmission {
         Item item = getItem();
         // make sure this isn't matching a former msid:
         if (JournalUtils.manuscriptIsKnownFormerManuscriptNumber(item,manuscript)) {
-            log.error("manuscript number " + manuscript.getManuscriptId() + " matches a former msid");
+            log.error("manuscript number " + manuscript.getManuscriptId() + " matches a former msid for item " + item.getID());
             return false;
         }
         // check to see if this matches by msid:

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/WorkflowItem.java
@@ -297,6 +297,11 @@ public class WorkflowItem implements InProgressSubmission {
     private boolean compareToManuscript(Manuscript manuscript, StringBuilder result) {
         boolean matched = false;
         Item item = getItem();
+        // make sure this isn't matching a former msid:
+        if (JournalUtils.manuscriptIsKnownFormerManuscriptNumber(item,manuscript)) {
+            log.error("manuscript number " + manuscript.getManuscriptId() + " matches a former msid");
+            return false;
+        }
         // check to see if this matches by msid:
         DCValue[] msids = item.getMetadata("dc", "identifier", "manuscriptNumber", Item.ANY);
         if (msids != null && msids.length > 0) {

--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/handler/ManuscriptReviewStatusChangeHandler.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/handler/ManuscriptReviewStatusChangeHandler.java
@@ -65,7 +65,7 @@ public class ManuscriptReviewStatusChangeHandler implements HandlerInterface<Man
                 // if it's just a submitted notice, there is no status to change.
                 return;
             }
-            ApproveRejectReviewItem.reviewManuscript(manuscript);
+            ApproveRejectReviewItem.processWorkflowItemsUsingManuscript(manuscript);
         } catch (ApproveRejectReviewItemException ex) {
             throw new HandlerException("Exception handling acceptance notice for manuscript " + manuscript.getManuscriptId(), ex);
         }

--- a/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
+++ b/dspace/modules/journal-submit/src/main/java/org/datadryad/submission/DryadEmailSubmission.java
@@ -366,7 +366,7 @@ public class DryadEmailSubmission extends HttpServlet {
                         LOGGER.error("Error Initializing DSpace kernel in ManuscriptReviewStatusChangeHandler", ex);
                     }
 
-                    ApproveRejectReviewItem.reviewManuscript(manuscript);
+                    ApproveRejectReviewItem.processWorkflowItemsUsingManuscript(manuscript);
                 }
             } catch (StorageException e) {
                 LOGGER.error("failed to write ms " + manuscript.getManuscriptId());

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -14,10 +14,7 @@ import org.dspace.core.I18nUtil;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
 import org.dspace.storage.rdbms.TableRowIterator;
-import org.dspace.workflow.ApproveRejectReviewItem;
-import org.dspace.workflow.ClaimedTask;
-import org.dspace.workflow.DryadWorkflowUtils;
-import org.dspace.workflow.WorkflowItem;
+import org.dspace.workflow.*;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -275,14 +272,17 @@ public class PublicationUpdater extends HttpServlet {
                                 }
                                 if (databaseManuscript.isAccepted()) {
                                     // see if this can be pushed out of review
-                                    ApproveRejectReviewItem.processWorkflowItemWithManuscript(context, wfi, databaseManuscript);
+                                    ApproveRejectReviewItem.processWorkflowItemUsingManuscript(context, wfi, databaseManuscript);
                                 }
                             }
                         }
                     } catch (ParseException e) {
                         // do we want to collect workflow items with faulty manuscript IDs?
                         LOGGER.error("Problem updating item " + item.getID() + ": Manuscript ID is incorrect.");
+                    } catch (ApproveRejectReviewItemException e) {
+                        LOGGER.error("Exception caught while reviewing item " + wfi.getItem().getID() + ": " + e.getMessage());
                     }
+
 
                     message.append(matchItemToCrossref(context, item));
                     if (!"".equals(message.toString())) {

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -267,7 +267,8 @@ public class PublicationUpdater extends HttpServlet {
                         databaseManuscripts = JournalUtils.getStoredManuscriptsMatchingManuscript(queryManuscript);
                         if (databaseManuscripts != null && databaseManuscripts.size() > 0) {
                             databaseManuscript = databaseManuscripts.get(0);
-                            if (isInReview) {     // only update the metadata if the item is in review.
+                            // only update the metadata if the item is in review and this ms is not one of the known former msids for this item.
+                            if (isInReview && !JournalUtils.manuscriptIsKnownFormerManuscriptNumber(item, databaseManuscript)) {
                                 StringBuilder provenance = new StringBuilder("Journal-provided metadata for msid " + databaseManuscript.getManuscriptId() + " with title '" + databaseManuscript.getTitle() + "' was added. ");
                                 if (updateItemMetadataFromManuscript(item, databaseManuscript, context, provenance)) {
                                     message = provenance;


### PR DESCRIPTION
Addresses https://trello.com/c/DhrRqIdS/586-add-metadata-field-for-formermanuscriptnumber.

This is a bit tricky to test. Find a package in review that corresponds to a manuscript in our database. Remove the manuscript number from the metadata, so that it has to match based on title/author. If you then run a PUT command on `api/v1/organizations/xxxx/manuscripts` with the json_data for the rejection as the body, the package should be moved back to the submitter’s workspace. If you look at the package’s metadata, you should see the former msid in the metadata. If you then resubmit it and re-run the PUT, you should see a comment about “manuscript number xxxx matches a former msid for item xxx”. The item won’t move into workspace because there’s not really a way for it to return to review stage, so it should stay in curation.