### PR TITLE
Verify status at checkout

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
@@ -905,9 +905,8 @@ public class FlowUtils {
 
 
 
-    private static void finishSubmission(Request request, Context context, Item publication) throws SQLException, AuthorizeException, IOException, TransformerException, WorkflowException, SAXException, WorkflowConfigurationException, MessagingException, ParserConfigurationException {
-
-       try{
+    private static void finishSubmission(Request request, Context context, Item publication) throws SQLException {
+        try {
             //We have completed everything time to start our dataset
             WorkspaceItem wsPublication = WorkspaceItem.findByItemId(context, publication.getID());
 
@@ -942,14 +941,14 @@ public class FlowUtils {
 
                 }
             }
-        }catch (Exception e){
+        } catch (Exception e){
             // adding an explicit rollback to save the integrity of the data
             // when an exception happens most likely spring doesn't throw it to
             // the Cocoon servlet that commit the transaction in every case.
             context.getDBConnection().rollback();
             log.error("Exception during CompleteSubmissionStep: ", e);
             throw new RuntimeException(e);
-       }
+        }
 
     }
 


### PR DESCRIPTION
Fixes https://trello.com/c/nKpVlxi0/642-bug-packages-should-be-checked-for-manuscript-status-at-time-of-submission-not-just-at-selectpublicationstep.

Test by choosing a manuscript for a journal that uses the review workflow. Manually set the ms to “submitted” in the database. Start a submission. Before checking out, change the ms status to “accepted” in the database. Check out. The item should move into the curation queue.

Do the same but change the status from “submitted” to “rejected.” The submission should move into review, but the msid should be in dryad.formerManuscriptNumber, not dc.identifier.manuscriptNumber.