### PR TITLE
Review redesign

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1686,6 +1686,9 @@ authority.controlled.dc.subject = true
 # Change number of choices shown in the select in Choices lookup popup
 #xmlui.lookup.select.size = 12
 
+# internal representation of review items
+authority.controlled.workflow.review.fileStatus = true
+
 #### Ordering of bitstreams ####
 
 ## Specify the ordering that bitstreams are listed.

--- a/dspace/config/registries/internal-types.xml
+++ b/dspace/config/registries/internal-types.xml
@@ -84,4 +84,10 @@
         <qualifier>toworkflow</qualifier>
     </dc-type>
 
+    <dc-type>
+        <schema>workflow</schema>
+        <element>review</element>
+        <qualifier>fileStatus</qualifier>
+    </dc-type>
+
 </dspace-dc-types>

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
@@ -254,15 +254,6 @@ public class DryadDataFile extends DryadObject {
         return null;
     }
 
-    public String getTitle() {
-        Item item = getItem();
-        DCValue[] titles = item.getMetadata("dc.title");
-        if (titles != null || titles.length > 0) {
-            return titles[0].value;
-        }
-        return "Untitled";
-    }
-
     public Long getTotalStorageSize() throws SQLException {
         // bundles and bitstreams
         Long size = 0L;

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -534,11 +534,6 @@ public class DryadDataPackage extends DryadObject {
         return getSingleMetadataValue(RELATION_SCHEMA, RELATION_ELEMENT, RELATION_ISREFERENCEDBY_QUALIFIER);
     }
 
-    public void setTitle(String title) throws SQLException {
-        // Need to filter just on metadata values that are publication DOIs
-        addSingleMetadataValue(Boolean.TRUE, TITLE_SCHEMA, TITLE_ELEMENT, null, title);
-    }
-
     public String getTitle() throws SQLException {
         return getSingleMetadataValue(TITLE_SCHEMA, TITLE_ELEMENT, null);
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
@@ -41,6 +41,10 @@ public abstract class DryadObject {
     static final String RELATION_SCHEMA = "dc";
     static final String RELATION_ELEMENT = "relation";
 
+    // Object title
+    static final String TITLE_SCHEMA = "dc";
+    static final String TITLE_ELEMENT = "title";
+
     // File ispartof package
     static final String RELATION_ISPARTOF_QUALIFIER = "ispartof";
 
@@ -172,6 +176,18 @@ public abstract class DryadObject {
         } catch (AuthorizeException ex) {
             log.error("Authorize exception reserving identifier", ex);
         }
+    }
+
+    public String getTitle() throws SQLException {
+        String result = getSingleMetadataValue(TITLE_SCHEMA, TITLE_ELEMENT, null);
+        if (result == null) {
+            result = "Untitled";
+        }
+        return result;
+    }
+
+    public void setTitle(String newTitle) throws SQLException {
+        addSingleMetadataValue(Boolean.TRUE, TITLE_SCHEMA, TITLE_ELEMENT, null, newTitle);
     }
 
     protected final void addToCollectionAndArchive(Collection collection) throws SQLException {

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AlterWorkflowStepAction.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AlterWorkflowStepAction.java
@@ -57,6 +57,10 @@ public class AlterWorkflowStepAction extends AbstractAction {
             //Remove all the tasks
             WorkflowManager.deleteAllTasks(context, wfItem);
 
+            if (newStep.getId().equals("dryadAcceptEditReject")) {
+                WorkflowManager.updateFileNames(context, wfItem);
+            }
+
 
             WorkflowActionConfig nextActionConfig = newStep.getUserSelectionMethod();
             nextActionConfig.getProcessingAction().activate(context, wfItem);

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/OverviewStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/OverviewStep.java
@@ -45,6 +45,7 @@ public class OverviewStep extends AbstractStep {
     private static final Message T_BUTTON_DATAFILE_ADD = message("xmlui.Submission.submit.OverviewStep.button.add-datafile");
     private static final Message T_BUTTON_DATAFILE_EDIT = message("xmlui.Submission.submit.OverviewStep.button.datafile.edit");
     private static final Message T_BUTTON_DATAFILE_DELETE = message("xmlui.Submission.submit.OverviewStep.button.datafile.delete");
+    private static final Message T_BUTTON_DATAFILE_EDIT_METADATA = message("xmlui.Submission.Submissions.OverviewStep.edit-metadata-dataset");
     private static final Message T_BUTTON_DATAFILE_CONTINUE = message("xmlui.Submission.submit.OverviewStep.button.datafile.continue");
     private static final Message T_DUP_SUBMISSION = message("xmlui.submit.publication.describe.duplicatesubmission");
 
@@ -135,6 +136,11 @@ public class OverviewStep extends AbstractStep {
                     editButton.setValue(T_BUTTON_DATAFILE_EDIT);
                 }
                 actionCell.addButton("submit_delete_dataset_" + wsDataset.getID()).setValue(T_BUTTON_DATAFILE_DELETE);
+
+                // add metadata edit button if it's in workflow
+                if (wsDataset instanceof WorkflowItem) {
+                    actionCell.addButton("submit_edit_metadata_" + wsDataset.getID()).setValue(T_BUTTON_DATAFILE_EDIT_METADATA);
+                }
             }
         }
 

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/DryadReviewActionXMLUI.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/DryadReviewActionXMLUI.java
@@ -109,7 +109,9 @@ public class DryadReviewActionXMLUI extends AbstractXMLUIAction {
             }
         }
 
-        actionsDiv.addPara().addButton("submit_leave").setValue(T_cancel_submit);
+        Para buttonsPara = actionsDiv.addPara();
+        buttonsPara.addButton("submit_leave").setValue(T_cancel_submit);
+        buttonsPara.addButton("save_review_changes").setValue(T_save_changes);
 
         mainDiv.addHidden("submission-continue").setValue(knot.getId());
     }

--- a/dspace/modules/xmlui/src/main/resources/aspects/Submission/submission.js
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Submission/submission.js
@@ -944,9 +944,10 @@ function doWorkflow()
                 sendPage("handle/"+handle+"/workflow_new/workflowexception",{"error":"Unknown error"});
             }
         }
