### PR TITLE
Apache client update for DataONE

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -266,20 +266,16 @@
             <groupId>org.dspace</groupId>
             <artifactId>dspace-services-impl</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-        </dependency>
-
-
+	<dependency>
+	  <groupId>org.apache.httpcomponents</groupId>
+	  <artifactId>httpclient</artifactId>
+	  <version>4.5.3</version>
+	</dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
             <version>1.4.1</version>
         </dependency>
-
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/dspace/modules/api/pom.xml
+++ b/dspace/modules/api/pom.xml
@@ -153,12 +153,6 @@
            <artifactId>dspace-solr-solrj</artifactId>
            <version>1.4.0.1</version>
        </dependency>
-       <!---->
-       <!--<dependency>-->
-           <!--<groupId>org.apache.solr</groupId>-->
-           <!--<artifactId>solr-solrj</artifactId>-->
-           <!--<version>1.4.1</version>-->
-       <!--</dependency>-->
 
        <dependency>
            <groupId>org.dspace.modules</groupId>
@@ -170,16 +164,12 @@
 	        <artifactId>doi-service</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
-        </dependency>
        <dependency>
-           <groupId>org.apache.httpcomponents</groupId>
-           <artifactId>httpclient</artifactId>
-           <version>4.3.4</version>
+	 <groupId>org.apache.httpcomponents</groupId>
+	 <artifactId>httpclient</artifactId>
+	 <version>4.5.3</version>
        </dependency>
+       
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -187,11 +177,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!--dependency>
-            <groupId>org.dspace.modules</groupId>
-            <artifactId>versioning-api</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency-->
        <dependency>
            <groupId>org.glassfish.jersey.core</groupId>
            <artifactId>jersey-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -559,11 +559,11 @@
             <artifactId>oclc-harvester2</artifactId>
             <version>0.1.12</version>
          </dependency>
-         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
-         </dependency>
+	 <dependency>
+	   <groupId>org.apache.httpcomponents</groupId>
+	   <artifactId>httpclient</artifactId>
+	   <version>4.5.3</version>
+	 </dependency>
          <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
Fixes the first issue on https://trello.com/c/uvOwJ7Lj --- allows bitstreams to be downloaded through the DataONE API using a URL like http://datadryad.org/mn/object/doi:10.5061/dryad.20/1/bitstream

Also removes some old entries in pom files that were already commented out.