### PR TITLE
Don't process as a match if pub date is in the future

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -716,7 +716,6 @@ public class JournalUtils {
             try {
                 JsonNode dateParts = dateNode.path("date-parts").get(0);
                 Date date = dateFormat.parse(dateParts.get(0).intValue() + "-" + dateParts.get(1).intValue() + "-" + dateParts.get(2).intValue());
-                }
                 manuscript.setPublicationDate(date);
             } catch (ParseException e) {
                 log.error("couldn't parse date: " + dateNode.path("date-time").textValue());

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -637,6 +637,9 @@ public class JournalUtils {
 
             // sanity check:
             if (currentMatch != null) {
+                if (currentMatch.getPublicationDate() != null && currentMatch.getPublicationDate().after(new Date())) {
+                    throw new RESTModelException("CrossRef match has publication date in the future");
+                }
                 if (currentMatch.getAuthorList() == null || currentMatch.getAuthorList().size() == 0) {
                     throw new RESTModelException("CrossRef match does not have authors");
                 }

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -709,15 +709,15 @@ public class JournalUtils {
             }
         }
 
-        JsonNode dateNode = jsonNode.path("created");
+        JsonNode dateNode = jsonNode.path("issued");
         if (!dateNode.isMissingNode()) {
             //2016-04-11T17:53:39Z
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
             try {
-                if (dateNode.path("date-time") != null) {
-                    Date date = dateFormat.parse(dateNode.path("date-time").textValue());
-                    manuscript.setPublicationDate(date);
+                JsonNode dateParts = dateNode.path("date-parts").get(0);
+                Date date = dateFormat.parse(dateParts.get(0).intValue() + "-" + dateParts.get(1).intValue() + "-" + dateParts.get(2).intValue());
                 }
+                manuscript.setPublicationDate(date);
             } catch (ParseException e) {
                 log.error("couldn't parse date: " + dateNode.path("date-time").textValue());
             }

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -637,6 +637,9 @@ public class JournalUtils {
 
             // sanity check:
             if (currentMatch != null) {
+                if (currentMatch.getPublicationDate() == null) {
+                    throw new RESTModelException("CrossRef match does not have a publication date");
+                }
                 if (currentMatch.getPublicationDate() != null && currentMatch.getPublicationDate().after(new Date())) {
                     throw new RESTModelException("CrossRef match has publication date in the future");
                 }


### PR DESCRIPTION
https://trello.com/c/FyQsjq3m/635-for-some-journals-apu-alerts-us-to-articles-not-yet-published

I had been using the wrong field in the CrossRef results for publication date: I was using "created," which refers to the date the CrossRef data was created, instead of "issued," which refers to the first publication date of the article. So I have corrected several things: I switched to using "issued" and then I also now check for the presence of a date at all OR a date in the future, and throw exceptions in both of those cases.

To test, run the APU on a journal that submits CrossRef data for future publications, such as Communications Biology, ISSN 2399-3642. You should get several results with future pub dates, and those should throw an error in the pub-updater.log, saying "crossref match wasn't valid: CrossRef match has publication date in the future"