### PR TITLE
Disable orcid lookup button

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/forms.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/forms.xsl
@@ -124,10 +124,10 @@
 
         <div class="spacer">&#160;</div>
         <!-- This div handles ORCID lookup-->
-        <div class="ds-form-content">
-            <xsl:call-template name="addLookupButtonAuthor"/><br/>
-            <a class="ds-form-content" href="http://orcid.org" target="_blank">What is ORCID?</a>
-        </div>
+        <!--<div class="ds-form-content">-->
+            <!--<xsl:call-template name="addLookupButtonAuthor"/><br/>-->
+            <!--<a class="ds-form-content" href="http://orcid.org" target="_blank">What is ORCID?</a>-->
+        <!--</div>-->
 
         <!-- This div handles manual author add-->
         <div class="ds-form-content">


### PR DESCRIPTION
tiny change to disable presentation of the ORCID lookup button, since it’s broken.