### PR TITLE
Create stub concept for new ISSNs

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadJournalConcept.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadJournalConcept.java
@@ -225,7 +225,13 @@ public class DryadJournalConcept extends DryadOrganizationConcept {
     }
 
     public void setISSN(String value) {
+        if (getISSN().equals("")) {
+            // if there is only an empty placeholder, set that one to the value
+            setConceptMetadataValue(metadataProperties.getProperty(ISSN), value);
+            return;
+        }
         if (!getISSNs().contains(value)) {
+            // otherwise, add as another ISSN
             addConceptMetadataValue(metadataProperties.getProperty(ISSN), value);
         }
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/storage/rdbms/JournalConceptDatabaseStorageImpl.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/storage/rdbms/JournalConceptDatabaseStorageImpl.java
@@ -77,6 +77,21 @@ public class JournalConceptDatabaseStorageImpl extends AbstractOrganizationConce
         if (row != null) {
             return DryadJournalConcept.getJournalConceptMatchingConceptID(context, row.getIntColumn(COLUMN_ID));
         }
+
+        // if the query was for an ISSN, try to see if it actually exists as a journal and, if so, make a concept
+        if (isISSN) {
+            try {
+                String journalName = JournalUtils.getCrossRefJournalForISSN(codeOrISSN);
+                DryadJournalConcept dryadJournalConcept = JournalUtils.createJournalConcept(journalName);
+                if (dryadJournalConcept != null) {
+                    dryadJournalConcept.setISSN(codeOrISSN);
+                    log.info("created a concept for " + codeOrISSN + ": " + journalName);
+                    return dryadJournalConcept;
+                }
+            } catch (Exception e) {
+                throw new SQLException("couldn't create a stub concept for " + codeOrISSN);
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
Similar to how new candidate concepts are created in SelectPublicationStep, create a candidate concept if a GET call is made for a valid ISSN that doesn’t yet have a concept.

To test, try making a GET call to /api/v1/organizations/8888-8888/. This invalid ISSN should return an error. Then try making a GET call to a valid ISSN (I recommend deleting a perfectly valid one from your test db, like Apidologie 1297-9678, and then using its ISSN). A new concept should be created.