### PR TITLE
Don't double the DOI prefix

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace/modules/api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -389,6 +389,8 @@ public class DOIIdentifierProvider extends IdentifierProvider implements org.spr
             Matcher doimatcher = Pattern.compile("doi:(.+)").matcher(itemDOI);
             if (doimatcher.find()) {
                 doi_url = "https://doi.org/" + doimatcher.group(1);
+            } else if (itemDOI.startsWith("http://doi.org") || itemDOI.startsWith("https://doi.org")) {
+                doi_url = itemDOI;
             } else {
                 doi_url = "https://doi.org/" + itemDOI;
             }


### PR DESCRIPTION
Corrects the second problem from https://trello.com/c/uvOwJ7Lj -- in DataONE metadata, the dcterms.identifer has two copies of "https://doi.org". 

To test, look at a URL like https://SERVERNAME/mn/object/doi:10.5061/dryad.1850, and verify the dcterms.identifier is formatted correctly.