### PR TITLE
Don't swallow the original exception

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/statistics/SiteOverview.java
+++ b/dspace/modules/xmlui/src/main/java/org/datadryad/dspace/statistics/SiteOverview.java
@@ -67,7 +67,7 @@ public class SiteOverview extends AbstractDSpaceTransformer implements
             }
         } catch (Exception ex) {
             log.error(ex.getMessage());
-            throw new UIException("Failed to create stats overview object");
+            throw new UIException("Failed to create stats overview object", ex);
         }
 
         Division overviewStats = body.addDivision("front-page-stats");


### PR DESCRIPTION
Ensure the log is comprehensible when there is an exception creating the statistics block. Keep the originating exception as part of the stack trace.

This aids in debugging if we ever have another problem like secundus running out of disk space and not being able to write the cache files for the statistics.