### PR TITLE
Better check for whether or not to display reduced pub header

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -79,7 +79,7 @@
         </xsl:variable>
 
         <xsl:choose>
-            <xsl:when test=".//dim:field[@mdschema='internal'][@element='workflow'][@qualifier='submitted']">
+            <xsl:when test="contains($meta[@element='request'][@qualifier='URI'], 'submit-overview')">
                 <!-- publication header -->
                 <div class="publication-header">
                     <xsl:call-template name="publication-header">
@@ -88,7 +88,7 @@
                     </xsl:call-template>
                 </div>
             </xsl:when>
-            <xsl:when test=".//dim:field[@mdschema='workflow'][@element='step'][@qualifier='reviewerKey']">
+            <xsl:when test="contains($meta[@element='request'][@qualifier='URI'], 'workflow')">
                 <!-- publication header -->
                 <div class="publication-header">
                     <xsl:call-template name="publication-header">


### PR DESCRIPTION
Specifically check to see if we’re on a particular URI in order to know whether or not to display the reduced pub header. This way, only the submitter should see the reduced headers; curators should see the old-style full information.