### PR TITLE
Use the "polite" form of API queries to CrossRef 

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -51,7 +51,7 @@ public class JournalUtils {
         JOURNAL_NOT_INTEGRATED
     }
 
-    public final static String crossRefApiRoot = "http://api.crossref.org/";
+    public final static String crossRefApiRoot = "https://api.crossref.org/";
     public final static String nsfApiRoot = "http://api.nsf.gov/services/v1/awards/";
 
     public static final String archivedDataPackageIds    = "SELECT * FROM ArchivedPackageItemIdsByJournal(?,?);";
@@ -552,7 +552,7 @@ public class JournalUtils {
     public static String getCrossRefJournalForISSN(String issn) throws RESTModelException {
         String crossRefURL = crossRefApiRoot + "journals/" + issn;
         try {
-            URL url = new URL(crossRefURL.replaceAll("\\s+", ""));
+            URL url = new URL(crossRefURL.replaceAll("\\s+", "") + "?mailto=" + ConfigurationManager.getProperty("alert.recipient"));
             ObjectMapper m = new ObjectMapper();
             JsonNode rootNode = m.readTree(url.openStream());
             JsonNode titleNode = rootNode.path("message").path("title");
@@ -574,7 +574,8 @@ public class JournalUtils {
         StringBuilder queryString = new StringBuilder();
         String pubDOI = queryManuscript.getPublicationDOI();
         if (pubDOI != null && (!"".equals(StringUtils.stripToEmpty(pubDOI).replaceAll("null","")))) {
-            crossRefURLs.add(crossRefApiRoot + "works/" + queryManuscript.getPublicationDOI());
+            crossRefURLs.add(crossRefApiRoot + "works/" + queryManuscript.getPublicationDOI() +
+                             "?mailto=" + ConfigurationManager.getProperty("alert.recipient"));
         } else {
             // make a query string of the authors' last names
             ArrayList<String> lastNames = new ArrayList<String>();
@@ -588,7 +589,8 @@ public class JournalUtils {
             // append the title to the query
             queryString.append(queryManuscript.getTitle().replaceAll("[^a-zA-Z\\s]", "").replaceAll("\\s+", " "));
             for (String issn : queryManuscript.getJournalConcept().getISSNs()) {
-                crossRefURLs.add(crossRefApiRoot + "journals/" + issn + "/works?sort=score&order=desc&query=" + queryString.toString().replaceAll("\\s+", "+"));
+                crossRefURLs.add(crossRefApiRoot + "journals/" + issn + "/works?sort=score&order=desc&query=" +
+                                 queryString.toString().replaceAll("\\s+", "+") + "?mailto=" + ConfigurationManager.getProperty("alert.recipient"));
             }
         }
 

--- a/dspace/modules/api/src/main/java/org/dspace/submit/step/SelectPublicationStep.java
+++ b/dspace/modules/api/src/main/java/org/dspace/submit/step/SelectPublicationStep.java
@@ -11,6 +11,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
 import org.dspace.content.authority.Choices;
 import org.dspace.content.crosswalk.IngestionCrosswalk;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.PluginManager;
 import org.dspace.paymentsystem.PaymentSystemService;
@@ -62,7 +63,7 @@ public class SelectPublicationStep extends AbstractProcessingStep {
     public final static int  UNKNOWN_DOI=5;
     public final static int  MANU_ACC=6;
 
-    public final static String crossRefApiRoot = "http://api.crossref.org/works/";
+    public final static String crossRefApiRoot = "https://api.crossref.org/works/";
     public final static String crossRefApiFormat = "/transform/application/vnd.crossref.unixref+xml";
 
     public int doProcessing(Context context, HttpServletRequest request, HttpServletResponse response, SubmissionInfo submissionInfo) throws ServletException, IOException, SQLException, AuthorizeException {
@@ -118,7 +119,8 @@ public class SelectPublicationStep extends AbstractProcessingStep {
      **/
     private boolean processDOI(Context context, Item item, String identifier){
         try {
-            Element jElement = retrieveXML(crossRefApiRoot + identifier + crossRefApiFormat);
+            Element jElement = retrieveXML(crossRefApiRoot + identifier + crossRefApiFormat  +
+                                           "?mailto=" + ConfigurationManager.getProperty("alert.recipient"));
             if (jElement != null) {
                 if (!jElement.getName().equals("doi_records") || jElement.getChildren().size()==0) {
                     return false;


### PR DESCRIPTION
Updates calls to the CrossRef API to use the polite form as described by https://github.com/CrossRef/rest-api-doc#etiquette. All calls now use https, and include an email address that CrossRef can contact about problems.

This should correct the APU problem described by https://trello.com/c/0korba3U. In testing, the polite form of the call returns more consistent results than the non-polite form.