### PR TITLE
Use current year for blackout publicationDate

### DIFF
--- a/dspace/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl
@@ -5,6 +5,7 @@
                 xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:dryad="http://purl.org/dryad/terms/"
+		xmlns:ex="http://exslt.org/dates-and-times" extension-element-prefixes="ex"
                 version="1.0">
 
 	<xsl:strip-space elements="*"/>
@@ -69,7 +70,7 @@
 
 			<!-- ************ Publication Year ************** -->
 			<publicationYear>
-				<xsl:text>0000</xsl:text>
+			  <xsl:value-of select="ex:year()"/>
 			</publicationYear>
 
 			<!-- ************ Subjects ************** -->


### PR DESCRIPTION
This allows blackout items to be registered properly in DataCite's Fabrica system. Using the old placeholder date, they would be registered in "draft" status.

To test, get a copy of the METS document for an item (e.g., https://datadryad.org/resource/doi:10.5061/dryad.bb702/mets.xml) and run

`xsltproc dryad-repo/dspace/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl mets.xml`

The publicationYear field should display the current year, rather than the placeholder 0000.