### PR TITLE
Update config and text for DOI switch

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -315,7 +315,7 @@ doi.service.testmode= ${default.doi.testmode}
 
 doi.dir = ${dspace.dir}/doi-minter
 
-doi.username = dryad
+doi.username = ${default.doi.username}
 
 doi.password = ${default.doi.password}
 

--- a/dspace/config/emails/datacite_error
+++ b/dspace/config/emails/datacite_error
@@ -7,8 +7,8 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: Dryad - Problem with the datacite EZID
-A Datacite EZID {0} was not successfully completed, due to the following reason:
+Subject: Dryad - Problem with the datacite DOI {0}
+A Datacite DOI {0} was not successfully completed, due to the following reason:
 
 {1}
 

--- a/dspace/etc/server/settings.xml
+++ b/dspace/etc/server/settings.xml
@@ -30,7 +30,7 @@
 				<!-- PostgreSQL/Dryad username and password -->
 				<default.db.username>[PUT_DB_USERNAME_HERE]</default.db.username>
 				<default.db.password>[PUT_DB_PASSWORD_HERE]</default.db.password>
-				<!-- DOI registration (EZID currently) username and password -->
+				<!-- DOI registration username and password -->
 				<default.doi.username>[PUT_DOI_REG_USERNAME_HERE]</default.doi.username>
 				<default.doi.password>[PUT_DOI_REG_PASSWORD_HERE]</default.doi.password>
 				<!-- Dryad's DOI prefix -->

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -3300,8 +3300,8 @@
     <message key="xmlui.Submission.MyTasks.doi_registration_status">DOI Registration Status:</message>
     <message key="xmlui.Submission.MyTasks.doi">DOI:</message>
 
-    <message key="xmlui.Submission.MyTasks.doi_not_registered">Not Registered with EZID</message>
-    <message key="xmlui.Submission.MyTasks.doi_registered">Successfully Registered with EZID</message>
+    <message key="xmlui.Submission.MyTasks.doi_not_registered">Not Registered with DataCite</message>
+    <message key="xmlui.Submission.MyTasks.doi_registered">Successfully Registered with DataCite</message>
 
     <message key="xmlui.Submission.MyTasks.with_identifier"> with identifier: </message>
 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/faq.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/faq.xhtml
@@ -371,7 +371,7 @@ The DOI for each data file is composed of the base DOI for the data package “h
 </p>
 
 <p>
-Dryad DOIs are assigned through the <a href="http://n2t.net/ezid" target="_blank">EZID</a> service from the California Digital Library and are registered by <a href="http://datacite.org" target="_blank">DataCite</a>. 
+Dryad DOIs are assigned through the <a href="http://datacite.org" target="_blank">DataCite</a> system. 
 </p>
 
 <h2 id="info-cc0">Why does Dryad use Creative Commons Zero?</h2>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/repository.xhtml
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages/repository.xhtml
@@ -63,7 +63,7 @@
 	<ul>
 	<li>Dryad is built upon the open-source <a href="http://www.dspace.org">DSpace</a> repository software. All customizations not available within the main DSpace distribution are available from the <a href="https://github.com/datadryad/dryad-repo">Dryad code repository</a> under an open source (new BSD) license.</li>
 	<li>Dryad supports multiple ways of receiving article or manuscript metadata from publishers. The simplest method involves reading email notifications, but we are also implementing a <a target="_blank" href="http://wiki.datadryad.org/Journal_Metadata#Metadata_Submission_via_API">REST API</a> for those desiring greater control over the data deposition process.</li>
-	<li>Digital Object Identifers provided by <a target="_blank" href="http://datacite.org">DataCite</a> through <a target="_blank" href="http://n2t.net/ezid">EZID</a></li>
+	<li>Digital Object Identifers provided by <a target="_blank" href="http://datacite.org">DataCite</a></li>
 	<li>Terms of reuse provided by <a target="_blank" href="http://creativecommons.org/">Creative Commons</a></li>
 	<li>Information on programmatic access to Dryad's data is available on the <a target="_blank" href="http://wiki.datadryad.org/Data_Access">Dryad wiki</a>.</li>
 	<li>Those interested in contributing to or using the software are welcome to join the <a target="_blank" href="http://groups.google.com/group/dryad-dev">developer mailing list</a>.</li>

--- a/test/config/emails/datacite_error
+++ b/test/config/emails/datacite_error
@@ -7,8 +7,8 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: Dryad - Problem with the datacite EZID
-A Datacite EZID {0} was not successfully completed, due to the following reason:
+Subject: Dryad - Problem with the datacite {0}
+A Datacite DOI {0} was not successfully completed, due to the following reason:
 
 {1}
 


### PR DESCRIPTION
Updates the config file to properly read the DOI username out of the maven config. 

Updates textual elements to remove the EZID name.