### PR TITLE
Curation bugs

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/submit/step/DescribeDatasetStep.java
+++ b/dspace/modules/api/src/main/java/org/dspace/submit/step/DescribeDatasetStep.java
@@ -40,7 +40,11 @@ public class DescribeDatasetStep extends DescribeStep {
         if(buttonPressed.equals("submit_cancel")){
             EventLogger.log(context, "submission-describe-dataset", "status=cancelled");
             if (subInfo != null) {
-                ((WorkspaceItem) subInfo.getSubmissionItem()).deleteAll();
+                // is the item here a new item w/o content, i.e. no file sizes? if so, delete.
+                DCValue[] sizes = subInfo.getSubmissionItem().getItem().getMetadata("dc.format.extent");
+                if (sizes == null || sizes.length == 0) {
+                    ((WorkspaceItem) subInfo.getSubmissionItem()).deleteAll();
+                }
                 Item publication = DryadWorkflowUtils.getDataPackage(context, subInfo.getSubmissionItem().getItem());
                 WorkflowItem wfi = null;
                 if (publication != null) {

--- a/dspace/modules/api/src/main/java/org/dspace/submit/step/DescribeDatasetStep.java
+++ b/dspace/modules/api/src/main/java/org/dspace/submit/step/DescribeDatasetStep.java
@@ -40,18 +40,23 @@ public class DescribeDatasetStep extends DescribeStep {
         if(buttonPressed.equals("submit_cancel")){
             EventLogger.log(context, "submission-describe-dataset", "status=cancelled");
             if (subInfo != null) {
+                ((WorkspaceItem) subInfo.getSubmissionItem()).deleteAll();
                 Item publication = DryadWorkflowUtils.getDataPackage(context, subInfo.getSubmissionItem().getItem());
                 WorkflowItem wfi = null;
                 if (publication != null) {
                     wfi = WorkflowItem.findByItemId(context, publication.getID());
                 }
                 if (wfi != null) {
-                    // we're dealing with adding files to a package in review, so redirect to the review workflow
-                    ((WorkspaceItem) subInfo.getSubmissionItem()).deleteAll();
-                    response.sendRedirect(request.getContextPath() + "/handle/" + publication.getOwningCollection().getHandle() + "/workflow?workflowID=" + wfi.getID() + "&stepID=reviewStep&actionID=reviewAction");
+                    // this item is either in review or it's in curation.
+                    if (DryadWorkflowUtils.isItemInReview(context, wfi)) {
+                        // redirect to the review workflow
+                        response.sendRedirect(request.getContextPath() + "/handle/" + publication.getOwningCollection().getHandle() + "/workflow?workflowID=" + wfi.getID() + "&stepID=reviewStep&actionID=reviewAction");
+                    } else {
+                        // redirect to curation workflow
+                        response.sendRedirect(request.getContextPath() + "/handle/" + publication.getOwningCollection().getHandle() + "/workflow?workflowID=" + wfi.getID() + "&stepID=dryadAcceptEditReject&actionID=dryadAcceptEditRejectAction");
+                    }
                 } else {
                     WorkspaceItem wi = WorkspaceItem.findByItem(context, publication);
-                    ((WorkspaceItem) subInfo.getSubmissionItem()).deleteAll();
                     response.sendRedirect(request.getContextPath() + "/submit-overview?workspaceID=" + wi.getID());
                 }
             }

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/AutoReturnReviewItem.java
@@ -113,15 +113,11 @@ public class AutoReturnReviewItem {
     }
 
     private static void purgeOldItem(Context context, WorkflowItem wfi) {
-	// get a List of ClaimedTasks, using the WorkflowItem
-        List<ClaimedTask> claimedTasks = null;
         try {
             if (wfi != null) {
-                claimedTasks = ClaimedTask.findByWorkflowId(context, wfi.getID());
                 //Check for a valid task
-                // There must be a claimedTask & it must be in the review stage, else it isn't a review workflowitem
                 Item item = wfi.getItem();
-                if (claimedTasks == null || claimedTasks.isEmpty() || !claimedTasks.get(0).getActionID().equals("reviewAction")) {
+                if (!DryadWorkflowUtils.isItemInReview(context, wfi)) {
                     log.debug("Item " + item.getID() + " not found or not in review");
                 } else {
                     // make sure that this item is updated according to the ApproveReject mechanism:

--- a/dspace/modules/api/src/main/java/org/dspace/workflow/DryadWorkflowUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/workflow/DryadWorkflowUtils.java
@@ -79,6 +79,15 @@ public class DryadWorkflowUtils {
         return null;
     }
 
+    public static boolean isItemInReview(Context context, WorkflowItem wfi) throws SQLException {
+        boolean isInReview = false;
+        List<ClaimedTask> claimedTasks = ClaimedTask.findByWorkflowId(context, wfi.getID());
+        if (claimedTasks != null && claimedTasks.size() > 0 && claimedTasks.get(0).getActionID().equals("reviewAction")) {
+            isInReview = true;
+        }
+        return isInReview;
+    }
+
     public static Item[] getDataFiles(Context context, Item dataPackage) throws SQLException {
         DCValue[] dataFileUrls = dataPackage.getMetadata(MetadataSchema.DC_SCHEMA, "relation", "haspart", Item.ANY);
         List<Item> result = new ArrayList<Item>();

--- a/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
+++ b/dspace/modules/publication-updater/src/main/java/org/datadryad/publication/PublicationUpdater.java
@@ -241,13 +241,9 @@ public class PublicationUpdater extends HttpServlet {
             for (WorkflowItem wfi : items) {
                 if (DryadWorkflowUtils.isDataPackage(wfi)) {
                     // is this package in review?
-                    List<ClaimedTask> claimedTasks = null;
                     boolean isInReview = false;
                     try {
-                        claimedTasks = ClaimedTask.findByWorkflowId(context, wfi.getID());
-                        if (claimedTasks != null && claimedTasks.size() > 0 && claimedTasks.get(0).getActionID().equals("reviewAction")) {
-                            isInReview = true;
-                        }
+                        isInReview = DryadWorkflowUtils.isItemInReview(context, wfi);
                     } catch (SQLException e) {
                         LOGGER.debug("couldn't find claimed task for item " + wfi.getItem().getID());
                     }


### PR DESCRIPTION
More bug fixes:

1) The old “cancel and delete” button on DescribeDatasetStep: it should be a regular cancel button. Therefore, if you’re adding a new file, don’t actually add any file, and you then hit cancel, it should delete that stub item. If you’re editing an existing file, cancelling should not actually delete the item.

The only caveat here is that if you are adding a new file and you actually do upload a file, cancelling will leave the stub file present, and the user will have to delete it from the overview page. This is still a better behavior, IMO, than “cancel and delete.”

2) if a curator is editing a file in a package in curation, hitting cancel should actually just go back to the overview page and not throw an error (and delete the file).