### PR TITLE
Better error handling for future dates

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -720,7 +720,7 @@ public class JournalUtils {
                 if (dateParts.has(2)) {
                     day = dateParts.get(2).asInt();
                     if (dateFormat.parse(year + "-" + month + "-" + day).after(new Date())) {
-                        throw new RESTModelException("CrossRef match has publication date in the future");
+                        throw new RESTModelException("CrossRef match has publication date in the future: " + year + "-" + month + "-" + day);
                     }
                 } else {
                     // adjust to the end of the month, if necessary:

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -685,7 +685,7 @@ public class JournalUtils {
         return numMatched;
     }
 
-    public static Manuscript manuscriptFromCrossRefJSON(JsonNode jsonNode) throws RESTModelException {
+    private static Manuscript manuscriptFromCrossRefJSON(JsonNode jsonNode) throws RESTModelException {
         // manuscripts should only be returned if the crossref match is of type "journal-article"
         if (!jsonNode.path("type").isMissingNode()) {
             if (!"journal-article".equals(jsonNode.path("type").textValue())) {

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -719,6 +719,9 @@ public class JournalUtils {
                 }
                 if (dateParts.has(2)) {
                     day = dateParts.get(2).asInt();
+                    if (dateFormat.parse(year + "-" + month + "-" + day).after(new Date())) {
+                        throw new RESTModelException("CrossRef match has publication date in the future");
+                    }
                 } else {
                     // adjust to the end of the month, if necessary:
                     LocalDate date = LocalDate.of(year, month, day);

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -639,15 +639,6 @@ public class JournalUtils {
 
             // sanity check:
             if (currentMatch != null) {
-                if (currentMatch.getPublicationDate() == null) {
-                    throw new RESTModelException("CrossRef match does not have a publication date");
-                }
-                if (currentMatch.getPublicationDate() != null && currentMatch.getPublicationDate().after(new Date())) {
-                    throw new RESTModelException("CrossRef match has publication date in the future");
-                }
-                if (currentMatch.getAuthorList() == null || currentMatch.getAuthorList().size() == 0) {
-                    throw new RESTModelException("CrossRef match does not have authors");
-                }
                 if (!queryManuscript.getJournalISSN().equals(currentMatch.getJournalISSN())) {
                     throw new RESTModelException("publication DOI listed for item does not belong to the correct journal");
                 }
@@ -698,7 +689,7 @@ public class JournalUtils {
         // manuscripts should only be returned if the crossref match is of type "journal-article"
         if (!jsonNode.path("type").isMissingNode()) {
             if (!"journal-article".equals(jsonNode.path("type").textValue())) {
-                throw new RESTModelException("crossref result is not of type journal-article: " + jsonNode.path("type").textValue());
+                throw new RESTModelException("Crossref result is not of type journal-article: " + jsonNode.path("type").textValue());
             }
         }
 
@@ -769,8 +760,16 @@ public class JournalUtils {
                 }
             }
         }
+
+        // sanity checks for manuscript format:
         if (manuscript.getJournalConcept() == null) {
-            throw new RESTModelException("couldn't find journal concept");
+            throw new RESTModelException("Couldn't find journal concept");
+        }
+        if (manuscript.getPublicationDate() == null) {
+            throw new RESTModelException("CrossRef match does not have a publication date");
+        }
+        if (manuscript.getAuthorList() == null || manuscript.getAuthorList().size() == 0) {
+            throw new RESTModelException("CrossRef match does not have authors");
         }
         manuscript.setStatus(Manuscript.STATUS_PUBLISHED);
         return manuscript;

--- a/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
+++ b/dspace/modules/api/src/main/java/org/dspace/JournalUtils.java
@@ -709,17 +709,26 @@ public class JournalUtils {
         if (!dateNode.isMissingNode()) {
             //2016-04-11T17:53:39Z
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            Date today = new Date();
+            Calendar calendar = new GregorianCalendar();
+            calendar.setTime(today);
             try {
                 JsonNode dateParts = dateNode.path("date-parts").get(0);
                 int year = dateParts.get(0).asInt();
+                if (year > calendar.get(Calendar.YEAR)) {
+                    throw new RESTModelException("CrossRef match has publication date in the future: " + year);
+                }
                 int month = 12;
-                int day = 1;
                 if (dateParts.has(1)) {
                     month = dateParts.get(1).asInt();
+                    if (month > calendar.get(Calendar.MONTH)) {
+                        throw new RESTModelException("CrossRef match has publication date in the future: " + year + "-" + month);
+                    }
                 }
+                int day = 1;
                 if (dateParts.has(2)) {
                     day = dateParts.get(2).asInt();
-                    if (dateFormat.parse(year + "-" + month + "-" + day).after(new Date())) {
+                    if (day > calendar.get(Calendar.DATE)) {
                         throw new RESTModelException("CrossRef match has publication date in the future: " + year + "-" + month + "-" + day);
                     }
                 } else {


### PR DESCRIPTION
I moved the logic for catching future dates into the original method that parses the crossref JSON. 
To test: run the APU from the current dryad-master branch on a recent database copy (e.g. `GET http://yourserver.datadryad.org/publication-updater/retrieve?auth=<your test token>&issn=2054-5703&user=tester`). Note that there are some future dates present (do a find in the pub-updater.log for “publication date in the future”).

Reload the same database copy and this pull request and re-run the same APU command. Note that there should be no future dates present.