### PR TITLE
Curator notes

### DIFF
--- a/dspace/config/crosswalks/DIM2DATACITE.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE.xsl
@@ -322,7 +322,7 @@
 				<descriptions>
 					<description descriptionType="Other">
 					        <!-- Exclude provenance fields, since these often contain private information -->
-						<xsl:value-of select="dspace:field[@element='description' and not(@qualifier='provenance')]"/>
+						<xsl:value-of select="dspace:field[@element='description']"/>
 					</description>
 				</descriptions>
 			</xsl:if>

--- a/dspace/config/crosswalks/DIM2DATACITE.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE.xsl
@@ -322,7 +322,7 @@
 				<descriptions>
 					<description descriptionType="Other">
 					        <!-- Exclude provenance fields, since these often contain private information -->
-						<xsl:value-of select="dspace:field[@element='description']"/>
+						<xsl:value-of select="dspace:field[@element='description' and not(@qualifier='provenance')]"/>
 					</description>
 				</descriptions>
 			</xsl:if>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1099,6 +1099,11 @@ metadata.hide.dc.description.provenance = true
 metadata.hide.internal.payment.transactionID = true
 metadata.hide.internal.payment.charge = true
 metadata.hide.dryad.citationInProgress = true
+metadata.hide.dc.identifier.manuscriptNumber = true
+metadata.hide.dryad.formerManuscriptNumber = true
+metadata.hide.dryad.citationMismatchedDOI = true
+metadata.hide.dryad.duplicateItem = true
+metadata.hide.dryad.curatorNotePrivate = true
 ##### Settings for Submission Process #####
 
 # Should the submit UI block submissions marked as theses?

--- a/dspace/config/registries/dryad-types.xml
+++ b/dspace/config/registries/dryad-types.xml
@@ -23,10 +23,12 @@
     <dc-type>
     	<schema>dryad</schema>
       	<element>curatorNote</element>
+        <scope_note>Notes private to other curators</scope_note>
     </dc-type>
     <dc-type>
         <schema>dryad</schema>
         <element>curatorNotePublic</element>
+        <scope_note>Notes for public view</scope_note>
     </dc-type>
     <dc-type>
         <schema>dryad</schema>

--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -454,7 +454,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
         if (!(dso instanceof Item)) return;
         Item item = (Item) dso;
 
-        if (AuthorizeManager.isCuratorOrAdmin(context)) {
+        if (AuthorizeManager.isCuratorOrAdmin(context) && showFullItem(objectModel)) {
             DCValue[] curatorNotes = item.getMetadata("dryad.curatorNote");
             if (curatorNotes != null && curatorNotes.length > 0) {
                 Division notes = body.addDivision("curator-notes", "curator-notes");

--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/xmlui/aspect/browse/ItemViewer.java
@@ -454,6 +454,16 @@ public class ItemViewer extends AbstractDSpaceTransformer implements
         if (!(dso instanceof Item)) return;
         Item item = (Item) dso;
 
+        if (AuthorizeManager.isCuratorOrAdmin(context)) {
+            DCValue[] curatorNotes = item.getMetadata("dryad.curatorNote");
+            if (curatorNotes != null && curatorNotes.length > 0) {
+                Division notes = body.addDivision("curator-notes", "curator-notes");
+                for (DCValue curatorNote : curatorNotes) {
+                    notes.addPara(curatorNote.value);
+                }
+            }
+        }
+
         // Build the item viewer division.
         Division division = body.addDivision("item-view", "primary");
         String title = getItemTitle(item);

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemMetadataForm.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemMetadataForm.java
@@ -128,6 +128,14 @@ public class EditItemMetadataForm extends AbstractDSpaceTransformer {
             }
         }
 
+        DCValue[] curatorNotes = item.getMetadata("dryad.curatorNote");
+        if (curatorNotes != null && curatorNotes.length > 0) {
+            Division notes = body.addDivision("curator-notes", "curator-notes");
+            for (DCValue curatorNote : curatorNotes) {
+                notes.addPara(curatorNote.value);
+            }
+        }
+
         // DIVISION: main
         Division main = body.addInteractiveDivision("edit-item-status", contextPath + "/admin/item", Division.METHOD_POST, "primary administrative item");
         if (editingTemplateItem) {

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/ViewItem.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/ViewItem.java
@@ -54,6 +54,7 @@ import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.app.xmlui.wing.element.Para;
 import org.dspace.app.xmlui.wing.element.ReferenceSet;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Collection;
 import org.dspace.content.DCValue;
 import org.dspace.content.Item;
@@ -249,6 +250,16 @@ public class ViewItem extends AbstractDSpaceTransformer {
 		Item item = Item.find(context, itemID);
 		String baseURL = contextPath + "/admin/item?administrative-continue="
 				+ knot.getId();
+
+		if (AuthorizeManager.isCuratorOrAdmin(context)) {
+			DCValue[] curatorNotes = item.getMetadata("dryad.curatorNote");
+			if (curatorNotes != null && curatorNotes.length > 0) {
+				Division notes = body.addDivision("curator-notes", "curator-notes");
+				for (DCValue curatorNote : curatorNotes) {
+					notes.addPara(curatorNote.value);
+				}
+			}
+		}
 
 		String link = baseURL + "&view_item"
 				+ (showFullItem ? "" : "&show=full");

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/ViewItem.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/ViewItem.java
@@ -251,7 +251,7 @@ public class ViewItem extends AbstractDSpaceTransformer {
 		String baseURL = contextPath + "/admin/item?administrative-continue="
 				+ knot.getId();
 
-		if (AuthorizeManager.isCuratorOrAdmin(context)) {
+		if (AuthorizeManager.isCuratorOrAdmin(context) && showFullItem) {
 			DCValue[] curatorNotes = item.getMetadata("dryad.curatorNote");
 			if (curatorNotes != null && curatorNotes.length > 0) {
 				Division notes = body.addDivision("curator-notes", "curator-notes");

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -1222,9 +1222,7 @@
             </a>
         </xsl:if>
     </xsl:template>
-    <!-- Override metadata field rendering to hide manuscript number -->
     <xsl:template match="dim:field" mode="itemDetailView-DIM">
-        <xsl:if test="not(./@qualifier = 'manuscriptNumber')">
             <tr>
                 <xsl:attribute name="class">
                     <xsl:text>ds-table-row </xsl:text>
@@ -1250,7 +1248,6 @@
             </td>
                 <td><xsl:value-of select="./@language"/></td>
             </tr>
-        </xsl:if>
     </xsl:template>
 
     <xsl:template name="format-json-ld-metadata">

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
@@ -335,6 +335,13 @@ div.ds-option-set {
     border-color: #1f2a6f;
 }
 
+.curator-notes {
+    background-color: #c4c4ff;
+    color: #1f2a6f;
+    border-color: #1f2a6f;
+    margin-bottom: 10px;
+}
+
 #submit-data-feature-box h1 {
     background-color: #87C033;
     border-bottom: none;


### PR DESCRIPTION
Curators can add notes in the dryad.curatorNote metadata field and they will display at the top of the Edit Metadata page and any view item: show full metadata pages. These will only be visible to curators and admins, not to users.