### PR TITLE
Dryad *Digital* Repository, not Dryad *Data* Repository

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -43,7 +43,7 @@ dspace.url = ${default.dspace.url}
 dspace.oai.url = ${dspace.baseUrl}/oai
 
 # Name of the site
-dspace.name = Dryad Data Repository
+dspace.name = Dryad Digital Repository
 
 # The home of this particular instance (UK or NCSU)
 dryad.home = ${default.dryad.home}

--- a/dspace/modules/xmlui/src/main/java/org/dspace/springmvc/RisView.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/springmvc/RisView.java
@@ -120,7 +120,7 @@ public class RisView implements View {
 			builder.append("JF  - ").append(journalName).append(EOL);
 		}
 
-		builder.append("PB  - ").append("Dryad Data Repository").append(EOL);
+		builder.append("PB  - ").append("Dryad Digital Repository").append(EOL);
 
 		if (doi != null) {
 			builder.append("UR  - ");


### PR DESCRIPTION
Pointed out in https://trello.com/c/XiKnfcky/248-ris-citation-download-says-dryad-data-repository

Also, how has it been misidentified as such in the dspace.cfg file for so long??