### PR TITLE
Allow more than one ISSN in concept metadata values

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/AuthorityObject.java
@@ -274,7 +274,7 @@ public abstract class AuthorityObject extends DSpaceObject {
         Context context = getContext();
         try {
             TableRowIterator tri = DatabaseManager.queryTable(context, this.getMetadataTable() ,
-                    "SELECT * FROM " + this.getMetadataTable() + " WHERE parent_id= ? ORDER BY field_id",
+                    "SELECT * FROM " + this.getMetadataTable() + " WHERE parent_id= ? ORDER BY field_id, place asc",
                     getID());
 
             if (tri != null) {

--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/authority/FlowAuthorityMetadataValueUtils.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/authority/FlowAuthorityMetadataValueUtils.java
@@ -7,6 +7,7 @@ import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
 import org.dspace.content.authority.AuthorityMetadataValue;
 import org.dspace.content.authority.AuthorityObject;
 import org.dspace.content.authority.Choices;
@@ -18,6 +19,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 
 /**
  * User: lantian @ atmire . com
@@ -144,12 +146,17 @@ public class FlowAuthorityMetadataValueUtils {
         String value = request.getParameter("value");
         String language = request.getParameter("language");
 
+        AuthorityObject thisObject = AuthorityObject.find(context, type, id);
+        MetadataField thisField = MetadataField.find(Integer.parseInt(fieldID));
+        List<AuthorityMetadataValue> authorityMetadataValues = thisObject.getMetadata(thisField.getSchemaName(), thisField.getElement(), thisField.getQualifier());
+
         //add email to concept metadata
         AuthorityMetadataValue authorityMetadataValue = new AuthorityMetadataValue(tableName);
 
         authorityMetadataValue.setValue(value);
         authorityMetadataValue.setFieldId(Integer.parseInt(fieldID));
         authorityMetadataValue.setParentId(id);
+        authorityMetadataValue.setPlace(authorityMetadataValues.size()+1);
         authorityMetadataValue.create(context);
         context.addEvent(new Event(Event.MODIFY_METADATA, type, id, null));
         context.commit();

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadJournalConcept.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadJournalConcept.java
@@ -206,7 +206,14 @@ public class DryadJournalConcept extends DryadOrganizationConcept {
     }
 
     public List<String> getISSNs() {
-        return getConceptMetadataValues(metadataProperties.getProperty(ISSN));
+        List<String> results = new ArrayList<>();
+        List<String> issns = getConceptMetadataValues(metadataProperties.getProperty(ISSN));
+        for (String issn : issns) {
+            if (!"".equals(issn)) {
+                results.add(issn);
+            }
+        }
+        return results;
     }
 
     public String getISSN() {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadJournalConcept.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadJournalConcept.java
@@ -17,6 +17,7 @@ import java.lang.*;
 import java.lang.Exception;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -204,12 +205,22 @@ public class DryadJournalConcept extends DryadOrganizationConcept {
         setConceptMetadataValue(metadataProperties.getProperty(METADATADIR), value);
     }
 
+    public List<String> getISSNs() {
+        return getConceptMetadataValues(metadataProperties.getProperty(ISSN));
+    }
+
     public String getISSN() {
-        return getConceptMetadataValue(metadataProperties.getProperty(ISSN));
+        List<String> issns = getISSNs();
+        if (issns.size() > 0) {
+            return issns.get(0);
+        }
+        return "";
     }
 
     public void setISSN(String value) {
-        setConceptMetadataValue(metadataProperties.getProperty(ISSN), value);
+        if (!getISSNs().contains(value)) {
+            addConceptMetadataValue(metadataProperties.getProperty(ISSN), value);
+        }
     }
 
     @Override

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -187,8 +187,10 @@ public class JournalUtils {
                     break;
                 }
             }
-            if (!"".equals(journalConcept.getISSN())) {
-                journalConceptHashMapByISSN.put(journalConcept.getISSN(), journalConcept);
+            if (journalConcept.getISSNs().size() > 0) {
+                for (String issn : journalConcept.getISSNs()) {
+                    journalConceptHashMapByISSN.put(issn, journalConcept);
+                }
             }
 
             for (DryadJournalConcept concept : recentlyIntegratedJournals) {

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -595,7 +595,7 @@ public class JournalUtils {
         for (String crossRefURL : crossRefURLs) {
             Manuscript currentMatch = null;
             try {
-                resultString.append("crossref url was ").append(crossRefURL).append("\n");
+                resultString.append("\n\tcrossref url was ").append(crossRefURL).append("\n");
                 URL url = new URL(crossRefURL.replaceAll("\\s+", ""));
                 ObjectMapper m = new ObjectMapper();
                 JsonNode rootNode = m.readTree(url.openStream());

--- a/dspace/modules/publication-updater/pom.xml
+++ b/dspace/modules/publication-updater/pom.xml
@@ -19,8 +19,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<fork>true</fork>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
This has been kicking around as an idea for awhile: in case journals have multiple ISSNs, like print, electronic, etc., we should be able to have more than one available. The first one is the primary one we use, but others can be listed as multiple metadata values.