-        else
-        if (cocoon.request.get("submit_edit"))
-        {
+        else if (cocoon.request.get("save_changes")) {
+
+        }
+        else if (cocoon.request.get("submit_edit")) {
         	//User is editing this submission:
             //	Send user through the Submission Control
             cocoon.redirectTo(cocoon.request.getContextPath() + "/submit-overview?workflowID=" + workflowItemId, true);
@@ -987,6 +988,13 @@ function doWorkflow()
             //cancel perform the reauthorizationpaymentaction
             var contextPath = cocoon.request.getContextPath();
             cocoon.redirectTo(contextPath+"/my-tasks",true);
+            getDSContext().complete();
+            cocoon.exit();
+        }
+        else if (cocoon.request.get("save_review_changes")) {
+            FlowUtils.processReviewSaveChanges(getDSContext(), cocoon.request, workflowItem.getID());
+            var contextPath = cocoon.request.getContextPath();
+            cocoon.redirectTo(contextPath+"/submissions",true);
             getDSContext().complete();
             cocoon.exit();
         }

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -3098,7 +3098,7 @@
 	<message key="xmlui.Submission.Submissions.curator.delete.column.date">Deletion date</message>
 	<message key="xmlui.Submission.Submissions.curator.edit.item">Edit item metadata</message>
 	<message key="xmlui.Submission.Submissions.OverviewStep.edit-metadata-pub">Edit publication metadata</message>
-	<message key="xmlui.Submission.Submissions.OverviewStep.edit-metadata-dataset">Edit data file metadata</message>
+	<message key="xmlui.Submission.Submissions.OverviewStep.edit-metadata-dataset">Edit file metadata</message>
 
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_prism.publicationName_filter">Publication Name</message>
 	<message key="xmlui.Discovery.AbstractSearch.type_prism.publicationName_filter">Refine by: Publication Name</message>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -77,7 +77,7 @@
         </xsl:variable>
 
         <xsl:choose>
-            <xsl:when test=".//dim:field[@mdschema='internal'][@element='workflow'][@qualifier='submitted']">
+            <xsl:when test="contains($meta[@element='request'][@qualifier='URI'], 'submit-overview')">
                 <!-- publication header -->
                 <div class="publication-header">
                     <xsl:call-template name="publication-header">
@@ -86,7 +86,7 @@
                     </xsl:call-template>
                 </div>
             </xsl:when>
-            <xsl:when test=".//dim:field[@mdschema='workflow'][@element='step']">
+            <xsl:when test="contains($meta[@element='request'][@qualifier='URI'], 'workflow')">
                 <!-- publication header -->
                 <div class="publication-header">
                     <xsl:call-template name="publication-header">

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -86,7 +86,7 @@
                     </xsl:call-template>
                 </div>
             </xsl:when>
-            <xsl:when test=".//dim:field[@mdschema='workflow'][@element='step'][@qualifier='reviewerKey']">
+            <xsl:when test=".//dim:field[@mdschema='workflow'][@element='step']">
                 <!-- publication header -->
                 <div class="publication-header">
                     <xsl:call-template name="publication-header">

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
@@ -841,6 +841,10 @@ li.ds-form-item label.ds-composite-component.last{
     margin-left: 0;
 }
 
+.ds-radio-field.filestatus input {
+    margin-right: 5px;
+}
+
 .ds-checkbox-field label,
 .ds-radio-field label {
     margin-right: 3px;
@@ -2072,6 +2076,13 @@ fieldset.ds-checkbox-field legend,fieldset.ds-radio-field legend {
 fieldset.ds-checkbox-field label,fieldset.ds-radio-field label {
     display: block;
 }
+
+/* for review layout, buttons should be side by side. */
+fieldset.ds-radio-field.filestatus label {
+    display: inline;
+    margin-right:5px;
+}
+
 /* Sub sections within a form */
 fieldset.ds-form-list {
     border: none;


### PR DESCRIPTION
Before testing, update the internal-types metadata schema.

When a submitter is working with an item in review, they should be able to mark each file as “keep” or “delete,” and that should be saved at the package level as “workflow.review.fileStatus” metadata; the value will be the itemId of the file and its confidence will either be CF_ACCEPTED or CF_REJECTED.

Then, when the package moves to curation, the files with metadata confidence values of CF_REJECTED get “SUPERSEDED” prepended to their titles. This has been tested to work either via manually moving the workflow step, or via the journal-submit app.