### PR TITLE
Dash transfer -- initial version

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -333,8 +333,8 @@ doi.datacite.connected = ${default.doi.datacite.connected}
 
 ##### Connection to DASH API #####
 dash.server = ${default.dash.server}
-dash.username = ${default.dash.username}
-dash.password = ${default.dash.password}
+dash.application_id = ${default.dash.application_id}
+dash.application_secret = ${default.dash.application_secret}
 
 ##### Authorization system configuration - Delegate ADMIN #####
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -331,6 +331,10 @@ doi.localpart.testsuffix = FK2dryad.
 # For dev and testing, don't want to hit them all the time
 doi.datacite.connected = ${default.doi.datacite.connected}
 
+##### Connection to DASH API #####
+dash.server = ${default.dash.server}
+dash.username = ${default.dash.username}
+dash.password = ${default.dash.password}
 
 ##### Authorization system configuration - Delegate ADMIN #####
 

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -20,6 +20,7 @@ plugin.named.org.dspace.curate.CurationTask = \
     org.dspace.curate.PackageSimpleStats = packagestats, \
     org.dspace.curate.FileSimpleStats = filestats, \
     org.dspace.curate.DataFileStats = datafilestats, \
+    org.dspace.curate.TransferToDash = transfertodash, \
     org.dspace.curate.UpdateHandleRelationshipsToDOIs = updatehandlerelationships, \
     org.dspace.curate.DataPackagesWithInsufficientMetadata = packagesinsufficientmetadata, \
     org.dspace.curate.DataFilesWithInsufficientMetadata = datafilesinsufficientmetadata, \

