### PR TITLE
don't set a maxlen for the response string

### DIFF
--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
@@ -164,8 +164,8 @@ public class CDLDataCiteService {
 
         this.getClient(false).executeMethod(httpMethod);
 	log.info("HTTP status: " + httpMethod.getStatusLine());
-	log.debug("HTTP response text: " + httpMethod.getResponseBodyAsString(1000));
-        return httpMethod.getResponseBodyAsString(1000);
+	log.debug("HTTP response text: " + httpMethod.getResponseBodyAsString());
+        return httpMethod.getResponseBodyAsString();
     }
 
 


### PR DESCRIPTION
Pretty sure this fixes https://trello.com/c/x9GyJK0p/652-bug-original-doi-for-versioned-item-no-longer-appended-with-1.

It’s ridiculous, but apparently after the DataCite transition, the HTTP response text we get back is now much longer than it used to be, and so when CDLDataCiteConsumer tries to update the versioned DOI, it then throws an exception `org.apache.commons.httpclient.HttpContentTooLargeException: Content-Length not known but larger than 1000`. This can easily be fixed just by letting the response be longer than maxlen 1000.