### PR TITLE
Page index count should start at indexFrom+1 and go to indexTo

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/ResultSet.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/ResultSet.java
@@ -147,7 +147,7 @@ public class ResultSet {
                 indexTo = itemList.size();
             }
             log.debug("list from " + indexFrom + " to " + indexTo);
-            for (int i = indexFrom; i <= indexTo; i++) {
+            for (int i = indexFrom+1; i <= indexTo; i++) {
                 resultList.add(itemList.get(i));
             }
         }


### PR DESCRIPTION
Error reported in packages API, but probably present in other APIs as well: “When paging through journals, entries are repeated. For example, http://datadryad.org/api/v1/journals?count=3 ends with "Acta Palaeontologica Polonica". But the next page in the list, http://datadryad.org/api/v1/journals?cursor=2337&count=3, also starts with "Acta Palaeontologica Polonica”.”

This error is actually because the second page has four entries instead of three, starting with the last entry from the previous page.