--- a/dspace/config/registries/dash-transfer.xml
+++ b/dspace/config/registries/dash-transfer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<dspace-dc-types>
+
+  <!-- Date a data package was successfully transferred to DASH -->
+    <dc-type>
+        <schema>dryad</schema>
+        <element>dashTransferDate</element>
+    </dc-type>
+
+</dspace-dc-types>

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -27,6 +27,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import java.net.HttpURLConnection;
+import javax.net.ssl.HttpsURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -331,11 +332,10 @@ public class TransferToDash extends AbstractCurationTask {
         try {
             URL url = new URL(dashServer + "/api/datasets");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setRequestProperty("Authorization", "Bearer " + token);
-            connection.setDoOutput(true);
             connection.setRequestMethod("POST");
+            connection.setRequestProperty("Authorization", "Bearer " + token);
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setDoOutput(true);
 
             OutputStreamWriter wr= new OutputStreamWriter(connection.getOutputStream());
             wr.write(jsonString);

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -26,8 +26,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import sun.net.www.protocol.http.HttpURLConnection;
-import javax.net.ssl.HttpsURLConnection;
+import java.net.HttpURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -26,7 +26,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import java.net.HttpURLConnection;
+import sun.net.www.protocol.http.HttpURLConnection;
+import javax.net.ssl.HttpsURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -27,7 +27,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import java.net.HttpURLConnection;
-import javax.net.ssl.HttpsURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -332,10 +331,11 @@ public class TransferToDash extends AbstractCurationTask {
         try {
             URL url = new URL(dashServer + "/api/datasets");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Authorization", "Bearer " + token);
-            connection.setRequestProperty("Content-Type", "application/json");
             connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
 
             OutputStreamWriter wr= new OutputStreamWriter(connection.getOutputStream());
             wr.write(jsonString);

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -96,16 +96,16 @@ public class TransferToDash extends AbstractCurationTask {
         
         // init oauth connection with DASH
         dashServer = ConfigurationManager.getProperty("dash.server");
-        String dashUser = ConfigurationManager.getProperty("dash.application_id");
-        String dashPass = ConfigurationManager.getProperty("dash.application_secret");
+        String dashAppID = ConfigurationManager.getProperty("dash.application_id");
+        String dashAppSecret = ConfigurationManager.getProperty("dash.application_secret");
         
-        oauthToken = getOAUTHtoken(dashServer, dashUser, dashPass);
+        oauthToken = getOAUTHtoken(dashServer, dashAppID, dashAppSecret);
     }
     
-    private String getOAUTHtoken(String dashServer, String dashUser, String dashPass) {
+    private String getOAUTHtoken(String dashServer, String dashAppID, String dashAppSecret) {
         
         String url = dashServer + "/oauth/token";
-        String auth = dashUser + ":" + dashPass;
+        String auth = dashAppID + ":" + dashAppSecret;
         String authentication = Base64.getEncoder().encodeToString(auth.getBytes());
         Pattern pat = Pattern.compile(".*\"access_token\"\\s*:\\s*\"([^\"]+)\".*");
         String token = "";

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -282,133 +282,6 @@ public class TransferToDash extends AbstractCurationTask {
                 }
                 dataset.put("authors", allAuthors);
 
-                // ///////// Items below this are not yet added to json
-                
-		// journal
-	 	vals = item.getMetadata("prism.publicationName");
-		if (vals.length == 0) {
-		    setResult("Object has no prism.publicationName available " + handle);
-		    log.error("Skipping -- Object has no prism.publicationName available " + handle);
-		    context.abort();
-		    return Curator.CURATE_SKIP;
-		} else {
-		    journal = vals[0].value;
-		}
-		log.debug("journal = " + journal);
-
-		// accession date
-		vals = item.getMetadata("dc.date.accessioned");
-		if (vals.length == 0) {
-		    setResult("Object has no dc.date.accessioned available " + handle);
-		    log.error("Skipping -- Object has no dc.date.accessioned available " + handle);
-		    context.abort();
-		    return Curator.CURATE_SKIP;
-		} else {
-		    dateAccessioned = vals[0].value;
-		}
-		log.debug("dateAccessioned = " + dateAccessioned);
-
-		// manuscript number
-		DCValue[] manuvals = item.getMetadata("dc.identifier.manuscriptNumber");
-		manuscriptNum = null;
-		if(manuvals.length > 0) {
-		    manuscriptNum = manuvals[0].value;
-		}
-		if(manuscriptNum != null && manuscriptNum.trim().length() > 0) {
-		    log.debug("has a real manuscriptNum = " + manuscriptNum);
-
-		}
-		
-		// count the files, and compute statistics that depend on the files
-		log.debug("getting data file info");
-		DCValue[] dataFiles = item.getMetadata("dc.relation.haspart");
-		if (dataFiles.length == 0) {
-		    setResult("Object has no dc.relation.haspart available " + handle);
-		    log.error("Skipping -- Object has no dc.relation.haspart available " + handle);
-		    context.abort();
-		    return Curator.CURATE_SKIP;
-		} else {
-		    numberOfFiles = "" + dataFiles.length;
-		    packageSize = 0;
-		    
-		    // for each data file in the package
-
-		    for(int i = 0; i < dataFiles.length; i++) {
-			String fileID = dataFiles[i].value;
-			log.debug(" ======= processing fileID = " + fileID);
-
-			// get the DSpace Item for this fileID
-			Item fileItem = getDSpaceItem(fileID);
-
-			if(fileItem == null) {
-			    log.error("Skipping data file -- it's null");
-			    break;
-			}
-			log.debug("file internalID = " + fileItem.getID());
-			
-			// total package size
-			// add total size of the bitstreams in this data file 
-			// to the cumulative total for the package
-			// (includes metadata, readme, and textual conversions for indexing)
-			for (Bundle bn : fileItem.getBundles()) {
-			    for (Bitstream bs : bn.getBitstreams()) {
-				packageSize = packageSize + bs.getSize();
-			    }
-			}
-			log.debug("total package size (as of file " + fileID + ") = " + packageSize);
-
-			// Readmes
-			// Check for at least one readme bitstream. There may be more, due to indexing and cases
-			// where the file itself is named readme. We only count one readme per datafile.
-			boolean readmeFound = false;
-			for (Bundle bn : fileItem.getBundles()) {
-			    for (Bitstream bs : bn.getBitstreams()) {
-				String name = bs.getName().trim().toLowerCase();
-				if(name.startsWith("readme")) {
-				    readmeFound = true;
-				}
-			    }
-			}
-			
-			// embargo setting (of last file processed)
-			vals = fileItem.getMetadata("dc.type.embargo");
-			if (vals.length > 0) {
-			    embargoType = vals[0].value;
-			    log.debug("EMBARGO vals " + vals.length + " type " + embargoType);
-			}
-			vals = fileItem.getMetadata("dc.date.embargoedUntil");
-			if (vals.length > 0) {
-			    embargoDate = vals[0].value;
-			}
-			if((embargoType == null || embargoType.equals("") || embargoType.equals("none")) &&
-			   (embargoDate != null && !embargoDate.equals(""))) {
-			    // correctly encode embago type to "oneyear" if there is a date set, but the type is blank or none
-			    embargoType = "oneyear";
-			}
-			log.debug("embargoType = " + embargoType);
-			log.debug("embargoDate = " + embargoDate);
-			
-		       			    			
-			// number of downlaods for most downloaded file
-			// must use the DSpace item ID, since the solr stats system is based on this ID
-			// The SOLR address is hardcoded to the production system here, because even when we run on test servers,
-			// it's easiest to use the real stats --the test servers typically don't have useful stats available
-			URL downloadStatURL = new URL("http://datadryad.org/solr/statistics/select/?indent=on&q=owningItem:" + fileItem.getID());
-			log.debug("fetching " + downloadStatURL);
-			Document statsdoc = docb.parse(downloadStatURL.openStream());
-			NodeList nl = statsdoc.getElementsByTagName("result");
-			String downloadsAtt = nl.item(0).getAttributes().getNamedItem("numFound").getTextContent();
-			int currDownloads = Integer.parseInt(downloadsAtt);
-			if(currDownloads > maxDownloads) {
-			    maxDownloads = currDownloads;
-			    // rather than converting maxDownloads back to a string, just use the string we parsed above
-			    numberOfDownloads = downloadsAtt;
-			}
-			log.debug("max downloads (as of file " + fileID + ") = " + numberOfDownloads);
-			
-		    }
-
-		}
 		log.info(handle + " done.");
 	    } catch (Exception e) {
 		log.fatal("Skipping -- Exception in processing " + handle, e);
@@ -419,10 +292,10 @@ public class TransferToDash extends AbstractCurationTask {
 		return Curator.CURATE_SKIP;
 	    }
 
-            // write this item to json
+            // write this item to a file for easy debugging
             objectMapper.writerWithDefaultPrettyPrinter().writeValue(new File("/tmp/transferToDash.json"), dataset);
 
-            // send this item to the server
+            // send this item to the DASH server
             sendToDash(objectMapper.writeValueAsString(dataset));
             
             // provide output for the console
@@ -476,7 +349,7 @@ public class TransferToDash extends AbstractCurationTask {
                 out.append(line);
             }
             String response = out.toString();
-            System.out.println("##### " + response);
+            log.debug("transfer response " + response);
         } catch (Exception e) {
             log.fatal("Unable to send item to DASH", e);
         }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -26,8 +26,9 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import sun.net.www.protocol.http.HttpURLConnection;
-import javax.net.ssl.HttpsURLConnection;
+import java.net.HttpURLConnection;
+// import sun.net.www.protocol.http.HttpURLConnection;
+// import javax.net.ssl.HttpsURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -459,7 +460,8 @@ public class TransferToDash extends AbstractCurationTask {
         try {
             URL url = new URL(dashServer + "/api/datasets");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            //connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            connection.setRequestProperty("Content-Type", "application/json");
             connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Authorization", "Bearer " + token);
             connection.setDoOutput(true);

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -282,6 +282,133 @@ public class TransferToDash extends AbstractCurationTask {
                 }
                 dataset.put("authors", allAuthors);
 
+                // ///////// Items below this are not yet added to json
+                
+		// journal
+	 	vals = item.getMetadata("prism.publicationName");
+		if (vals.length == 0) {
+		    setResult("Object has no prism.publicationName available " + handle);
+		    log.error("Skipping -- Object has no prism.publicationName available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    journal = vals[0].value;
+		}
+		log.debug("journal = " + journal);
+
+		// accession date
+		vals = item.getMetadata("dc.date.accessioned");
+		if (vals.length == 0) {
+		    setResult("Object has no dc.date.accessioned available " + handle);
+		    log.error("Skipping -- Object has no dc.date.accessioned available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    dateAccessioned = vals[0].value;
+		}
+		log.debug("dateAccessioned = " + dateAccessioned);
+
+		// manuscript number
+		DCValue[] manuvals = item.getMetadata("dc.identifier.manuscriptNumber");
+		manuscriptNum = null;
+		if(manuvals.length > 0) {
+		    manuscriptNum = manuvals[0].value;
+		}
+		if(manuscriptNum != null && manuscriptNum.trim().length() > 0) {
+		    log.debug("has a real manuscriptNum = " + manuscriptNum);
+
+		}
+		
+		// count the files, and compute statistics that depend on the files
+		log.debug("getting data file info");
+		DCValue[] dataFiles = item.getMetadata("dc.relation.haspart");
+		if (dataFiles.length == 0) {
+		    setResult("Object has no dc.relation.haspart available " + handle);
+		    log.error("Skipping -- Object has no dc.relation.haspart available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    numberOfFiles = "" + dataFiles.length;
+		    packageSize = 0;
+		    
+		    // for each data file in the package
+
+		    for(int i = 0; i < dataFiles.length; i++) {
+			String fileID = dataFiles[i].value;
+			log.debug(" ======= processing fileID = " + fileID);
+
+			// get the DSpace Item for this fileID
+			Item fileItem = getDSpaceItem(fileID);
+
+			if(fileItem == null) {
+			    log.error("Skipping data file -- it's null");
+			    break;
+			}
+			log.debug("file internalID = " + fileItem.getID());
+			
+			// total package size
+			// add total size of the bitstreams in this data file 
+			// to the cumulative total for the package
+			// (includes metadata, readme, and textual conversions for indexing)
+			for (Bundle bn : fileItem.getBundles()) {
+			    for (Bitstream bs : bn.getBitstreams()) {
+				packageSize = packageSize + bs.getSize();
+			    }
+			}
+			log.debug("total package size (as of file " + fileID + ") = " + packageSize);
+
+			// Readmes
+			// Check for at least one readme bitstream. There may be more, due to indexing and cases
+			// where the file itself is named readme. We only count one readme per datafile.
+			boolean readmeFound = false;
+			for (Bundle bn : fileItem.getBundles()) {
+			    for (Bitstream bs : bn.getBitstreams()) {
+				String name = bs.getName().trim().toLowerCase();
+				if(name.startsWith("readme")) {
+				    readmeFound = true;
+				}
+			    }
+			}
+			
+			// embargo setting (of last file processed)
+			vals = fileItem.getMetadata("dc.type.embargo");
+			if (vals.length > 0) {
+			    embargoType = vals[0].value;
+			    log.debug("EMBARGO vals " + vals.length + " type " + embargoType);
+			}
+			vals = fileItem.getMetadata("dc.date.embargoedUntil");
+			if (vals.length > 0) {
+			    embargoDate = vals[0].value;
+			}
+			if((embargoType == null || embargoType.equals("") || embargoType.equals("none")) &&
+			   (embargoDate != null && !embargoDate.equals(""))) {
+			    // correctly encode embago type to "oneyear" if there is a date set, but the type is blank or none
+			    embargoType = "oneyear";
+			}
+			log.debug("embargoType = " + embargoType);
+			log.debug("embargoDate = " + embargoDate);
+			
+		       			    			
+			// number of downlaods for most downloaded file
+			// must use the DSpace item ID, since the solr stats system is based on this ID
+			// The SOLR address is hardcoded to the production system here, because even when we run on test servers,
+			// it's easiest to use the real stats --the test servers typically don't have useful stats available
+			URL downloadStatURL = new URL("http://datadryad.org/solr/statistics/select/?indent=on&q=owningItem:" + fileItem.getID());
+			log.debug("fetching " + downloadStatURL);
+			Document statsdoc = docb.parse(downloadStatURL.openStream());
+			NodeList nl = statsdoc.getElementsByTagName("result");
+			String downloadsAtt = nl.item(0).getAttributes().getNamedItem("numFound").getTextContent();
+			int currDownloads = Integer.parseInt(downloadsAtt);
+			if(currDownloads > maxDownloads) {
+			    maxDownloads = currDownloads;
+			    // rather than converting maxDownloads back to a string, just use the string we parsed above
+			    numberOfDownloads = downloadsAtt;
+			}
+			log.debug("max downloads (as of file " + fileID + ") = " + numberOfDownloads);
+			
+		    }
+
+		}
 		log.info(handle + " done.");
 	    } catch (Exception e) {
 		log.fatal("Skipping -- Exception in processing " + handle, e);
@@ -292,10 +419,10 @@ public class TransferToDash extends AbstractCurationTask {
 		return Curator.CURATE_SKIP;
 	    }
 
-            // write this item to a file for easy debugging
+            // write this item to json
             objectMapper.writerWithDefaultPrettyPrinter().writeValue(new File("/tmp/transferToDash.json"), dataset);
 
-            // send this item to the DASH server
+            // send this item to the server
             sendToDash(objectMapper.writeValueAsString(dataset));
             
             // provide output for the console
@@ -349,7 +476,7 @@ public class TransferToDash extends AbstractCurationTask {
                 out.append(line);
             }
             String response = out.toString();
-            log.debug("transfer response " + response);
+            System.out.println("##### " + response);
         } catch (Exception e) {
             log.fatal("Unable to send item to DASH", e);
         }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -166,7 +166,7 @@ public class TransferToDash extends AbstractCurationTask {
                 dataset.put("identifier", packageDOI);
 
                 // title
-                DCValue[] vals = item.getMetadata("dc.title");
+                vals = item.getMetadata("dc.title");
                 if (vals.length > 0) {
                     String title = vals[0].value;
                     log.debug("title = " + title);
@@ -176,8 +176,8 @@ public class TransferToDash extends AbstractCurationTask {
                 // abstract
                 vals = item.getMetadata("dc.description");
                 if (vals.length > 0) {
-                    String abstract = vals[0].value;
-                    dataset.put("abstract", abstract);
+                    String packageAbstract = vals[0].value;
+                    dataset.put("abstract", packageAbstract);
                 }
                        
                 // TODO -- fix this field! Need a real lookup!
@@ -309,11 +309,6 @@ public class TransferToDash extends AbstractCurationTask {
 				}
 			    }
 			}
-			if(readmeFound) {
-			    numReadmes++;
-			}
-			log.debug("total readmes (as of file " + fileID + ") = " + numReadmes);
-
 			
 			// embargo setting (of last file processed)
 			vals = fileItem.getMetadata("dc.type.embargo");
@@ -363,20 +358,21 @@ public class TransferToDash extends AbstractCurationTask {
 		context.abort();
 		return Curator.CURATE_SKIP;
 	    }
+
+            // write this item to json
+            objectMapper.writeValue(new File("/tmp/transferToDash.json"), dataset);
+
+            // provide output for the console
+            setResult("Last processed item = " + handle + " -- " + packageDOI);        
+            report(handle + ", " + packageDOI + ", " + articleDOI + ", \"" + journal + "\", " +
+                   numberOfFiles + ", " + packageSize);
+
 	} else {
 	    log.info("Skipping -- non-item DSpace object");
 	    setResult("Object skipped (not an item)");
 	    context.abort();
 	    return Curator.CURATE_SKIP;
         }
-
-        // write this item to json
-        objectMapper.writeValue(new File("/tmp/transferToDash.json"), dataset);
-
-        // provide output for the console
-	setResult("Last processed item = " + handle + " -- " + packageDOI);        
-	report(handle + ", " + packageDOI + ", " + articleDOI + ", \"" + journal + "\", " +
-	       numberOfFiles + ", " + packageSize);
 
 	// slow this down a bit so we don't overwhelm the production SOLR server with requests
 	try {

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -1,0 +1,360 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.curate;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Properties;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.dspace.JournalUtils;
+import org.dspace.content.authority.Concept;
+import org.dspace.content.authority.Scheme;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import org.dspace.handle.HandleManager;
+import org.dspace.app.util.DCInput;
+import org.dspace.app.util.DCInputSet;
+import org.dspace.app.util.DCInputsReader;
+import org.dspace.app.util.DCInputsReaderException;
+import org.dspace.content.DCValue;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.Bundle;
+import org.dspace.content.Bitstream;
+import org.dspace.content.crosswalk.MetadataValidationException;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.core.Constants;
+import org.dspace.identifier.IdentifierService;
+import org.dspace.identifier.IdentifierNotFoundException;
+import org.dspace.identifier.IdentifierNotResolvableException;
+import org.dspace.utils.DSpace;
+
+import org.apache.log4j.Logger;
+import org.datadryad.api.DryadJournalConcept;
+
+/**
+ * TransferToDash processes a data package and sends it to a DASH-based Dryad system.
+ *
+ * The task succeeds if it was able to process all required metadata and stats,
+ * otherwise it fails. If the transfer was successful, results are recorded in the
+ * metadata field dryad.dashTransferDate
+ *
+ * Originally based on the DataPackageStats curation task.
+ *
+ * Input: a single data package OR a collection that contains data packages
+ * Output: CSV file with appropriate stats
+ * Side Effects: Data package is transferred to DASH-based Dryad, Data Package is updated
+ *               with metadata indicating date of successfull transfer.
+ *
+ * @author Ryan Scherle
+ */
+
+@Suspendable
+public class TransferToDash extends AbstractCurationTask {
+
+    private static Logger log = Logger.getLogger(TransferToDash.class);
+    private IdentifierService identifierService = null;
+    DocumentBuilderFactory dbf = null;
+    DocumentBuilder docb = null;
+    static long total = 0;
+    private Context context;
+    
+    @Override 
+    public void init(Curator curator, String taskId) throws IOException {
+        super.init(curator, taskId);
+	
+        identifierService = new DSpace().getSingletonService(IdentifierService.class);            
+	
+	// init xml processing
+	try {
+	    dbf = DocumentBuilderFactory.newInstance();
+	    docb = dbf.newDocumentBuilder();
+	} catch (ParserConfigurationException e) {
+	    throw new IOException("unable to initiate xml processor", e);
+	}
+    }
+    
+    /**
+     * Perform the curation task upon passed DSO
+     *
+     * @param dso the DSpace object
+     * @throws IOException
+     */
+    @Override
+    public int perform(DSpaceObject dso) throws IOException {
+	log.info("performing TransferToDash task " + total++ );
+	
+	String handle = "\"[no handle found]\"";
+	String packageDOI = "\"[no package DOI found]\"";
+	String articleDOI = "\"[no article DOI found]\"";
+	String journal = "[no journal found]"; // don't add quotes here, because journal is always quoted when output below
+	String numberOfFiles = "\"[no numberOfFiles found]\"";
+	long packageSize = 0;
+	String embargoType = "none";
+	String embargoDate = "";
+	int maxDownloads = 0;
+	String numberOfDownloads = "\"[unknown]\"";
+	String manuscriptNum = null;
+	int numReadmes = 0;
+	String dateAccessioned = "\"[unknown]\"";
+
+	
+	try {
+	    context = new Context();
+        } catch (SQLException e) {
+	    log.fatal("Unable to open database connection", e);
+	    return Curator.CURATE_FAIL;
+	}
+	
+	if (dso.getType() == Constants.COLLECTION) {
+	    // output generic report header for the CSV file that will be created by processing all items in this collection
+	    report("handle, packageDOI, articleDOI, journal, numberOfFiles, packageSize, " +
+		   "embargoType, embargoDate, numberOfDownloads, manuscriptNum, numReadmes, dateAccessioned");
+	} else if (dso.getType() == Constants.ITEM) {
+            Item item = (Item)dso;
+
+	    try {
+		handle = item.getHandle();
+		log.info("handle = " + handle);
+		
+		if (handle == null) {
+		    // this item is still in workflow - no handle assigned
+		    handle = "in workflow";
+		}
+		
+		// package DOI
+		DCValue[] vals = item.getMetadata("dc.identifier");
+		if (vals.length == 0) {
+		    setResult("Object has no dc.identifier available " + handle);
+		    log.error("Skipping -- no dc.identifier available for " + handle);
+		    context.abort(); 
+		    return Curator.CURATE_SKIP;
+		} else {
+		    for(int i = 0; i < vals.length; i++) {
+			if (vals[i].value.startsWith("doi:")) {
+			    packageDOI = vals[i].value;
+			}
+		    }
+		}
+		log.debug("packageDOI = " + packageDOI);
+
+		// article DOI
+		vals = item.getMetadata("dc.relation.isreferencedby");
+		if (vals.length == 0) {
+		    log.debug("Object has no articleDOI (dc.relation.isreferencedby) " + handle);
+		} else {
+		    articleDOI = vals[0].value;
+		}
+		log.debug("articleDOI = " + articleDOI);
+
+		
+		// journal
+	 	vals = item.getMetadata("prism.publicationName");
+		if (vals.length == 0) {
+		    setResult("Object has no prism.publicationName available " + handle);
+		    log.error("Skipping -- Object has no prism.publicationName available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    journal = vals[0].value;
+		}
+		log.debug("journal = " + journal);
+
+		// accession date
+		vals = item.getMetadata("dc.date.accessioned");
+		if (vals.length == 0) {
+		    setResult("Object has no dc.date.accessioned available " + handle);
+		    log.error("Skipping -- Object has no dc.date.accessioned available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    dateAccessioned = vals[0].value;
+		}
+		log.debug("dateAccessioned = " + dateAccessioned);
+
+		// manuscript number
+		DCValue[] manuvals = item.getMetadata("dc.identifier.manuscriptNumber");
+		manuscriptNum = null;
+		if(manuvals.length > 0) {
+		    manuscriptNum = manuvals[0].value;
+		}
+		if(manuscriptNum != null && manuscriptNum.trim().length() > 0) {
+		    log.debug("has a real manuscriptNum = " + manuscriptNum);
+
+		}
+		
+		// count the files, and compute statistics that depend on the files
+		log.debug("getting data file info");
+		DCValue[] dataFiles = item.getMetadata("dc.relation.haspart");
+		if (dataFiles.length == 0) {
+		    setResult("Object has no dc.relation.haspart available " + handle);
+		    log.error("Skipping -- Object has no dc.relation.haspart available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    numberOfFiles = "" + dataFiles.length;
+		    packageSize = 0;
+		    
+		    // for each data file in the package
+
+		    for(int i = 0; i < dataFiles.length; i++) {
+			String fileID = dataFiles[i].value;
+			log.debug(" ======= processing fileID = " + fileID);
+
+			// get the DSpace Item for this fileID
+			Item fileItem = getDSpaceItem(fileID);
+
+			if(fileItem == null) {
+			    log.error("Skipping data file -- it's null");
+			    break;
+			}
+			log.debug("file internalID = " + fileItem.getID());
+			
+			// total package size
+			// add total size of the bitstreams in this data file 
+			// to the cumulative total for the package
+			// (includes metadata, readme, and textual conversions for indexing)
+			for (Bundle bn : fileItem.getBundles()) {
+			    for (Bitstream bs : bn.getBitstreams()) {
+				packageSize = packageSize + bs.getSize();
+			    }
+			}
+			log.debug("total package size (as of file " + fileID + ") = " + packageSize);
+
+			// Readmes
+			// Check for at least one readme bitstream. There may be more, due to indexing and cases
+			// where the file itself is named readme. We only count one readme per datafile.
+			boolean readmeFound = false;
+			for (Bundle bn : fileItem.getBundles()) {
+			    for (Bitstream bs : bn.getBitstreams()) {
+				String name = bs.getName().trim().toLowerCase();
+				if(name.startsWith("readme")) {
+				    readmeFound = true;
+				}
+			    }
+			}
+			if(readmeFound) {
+			    numReadmes++;
+			}
+			log.debug("total readmes (as of file " + fileID + ") = " + numReadmes);
+
+			
+			// embargo setting (of last file processed)
+			vals = fileItem.getMetadata("dc.type.embargo");
+			if (vals.length > 0) {
+			    embargoType = vals[0].value;
+			    log.debug("EMBARGO vals " + vals.length + " type " + embargoType);
+			}
+			vals = fileItem.getMetadata("dc.date.embargoedUntil");
+			if (vals.length > 0) {
+			    embargoDate = vals[0].value;
+			}
+			if((embargoType == null || embargoType.equals("") || embargoType.equals("none")) &&
+			   (embargoDate != null && !embargoDate.equals(""))) {
+			    // correctly encode embago type to "oneyear" if there is a date set, but the type is blank or none
+			    embargoType = "oneyear";
+			}
+			log.debug("embargoType = " + embargoType);
+			log.debug("embargoDate = " + embargoDate);
+			
+		       			    			
+			// number of downlaods for most downloaded file
+			// must use the DSpace item ID, since the solr stats system is based on this ID
+			// The SOLR address is hardcoded to the production system here, because even when we run on test servers,
+			// it's easiest to use the real stats --the test servers typically don't have useful stats available
+			URL downloadStatURL = new URL("http://datadryad.org/solr/statistics/select/?indent=on&q=owningItem:" + fileItem.getID());
+			log.debug("fetching " + downloadStatURL);
+			Document statsdoc = docb.parse(downloadStatURL.openStream());
+			NodeList nl = statsdoc.getElementsByTagName("result");
+			String downloadsAtt = nl.item(0).getAttributes().getNamedItem("numFound").getTextContent();
+			int currDownloads = Integer.parseInt(downloadsAtt);
+			if(currDownloads > maxDownloads) {
+			    maxDownloads = currDownloads;
+			    // rather than converting maxDownloads back to a string, just use the string we parsed above
+			    numberOfDownloads = downloadsAtt;
+			}
+			log.debug("max downloads (as of file " + fileID + ") = " + numberOfDownloads);
+			
+		    }
+
+		}
+		log.info(handle + " done.");
+	    } catch (Exception e) {
+		log.fatal("Skipping -- Exception in processing " + handle, e);
+		setResult("Object has a fatal error: " + handle + "\n" + e.getMessage());
+		report("Object has a fatal error: " + handle + "\n" + e.getMessage());
+		
+		context.abort();
+		return Curator.CURATE_SKIP;
+	    }
+	} else {
+	    log.info("Skipping -- non-item DSpace object");
+	    setResult("Object skipped (not an item)");
+	    context.abort();
+	    return Curator.CURATE_SKIP;
+        }
+
+	setResult("Last processed item = " + handle + " -- " + packageDOI);
+	report(handle + ", " + packageDOI + ", " + articleDOI + ", \"" + journal + "\", " +
+	       numberOfFiles + ", " + packageSize + ", " +
+	       embargoType + ", " + embargoDate + ", " + numberOfDownloads + ", " + manuscriptNum + ", " +
+	       numReadmes + ", " + dateAccessioned);
+
+	// slow this down a bit so we don't overwhelm the production SOLR server with requests
+	try {
+	    Thread.sleep(20);
+	} catch(InterruptedException e) {
+	    // ignore it
+	}
+
+	log.debug("TransferToDash complete");
+
+	try { 
+	    context.complete();
+        } catch (SQLException e) {
+	    log.fatal("Unable to close database connection", e);
+	}
+	return Curator.CURATE_SUCCESS;
+    }
+
+    /**
+       An XML utility method that returns the text content of a node.
+    **/
+    private String getNodeText(Node aNode) {
+	return aNode.getChildNodes().item(0).getNodeValue();
+    }
+
+    private Item getDSpaceItem(String itemID) {
+	Item dspaceItem = null;
+	try {
+	    dspaceItem = (Item)identifierService.resolve(context, itemID);  
+        } catch (IdentifierNotFoundException e) {
+	    log.fatal("Unable to get DSpace Item for " + itemID, e);
+	} catch (IdentifierNotResolvableException e) {
+	    log.fatal("Unable to get DSpace Item for " + itemID, e);
+	}
+
+	return dspaceItem;
+    }
+    
+}


### PR DESCRIPTION
This is the first version of the transfer mechanism between classic Dryad and New Dryad. It transfers basic metadata about a data package (title, authors, abstract). It can be run over a single data package, or the entire collection of data packages.

To test:
1. Ensure your maven settings file has appropriate values for 
  - default.dash.server = protocol and hostname of the target server (e.g. http://ryandash.datadryad.org)
  - default.dash.username = oauth application ID
  - default.dash.password = oauth application secret
2. Find the handle of an item you want to transfer
3. Call the tool from the command line, using the handle as the item's ID:
`/opt/dryad/bin/dspace curate -v -t transfertodash -i 10255/dryad.135814 -r -`

If you want to transfer all data packages, use the handle of the Data Packages collection (usually 10255/3).

Caveats:
- Although this PR includes a definition for a new metadata field, dashTransferDate, this field is not yet used. It will be used in a future update.
- The CSV written to stdout is intended to give basic feedback for someone watching the script run. It has been copied from the old DataPackageStats report, and currently contains some fields that do not yet have values. These values will be added in a future update.