### PR TITLE
Protect against null pointer exceptions with an empty path

### DIFF
--- a/dspace/modules/dataone-mn/dataone-mn-webapp/src/main/java/org/dspace/dataonemn/DataOneMN.java
+++ b/dspace/modules/dataone-mn/dataone-mn-webapp/src/main/java/org/dspace/dataonemn/DataOneMN.java
@@ -141,7 +141,12 @@ public class DataOneMN extends HttpServlet implements Constants {
      **/
     private String buildReqPath(String aPath) {
 	String reqPath = aPath;
-	
+
+        // if the path is empty, return an empty string
+        if(reqPath == null || reqPath.length() == 0) {
+            return "";
+        }
+        
 	// handle (and remove) the version indicator
 	// TODO: throw an error for requests that do not have a version indicator -- need to notify potential users first
 	if(reqPath.startsWith("/v1")) {


### PR DESCRIPTION

This problem doesn't appear to happen on a "normal" VM, but it was happening on secundus. When viewing http://api.datadryad.org/mn, a NullPointerError would appear.

Because I couldn't recreate the problem on my VM, I have already applied the fix to secundus.