### PR TITLE
Show README and other file information in submission overview

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
@@ -236,7 +236,26 @@ public class DryadDataFile extends DryadObject {
         return result;
     }
 
-    
+    public Bitstream getREADME() {
+        Item item = getItem();
+
+        try {
+            Bundle[] bundles = item.getBundles();
+
+            if (bundles.length > 0) {
+                Bitstream[] bitstreams = bundles[0].getBitstreams();
+                for (Bitstream bitstream : bitstreams) {
+                    if (bitstream.getName().toLowerCase().contains("readme")) {
+                        return bitstream;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("couldn't get bundles for item " + item.getID());
+        }
+        return null;
+    }
+
     public Long getTotalStorageSize() throws SQLException {
         // bundles and bitstreams
         Long size = 0L;

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
@@ -222,8 +222,7 @@ public class DryadDataFile extends DryadObject {
             result = bitstreams[i];
             String name = result.getName();
 
-            if (!name.equalsIgnoreCase("readme.txt")
-                && !name.equalsIgnoreCase("readme.txt.txt")) {
+            if (!name.toLowerCase().contains("readme.")) {
                 log.debug("Retrieving bitstream " + name);
                 found = true;
             }
@@ -245,7 +244,7 @@ public class DryadDataFile extends DryadObject {
             if (bundles.length > 0) {
                 Bitstream[] bitstreams = bundles[0].getBitstreams();
                 for (Bitstream bitstream : bitstreams) {
-                    if (bitstream.getName().toLowerCase().contains("readme")) {
+                    if (bitstream.getName().toLowerCase().contains("readme.")) {
                         return bitstream;
                     }
                 }

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/OverviewStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/OverviewStep.java
@@ -1,5 +1,6 @@
 package org.dspace.app.xmlui.aspect.submission.submit;
 
+import org.datadryad.api.DryadDataFile;
 import org.dspace.app.util.Util;
 import org.dspace.app.xmlui.aspect.submission.AbstractStep;
 import org.dspace.app.xmlui.utils.UIException;
@@ -282,6 +283,12 @@ public class OverviewStep extends AbstractStep {
             datasetTitle = "Untitled";
 
         dataItem.addXref(HandleManager.resolveToURL(context, dataset.getHandle()), datasetTitle);
+        DryadDataFile dryadDataFile = new DryadDataFile(dataset);
+        Bitstream readme = dryadDataFile.getREADME();
+        if (readme != null) {
+            dataItem.addContent(" *includes README ");
+        }
+
 
         Button editButton = dataItem.addButton("submit_edit_dataset_" + wsDataset.getID());
         //To determine which name our button is getting check if we are through submission with this


### PR DESCRIPTION
Revamps the file listing in submission overview. 

Fixes https://trello.com/c/x4gAAi9b/623-display-readmes-on-review-submission-page-in-submission-system