### PR TITLE
Make sure that the date is parseable by the SimpleDateFormat

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -510,7 +510,6 @@ public class JournalUtils {
      */
     public static TreeMap<Integer, Date> getArchivedPackagesFromKeyset(Context context, DryadJournalConcept journalConcept, int keyset) throws SQLException {
         TreeMap<Integer, Date> items = new TreeMap<Integer, Date>();
-        SimpleDateFormat dateIso = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         try {
             log.error("starting search");
             int pubNameFieldID = MetadataField.findByElement("prism.publicationName").getFieldID();
@@ -520,7 +519,13 @@ public class JournalUtils {
             while (tri.hasNext()) {
                 TableRow tableRow = tri.next();
                 int itemId = tableRow.getIntColumn("item_id");
-                Date date = dateIso.parse(tableRow.getStringColumn("mdv_date"));
+                String rawDate = tableRow.getStringColumn("mdv_date");
+                Matcher dateMatcher = Pattern.compile("(\\d+-\\d+-\\d+).?").matcher(rawDate);
+                Date date = null;
+                if (dateMatcher.find()) {
+                    SimpleDateFormat dateShort = new SimpleDateFormat("yyyy-MM-dd");
+                    date = dateShort.parse(dateMatcher.group(1));
+                }
                 items.put(itemId, date);
             }
             log.error("ending search");


### PR DESCRIPTION
Fixes new bugs discovered by Alf: https://datadryad.org/api/v1/journals/1471-2229/packages
https://datadryad.org//api/v1/journals/0014-3820/packages

In both cases, there were packages with a dc.date.accessioned with just a ‘yyyy-MM-dd’ formatted date, not a full ISO date. This was throwing a parseException.

These should now work correctly.