### PR TITLE
Review updates

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/DryadReviewTransformer.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/DryadReviewTransformer.java
@@ -233,7 +233,7 @@ public class DryadReviewTransformer extends AbstractDSpaceTransformer {
                 }
                 if (supersededList.size() > 0) {
                     ReferenceSet supersededFiles = itemRef.addReferenceSet("embeddedView", null, "isSuperseded");
-                    for (Item obj : hasPartsList) {
+                    for (Item obj : supersededList) {
                         supersededFiles.addReference(obj);
                     }
                 }

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/DryadReviewTransformer.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/DryadReviewTransformer.java
@@ -19,6 +19,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.DCValue;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
+import org.dspace.content.authority.Choices;
 import org.dspace.identifier.DOIIdentifierProvider;
 import org.dspace.identifier.IdentifierNotFoundException;
 import org.dspace.identifier.IdentifierNotResolvableException;
@@ -32,6 +33,7 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.dspace.workflow.ClaimedTask;
@@ -62,7 +64,8 @@ public class DryadReviewTransformer extends AbstractDSpaceTransformer {
     private boolean authorized;
     private boolean currentlyInReview;
     private String requestDoi;
-    List<Item> dataFiles = new ArrayList<Item>();
+    // map of items and whether or not they're superseded
+    Map<Item, Boolean> dataFiles = new HashMap<Item, Boolean>();
 
     @Override
     public void setup(SourceResolver resolver, Map objectModel, String src, Parameters parameters) throws ProcessingException, SAXException, IOException {
@@ -213,14 +216,26 @@ public class DryadReviewTransformer extends AbstractDSpaceTransformer {
             // adding the dataFile
             org.dspace.app.xmlui.wing.element.Reference itemRef = referenceSet.addReference(wfItem.getItem());
             if (wfItem.getItem().getMetadata("dc.relation.haspart").length > 0) {
-                ReferenceSet hasParts;
-                hasParts = itemRef.addReferenceSet("embeddedView", null, "hasPart");
-                hasParts.setHead(T_head_has_part);
-
+                ArrayList<Item> hasPartsList = new ArrayList<Item>();
+                ArrayList<Item> supersededList = new ArrayList<Item>();
                 if (dataFiles.size() == 0) retrieveDataFiles(wfItem.getItem());
-
-                for (Item obj : dataFiles) {
+                for (Item obj : dataFiles.keySet()) {
+                    if (dataFiles.get(obj)) {
+                        supersededList.add(obj);
+                    } else {
+                        hasPartsList.add(obj);
+                    }
+                }
+                ReferenceSet hasParts = itemRef.addReferenceSet("embeddedView", null, "hasPart");
+                hasParts.setHead(T_head_has_part);
+                for (Item obj : hasPartsList) {
                     hasParts.addReference(obj);
+                }
+                if (supersededList.size() > 0) {
+                    ReferenceSet supersededFiles = itemRef.addReferenceSet("embeddedView", null, "isSuperseded");
+                    for (Item obj : hasPartsList) {
+                        supersededFiles.addReference(obj);
+                    }
                 }
             }
 
@@ -293,9 +308,13 @@ public class DryadReviewTransformer extends AbstractDSpaceTransformer {
 
     private void retrieveDataFiles(Item item) throws SQLException {
         DOIIdentifierProvider dis = new DSpace().getSingletonService(DOIIdentifierProvider.class);
-
+        DCValue[] fileStatusMDVs = item.getMetadata("workflow.review.fileStatus");
+        HashMap<Integer, Boolean> fileIsSupersededMap = new HashMap<Integer, Boolean>();
+        for (DCValue fileStatusMDV : fileStatusMDVs) {
+            fileIsSupersededMap.put(Integer.valueOf(fileStatusMDV.value), (fileStatusMDV.confidence == Choices.CF_REJECTED));
+        }
         if (item.getMetadata("dc.relation.haspart").length > 0) {
-            dataFiles = new ArrayList<Item>();
+            dataFiles = new HashMap<Item, Boolean>();
             for (DCValue value : item.getMetadata("dc.relation.haspart")) {
 
                 DSpaceObject obj = null;
@@ -306,7 +325,11 @@ public class DryadReviewTransformer extends AbstractDSpaceTransformer {
                 } catch (IdentifierNotResolvableException e) {
                     // just keep going
                 }
-                if (obj != null) dataFiles.add((Item) obj);
+                if (obj != null) {
+                    Boolean isSuperseded = fileIsSupersededMap.get(obj.getID());
+                    if (isSuperseded == null) isSuperseded = false;
+                    dataFiles.put((Item) obj, isSuperseded);
+                }
             }
         }
     }
@@ -348,7 +371,7 @@ public class DryadReviewTransformer extends AbstractDSpaceTransformer {
     {
         this.wfItem = null;
 	this.authorized = false;
-	this.dataFiles=new ArrayList<Item>();
+	this.dataFiles=new HashMap<Item, Boolean>();
         super.recycle();
     }
 

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
@@ -1386,7 +1386,7 @@ public class FlowUtils {
     }
 
     // returns the table cell that actions should be rendered in
-    public static Cell renderDatasetItem(Context context, Table table, org.dspace.content.Item dataset, InProgressSubmission wsDataset) throws WingException, SQLException {
+    public static Cell renderDatasetItem(Context context, Table table, Item dataset) throws WingException, SQLException {
         // first row: buttons, title
         Row row = table.addRow("dataset-row-top", null, "dataset-row-top");
         Cell finalActionCell = row.addCell("dataset-action",null, 0, 0, "dataset-action");

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/OverviewStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/OverviewStep.java
@@ -114,7 +114,7 @@ public class OverviewStep extends AbstractStep {
 
         if(publication.isArchived()){
             //Add the current dataset, since our publication is archived this will probally be the only one !
-            Cell actionCell = FlowUtils.renderDatasetItem(context, dataSetList, submission.getItem(), (WorkspaceItem) submission);
+            Cell actionCell = FlowUtils.renderDatasetItem(context, dataSetList, submission.getItem());
         }
 
         for (org.dspace.content.Item dataset : datasets) {
@@ -126,7 +126,7 @@ public class OverviewStep extends AbstractStep {
                 wsDataset = WorkflowItem.findByItemId(context, dataset.getID());
             //Only add stuff IF we have a workspaceitem
             if(wsDataset != null){
-                Cell actionCell = FlowUtils.renderDatasetItem(context, dataSetList, dataset, wsDataset);
+                Cell actionCell = FlowUtils.renderDatasetItem(context, dataSetList, dataset);
                 Button editButton = actionCell.addButton("submit_edit_dataset_" + wsDataset.getID());
                 //To determine which name our button is getting check if we are through submission with this
                 if (dataset.getMetadata("internal", "workflow", "submitted", org.dspace.content.Item.ANY).length == 0 && (wsDataset instanceof WorkspaceItem)) {

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/DryadReviewActionXMLUI.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/workflow/actions/processingaction/DryadReviewActionXMLUI.java
@@ -92,7 +92,7 @@ public class DryadReviewActionXMLUI extends AbstractXMLUIAction {
             InProgressSubmission wfi;
             wfi = WorkflowItem.findByItemId(context, dataset.getID());
             if(wfi != null){
-                 Cell actionCell = FlowUtils.renderDatasetItem(context, dataSetList, dataset, wfi);
+                 Cell actionCell = FlowUtils.renderDatasetItem(context, dataSetList, dataset);
                  Radio fileButtons = actionCell.addRadio("filestatus_" + dataset.getID(), "filestatus");
                  fileButtons.addOption(Choices.CF_ACCEPTED, "Keep");
                  fileButtons.addOption(Choices.CF_REJECTED, "Delete");

--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/integrated-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/integrated-view.xsl
@@ -40,6 +40,14 @@
                 </div>
                 </div>
             </xsl:when>
+            <xsl:when test="current()[@rend='isSuperseded']">
+                <div class="ds-static-div primary">
+                    <h2 class="ds-list-head">Superseded files</h2>
+                    <div class="file-list" style="text-decoration: line-through">
+                        <xsl:apply-templates select="*[not(name()='head')]" mode="embeddedView"/>
+                    </div>
+                </div>
+            </xsl:when>
             <xsl:when test="current()[@rend='duplicateItems']">
                 <div class="ds-static-div primary">
                 <h2>Duplicate items detected:</h2>


### PR DESCRIPTION
For the reviewer’s display, move files marked as to be deleted/superseded to a separate area.

For testing, you can see this in action if you use two separate browsers, one logged in as the submitter of the review item and one just showing the reviewer url. As you modify the keep/delete status of the files (and save changes), you should be able to refresh the other and see the changes reflected.