### PR TITLE
More specificity

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Mirage/DryadItemSummary.xsl
@@ -99,7 +99,7 @@
                 </div>
                     <xsl:apply-templates select="$embeddedViewReferenceSet"/>
             </xsl:when>
-            <xsl:when test="contains($meta[@element='request'][@qualifier='URI'], 'internal-item')">
+            <xsl:when test="contains($meta[@element='request'][@qualifier='URI'], 'internal-item') and contains($meta[@element='request'][@qualifier='queryString'], 'reviewStep')">
                 <!-- publication header -->
                 <div class="publication-header">
                     <xsl:call-template name="publication-header">


### PR DESCRIPTION
Make sure that the changed pub header only affects internal-item AND reviewStep. This has already been deployed on the production server.