### PR TITLE
Dash transfer -- refactored version

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -333,8 +333,8 @@ doi.datacite.connected = ${default.doi.datacite.connected}
 
 ##### Connection to DASH API #####
 dash.server = ${default.dash.server}
-dash.username = ${default.dash.username}
-dash.password = ${default.dash.password}
+dash.application_id = ${default.dash.application_id}
+dash.application_secret = ${default.dash.application_secret}
 
 ##### Authorization system configuration - Delegate ADMIN #####
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -331,6 +331,10 @@ doi.localpart.testsuffix = FK2dryad.
 # For dev and testing, don't want to hit them all the time
 doi.datacite.connected = ${default.doi.datacite.connected}
 
+##### Connection to DASH API #####
+dash.server = ${default.dash.server}
+dash.username = ${default.dash.username}
+dash.password = ${default.dash.password}
 
 ##### Authorization system configuration - Delegate ADMIN #####
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -333,8 +333,8 @@ doi.datacite.connected = ${default.doi.datacite.connected}
 
 ##### Connection to DASH API #####
 dash.server = ${default.dash.server}
-dash.application_id = ${default.dash.application_id}
-dash.application_secret = ${default.dash.application_secret}
+dash.application.id = ${default.dash.application.id}
+dash.application.secret = ${default.dash.application.secret}
 
 ##### Authorization system configuration - Delegate ADMIN #####
 

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -374,6 +374,14 @@
 		</step>
 	</command>
 
+	<command>
+	  <name>dash-service</name>
+	  <description>DASH utility</description>
+	  <step>
+	    <class>org.datadryad.api.DashService</class>
+	  </step>
+	</command>
+
     <command>
         <name>review-item</name>
         <description>Approve or reject a workflow item in the review stage</description>

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -20,6 +20,7 @@ plugin.named.org.dspace.curate.CurationTask = \
     org.dspace.curate.PackageSimpleStats = packagestats, \
     org.dspace.curate.FileSimpleStats = filestats, \
     org.dspace.curate.DataFileStats = datafilestats, \
+    org.dspace.curate.TransferToDash = transfertodash, \
     org.dspace.curate.UpdateHandleRelationshipsToDOIs = updatehandlerelationships, \
     org.dspace.curate.DataPackagesWithInsufficientMetadata = packagesinsufficientmetadata, \
     org.dspace.curate.DataFilesWithInsufficientMetadata = datafilesinsufficientmetadata, \

--- a/dspace/config/registries/dash-transfer.xml
+++ b/dspace/config/registries/dash-transfer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<dspace-dc-types>
+
+  <!-- Date a data package was successfully transferred to DASH -->
+    <dc-type>
+        <schema>dryad</schema>
+        <element>dashTransferDate</element>
+    </dc-type>
+
+</dspace-dc-types>

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -156,6 +156,7 @@ public class DashService {
                 datasetID = matcher.group(1);
             }
 
+            dataPackage.addDashTransferDate();
             log.info("got dataset ID " + datasetID);
             log.info("result object " + response);
         } catch (Exception e) {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -2,6 +2,10 @@ package org.datadryad.api;
 
 /** 
     Utilities to facilitate communication with the DASH-based version of Dryad.
+
+    To use from the command line:
+    - retrieve an item from Dash:
+      /opt/dryad/bin/dspace dash-service <doi>
  **/
 
 import java.io.BufferedReader;
@@ -165,7 +169,7 @@ public class DashService {
     public static void main(String[] args) throws IOException {
         
         String usage = "\n\nUsage: \n" +
-            "\tlookup a specific item: class doi\n";
+            "\tlookup a specific item: dash-service doi\n";
         DashService service = new DashService();
 
         // LOOKUP: args[0]=DOI

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -1,0 +1,155 @@
+package org.datadryad.api;
+
+/** 
+    Utilities to facilitate communication with the DASH-based version of Dryad.
+ **/
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.log4j.Logger;
+import org.dspace.core.ConfigurationManager;
+
+
+
+
+public class DashService {
+
+    private static final Logger log = Logger.getLogger(DashService.class);
+    private String dashServer = "";
+    private String oauthToken = "";
+
+    public DashService() {
+        // init oauth connection with DASH
+        dashServer = ConfigurationManager.getProperty("dash.server");
+        String dashAppID = ConfigurationManager.getProperty("dash.application.id");
+        String dashAppSecret = ConfigurationManager.getProperty("dash.application.secret");
+        
+        oauthToken = getOAUTHtoken(dashServer, dashAppID, dashAppSecret);
+    }
+
+    
+    private String getOAUTHtoken(String dashServer, String dashAppID, String dashAppSecret) {
+        
+        String url = dashServer + "/oauth/token";
+        String auth = dashAppID + ":" + dashAppSecret;
+        String authentication = Base64.getEncoder().encodeToString(auth.getBytes());
+        Pattern tokenPattern = Pattern.compile(".*\"access_token\"\\s*:\\s*\"([^\"]+)\".*");
+        String token = "";
+
+        try {
+            URL urlObj = new URL(url);
+            HttpURLConnection con = (HttpURLConnection) urlObj.openConnection();
+            con.setRequestMethod("POST");
+            con.setDoOutput(true);
+            con.setRequestProperty("Authorization", "Basic " + authentication);
+            con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8");
+            con.setRequestProperty("Accept", "application/json");
+            
+            PrintStream os = new PrintStream(con.getOutputStream());
+            os.print("grant_type=client_credentials");
+            os.close();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            String line = null;
+            StringWriter out = new StringWriter(con.getContentLength() > 0 ? con.getContentLength() : 2048);
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+            }
+            String response = out.toString();
+            Matcher matcher = tokenPattern.matcher(response);
+            if (matcher.matches() && matcher.groupCount() > 0) {
+                token = matcher.group(1);
+            }
+
+            log.info("got OAuth token " + token);
+
+        } catch (Exception e) {
+            log.fatal("Unable to obtain OAuth token", e);
+        }
+
+        return token;
+    }
+
+    public String getDashJSON(String doi) {
+        return "getDashJSON NOT IMPLEMENTED YET";
+    }
+    
+    public String postDataPackage(DryadDataPackage dataPackage) {
+        String dashJSON = dataPackage.getDashJSON();
+        String responseCode = "POST not completed";
+        log.debug("Got JSON object: " + dashJSON);
+            
+        BufferedReader reader = null;
+
+        //TODO: replace this pattern matching with real JSON parsing 
+        Pattern datasetIDPattern = Pattern.compile("(/api/datasets/.+?)\"},"); 
+        
+        try {
+            URL url = new URL(dashServer + "/api/datasets");
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("Authorization", "Bearer " + oauthToken);
+            connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
+
+            OutputStreamWriter wr = new OutputStreamWriter(connection.getOutputStream());
+            wr.write(dashJSON);
+            wr.close();
+
+            reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            String line = null;
+            StringWriter out = new StringWriter(connection.getContentLength() > 0 ? connection.getContentLength() : 2048);
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+            }
+
+            responseCode = connection.getResponseCode() + " " + connection.getResponseMessage();
+            String response = out.toString();
+            String datasetID = "";
+            Matcher matcher = datasetIDPattern.matcher(response);
+            if (matcher.matches() && matcher.groupCount() > 0) {
+                datasetID = matcher.group(1);
+            }
+
+            log.info("got dataset ID " + datasetID);
+            log.info("result object " + response);
+        } catch (Exception e) {
+            log.fatal("Unable to send item to DASH", e);
+        }
+
+        return responseCode;
+    }
+    
+    /**
+     * Have to test this on dev since it's also IP restricted.
+     *
+     * @param args
+     */
+    public static void main(String[] args) throws IOException {
+        
+        String usage = "\n\nUsage: \n" +
+            "\tlookup a specific item: class doi\n";
+        DashService service = new DashService();
+
+        log.debug("========== Starting DOI command-line service ===========");
+
+        // LOOKUP: args[0]=DOI
+        if (args.length == 1) {
+            String doiID = args[0];
+            System.out.println(service.getDashJSON(doiID));
+        } else {
+            System.out.println(usage);
+        }
+    }
+
+
+}

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -129,18 +129,12 @@ public class DashService {
         return responseCode;
     }
     
-    /**
-     * Have to test this on dev since it's also IP restricted.
-     *
-     * @param args
-     */
+
     public static void main(String[] args) throws IOException {
         
         String usage = "\n\nUsage: \n" +
             "\tlookup a specific item: class doi\n";
         DashService service = new DashService();
-
-        log.debug("========== Starting DOI command-line service ===========");
 
         // LOOKUP: args[0]=DOI
         if (args.length == 1) {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -581,6 +581,20 @@ public class DryadDataPackage extends DryadObject {
             mapper.registerModule(new SimpleModule().addSerializer(Package.class, new Package.SchemaDotOrgSerializer()));
             return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(new Package(this));
         } catch (Exception e) {
+            log.error("Unable to serialize Schema.org JSON", e);
+            return "";
+        }
+    }
+
+    // Convenience method to access a properly serialized JSON string, formatted for use with DASH.
+    public String getDashJSON() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            mapper.registerModule(new SimpleModule().addSerializer(Author.class, new Author.DashSerializer()));
+            mapper.registerModule(new SimpleModule().addSerializer(Package.class, new Package.DashSerializer()));
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(new Package(this));
+        } catch (Exception e) {
+            log.error("Unable to serialize Dash-style JSON", e);
             return "";
         }
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -78,15 +78,8 @@ public class DryadDataPackage extends DryadObject {
     private static final String TITLE_SCHEMA = "dc";
     private static final String TITLE_ELEMENT = "title";
 
-    private static final String ABSTRACT_SCHEMA = "dc";
-    private static final String ABSTRACT_ELEMENT = "description";
-
     private static final String KEYWORD_SCHEMA = "dc";
     private static final String KEYWORD_ELEMENT = "subject";
-
-    private static final String AUTHOR_SCHEMA = "dc";
-    private static final String AUTHOR_ELEMENT = "contributor";
-    private static final String AUTHOR_QUALIFIER = "author";
 
     private final static String PUBLICATION_DATE_SCHEMA = "dc";
     private final static String PUBLICATION_DATE_ELEMENT = "date";
@@ -545,11 +538,18 @@ public class DryadDataPackage extends DryadObject {
     }
 
     public void setAbstract(String theAbstract) throws SQLException {
-        addSingleMetadataValue(Boolean.TRUE, ABSTRACT_SCHEMA, ABSTRACT_ELEMENT, null, theAbstract);
+        addSingleMetadataValue(Boolean.TRUE, "dc", "description", null, theAbstract);
     }
 
     public String getAbstract() throws SQLException {
-        return getSingleMetadataValue(ABSTRACT_SCHEMA, ABSTRACT_ELEMENT, null);
+        String theAbstract = getSingleMetadataValue("dc", "description", null);
+        String extraAbstract = getSingleMetadataValue("dc", "description", "abstract");
+
+        if (extraAbstract != null && extraAbstract.length() > 0) {
+            theAbstract = theAbstract + "\n" + extraAbstract;
+        }
+
+        return theAbstract;
     }
 
     public List<String> getKeywords() throws SQLException {
@@ -573,7 +573,15 @@ public class DryadDataPackage extends DryadObject {
 
     public List<Author> getAuthors() throws SQLException {
         ArrayList<Author> authors = new ArrayList<Author>();
-        DCValue[] metadata = item.getMetadata(AUTHOR_SCHEMA, AUTHOR_ELEMENT, AUTHOR_QUALIFIER, Item.ANY);
+        DCValue[] metadata = item.getMetadata("dc", "contributor", "author", Item.ANY);
+        for(DCValue dcValue : metadata) {
+            authors.add(new Author(dcValue));
+        }
+        metadata = item.getMetadata("dc", "contributor", null, Item.ANY);
+        for(DCValue dcValue : metadata) {
+            authors.add(new Author(dcValue));
+        }
+        metadata = item.getMetadata("dc", "creator", null, Item.ANY);
         for(DCValue dcValue : metadata) {
             authors.add(new Author(dcValue));
         }

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -8,6 +8,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -90,6 +92,9 @@ public class DryadDataPackage extends DryadObject {
     private final static String PUBLICATION_DATE_ELEMENT = "date";
     private final static String PUBLICATION_DATE_QUALIFIER = "issued";
 
+    private static final String DASH_TRANSFER_SCHEMA = "dryad";
+    private static final String DASH_TRANSFER_ELEMENT = "dashTransferDate";
+    
     private Set<DryadDataFile> dataFiles;
     private static Logger log = Logger.getLogger(DryadDataPackage.class);
 
@@ -388,6 +393,7 @@ public class DryadDataPackage extends DryadObject {
         addSingleMetadataValue(Boolean.FALSE,PROVENANCE_SCHEMA, PROVENANCE_ELEMENT, PROVENANCE_QUALIFIER, PROVENANCE_LANGUAGE, metadataValue);
     }
 
+    
     @Override
     Set<DryadObject> getRelatedObjects(final Context context) throws SQLException {
         return new HashSet<DryadObject>(getDataFiles(context));
@@ -556,6 +562,13 @@ public class DryadDataPackage extends DryadObject {
 
     public void addKeywords(List<String> keywords) throws SQLException {
         addMultipleMetadataValues(Boolean.FALSE, KEYWORD_SCHEMA, KEYWORD_ELEMENT, null, keywords);
+    }
+
+    public void addDashTransferDate() throws SQLException {
+        Date now = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss.SSSZ");
+        String transferDate = sdf.format(now);
+        addSingleMetadataValue(Boolean.FALSE, DASH_TRANSFER_SCHEMA, DASH_TRANSFER_ELEMENT, null, transferDate);
     }
 
     public List<Author> getAuthors() throws SQLException {

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Author.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Author.java
@@ -228,4 +228,18 @@ public class Author {
             jGen.writeEndObject();
         }
     }
+
+    public static class DashSerializer extends JsonSerializer<Author> {
+        @Override
+        public void serialize(Author author, JsonGenerator jGen, SerializerProvider provider) throws IOException {
+            jGen.writeStartObject();
+            jGen.writeStringField("firstName", author.getGivenNames());
+            jGen.writeStringField("lastName", author.getFamilyName());
+            if (author.getIdentifierType() != null && author.getIdentifierType().equals(ORCID_TYPE)) {
+                jGen.writeStringField("orcid", author.getIdentifier());
+            }
+            jGen.writeEndObject();
+        }
+    }
+
 }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
@@ -157,6 +157,7 @@ public class Package {
         }
         return packageList;
     }
+    
     public static class SchemaDotOrgSerializer extends JsonSerializer<Package> {
         @Override
         public void serialize(Package dataPackage, JsonGenerator jGen, SerializerProvider provider) throws IOException {
@@ -191,6 +192,36 @@ public class Package {
             jGen.writeStringField("url", "https://datadryad.org");
             jGen.writeEndObject();
 
+            jGen.writeEndObject();
+        }
+    }
+
+    public static class DashSerializer extends JsonSerializer<Package> {
+        @Override
+        public void serialize(Package dataPackage, JsonGenerator jGen, SerializerProvider provider) throws IOException {
+            jGen.writeStartObject();
+
+            jGen.writeStringField("identifier", dataPackage.getDryadDOI());
+            jGen.writeStringField("title", dataPackage.getTitle());
+            jGen.writeStringField("abstract", dataPackage.getAbstract());
+            jGen.writeObjectField("authors", dataPackage.getAuthorList());
+
+            if (dataPackage.getKeywords().size() > 0) {
+                jGen.writeObjectField("keywords", dataPackage.getKeywords());
+            }
+            
+            //TODO: replace this with a real epersonID OR DASH user ID
+            jGen.writeStringField("userID", "1");
+            
+            // write citation for article:
+            jGen.writeArrayFieldStart("relatedWorks");
+            jGen.writeStartObject();
+            jGen.writeStringField("relationship", "iscitedby");
+            jGen.writeStringField("identifierType", "DOI");
+            jGen.writeStringField("identifier", dataPackage.getPublicationDOI());
+            jGen.writeEndObject();
+            jGen.writeEndArray();
+             
             jGen.writeEndObject();
         }
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
@@ -25,7 +25,7 @@ import java.util.*;
 
 /**
  *
- * @author1 Dan Leehr <dan.leehr@nescent.org>
+ * @author Dan Leehr <dan.leehr@nescent.org>
  */
 @XmlRootElement
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -221,7 +221,13 @@ public class Package {
             jGen.writeStringField("identifier", dataPackage.getPublicationDOI());
             jGen.writeEndObject();
             jGen.writeEndArray();
-             
+
+            // When working with Dryad Classic packages, we want to disable the
+            // default DASH validation and interaction with DataCite
+            jGen.writeBooleanField("skipDataciteUpdate", true);
+            jGen.writeBooleanField("skipEmails", true);
+            jGen.writeBooleanField("loosenValidation", true);
+            
             jGen.writeEndObject();
         }
     }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -23,10 +23,8 @@ import org.dspace.core.Constants;
  * otherwise it fails. If the transfer was successful, results are recorded in the
  * metadata field dryad.dashTransferDate
  *
- * Originally based on the DataPackageStats curation task.
- *
  * Input: a single data package OR a collection that contains data packages
- * Output: CSV file with some quick stats
+ * Output: list of DOIs of the processed items
  * Side Effects: Data package is transferred to DASH-based Dryad, Data Package is updated
  *               with metadata indicating date of successfull transfer.
  *
@@ -76,13 +74,6 @@ public class TransferToDash extends AbstractCurationTask {
             return Curator.CURATE_SKIP;
         }
 
-        // slow this down a bit so we don't overwhelm the production SOLR server with requests
-        try {
-            Thread.sleep(20);
-        } catch(InterruptedException e) {
-            // ignore it
-        }
-        
         log.info("TransferToDash complete");
         return Curator.CURATE_SUCCESS;
     }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -27,6 +27,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import java.net.HttpURLConnection;
+import javax.net.ssl.HttpsURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -331,11 +332,10 @@ public class TransferToDash extends AbstractCurationTask {
         try {
             URL url = new URL(dashServer + "/api/datasets");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setRequestProperty("Authorization", "Bearer " + token);
-            connection.setDoOutput(true);
             connection.setRequestMethod("POST");
+            connection.setRequestProperty("Authorization", "Bearer " + token);
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setDoOutput(true);
 
             OutputStreamWriter wr= new OutputStreamWriter(connection.getOutputStream());
             wr.write(jsonString);

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -26,8 +26,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import sun.net.www.protocol.http.HttpURLConnection;
-import javax.net.ssl.HttpsURLConnection;
+import java.net.HttpURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -26,7 +26,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import java.net.HttpURLConnection;
+import sun.net.www.protocol.http.HttpURLConnection;
+import javax.net.ssl.HttpsURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -27,7 +27,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import java.net.HttpURLConnection;
-import javax.net.ssl.HttpsURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -332,10 +331,11 @@ public class TransferToDash extends AbstractCurationTask {
         try {
             URL url = new URL(dashServer + "/api/datasets");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Authorization", "Bearer " + token);
-            connection.setRequestProperty("Content-Type", "application/json");
             connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
 
             OutputStreamWriter wr= new OutputStreamWriter(connection.getOutputStream());
             wr.write(jsonString);

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -7,51 +7,14 @@
  */
 package org.dspace.curate;
 
-import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.sql.SQLException;
-import java.util.Base64;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.log4j.Logger;
-
 import org.datadryad.api.DryadDataPackage;
-
-import org.dspace.JournalUtils;
-import org.dspace.content.authority.Concept;
-import org.dspace.content.authority.Scheme;
-import org.dspace.content.DCValue;
+import org.datadryad.api.DashService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.core.ConfigurationManager;
-import org.dspace.core.Context;
 import org.dspace.core.Constants;
-import org.dspace.identifier.IdentifierService;
-import org.dspace.identifier.IdentifierNotFoundException;
-import org.dspace.identifier.IdentifierNotResolvableException;
-import org.dspace.utils.DSpace;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 
 /**
  * TransferToDash processes a data package and sends it to a DASH-based Dryad system.
@@ -74,76 +37,16 @@ import org.w3c.dom.NodeList;
 public class TransferToDash extends AbstractCurationTask {
     
     private static Logger log = Logger.getLogger(TransferToDash.class);
-    private IdentifierService identifierService = null;
-    private DocumentBuilderFactory dbf = null;
-    private DocumentBuilder docb = null;
     private static long total = 0;
-    private Context context;
-    private String dashServer;
-    private String oauthToken;
+    private DashService dashService;
 
+    
     @Override 
     public void init(Curator curator, String taskId) throws IOException {
         super.init(curator, taskId);
-	
-        identifierService = new DSpace().getSingletonService(IdentifierService.class);            
-	
-	// init xml processing
-	try {
-	    dbf = DocumentBuilderFactory.newInstance();
-	    docb = dbf.newDocumentBuilder();
-	} catch (ParserConfigurationException e) {
-	    throw new IOException("unable to initiate xml processor", e);
-	}
-        
-        // init oauth connection with DASH
-        dashServer = ConfigurationManager.getProperty("dash.server");
-        String dashAppID = ConfigurationManager.getProperty("dash.application.id");
-        String dashAppSecret = ConfigurationManager.getProperty("dash.application.secret");
-        
-        oauthToken = getOAUTHtoken(dashServer, dashAppID, dashAppSecret);
+        dashService = new DashService();
     }
-    
-    private String getOAUTHtoken(String dashServer, String dashAppID, String dashAppSecret) {
-        
-        String url = dashServer + "/oauth/token";
-        String auth = dashAppID + ":" + dashAppSecret;
-        String authentication = Base64.getEncoder().encodeToString(auth.getBytes());
-        Pattern tokenPattern = Pattern.compile(".*\"access_token\"\\s*:\\s*\"([^\"]+)\".*");
-        String token = "";
-
-        try {
-            URL urlObj = new URL(url);
-            HttpURLConnection con = (HttpURLConnection) urlObj.openConnection();
-            con.setRequestMethod("POST");
-            con.setDoOutput(true);
-            con.setRequestProperty("Authorization", "Basic " + authentication);
-            con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8");
-            con.setRequestProperty("Accept", "application/json");
-            
-            PrintStream os = new PrintStream(con.getOutputStream());
-            os.print("grant_type=client_credentials");
-            os.close();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(con.getInputStream()));
-            String line = null;
-            StringWriter out = new StringWriter(con.getContentLength() > 0 ? con.getContentLength() : 2048);
-            while ((line = reader.readLine()) != null) {
-                out.append(line);
-            }
-            String response = out.toString();
-            Matcher matcher = tokenPattern.matcher(response);
-            if (matcher.matches() && matcher.groupCount() > 0) {
-                token = matcher.group(1);
-            }
-
-            log.info("got OAuth token " + token);
-
-        } catch (Exception e) {
-            log.fatal("Unable to obtain OAuth token", e);
-        }
-
-        return token;
-    }
+ 
     
     /**
      * Perform the curation task upon passed DSO
@@ -153,127 +56,34 @@ public class TransferToDash extends AbstractCurationTask {
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException {
-	log.info("performing TransferToDash task " + total++ );
-	
-	String handle = "\"[no handle found]\"";
-	String packageDOI = "\"[no package DOI found]\"";
-	String articleDOI = "\"[no article DOI found]\"";
-	String journal = "[no journal found]"; // don't add quotes here, because journal is always quoted when output below
-	String numberOfFiles = "\"[no numberOfFiles found]\"";
-	long packageSize = 0;
-	String embargoType = "none";
-	String embargoDate = "";
-	int maxDownloads = 0;
-	String numberOfDownloads = "\"[unknown]\"";
-	String manuscriptNum = null;
-	String dateAccessioned = "\"[unknown]\"";
-	
-	try {
-	    context = new Context();
-        } catch (SQLException e) {
-	    log.fatal("Unable to open database connection", e);
-	    return Curator.CURATE_FAIL;
-	}
-        
-	if (dso.getType() == Constants.COLLECTION) {
-	    // output generic report header for the CSV file that will be created by processing all items in this collection
-	    report("handle, packageDOI, articleDOI, journal, numberOfFiles, packageSize");
-	} else if (dso.getType() == Constants.ITEM) {
-
+        log.info("performing TransferToDash task " + total++ );
+                        
+        if (dso.getType() == Constants.COLLECTION) {
+            // indicate that the "report" output from this class will consist only of packageDOIs
+            report("packageDOI");
+        } else if (dso.getType() == Constants.ITEM) {
             DryadDataPackage dataPackage = new DryadDataPackage((Item)dso);
-            String dashJSON = dataPackage.getDashJSON();
-            log.debug("Got JSON object: " + dashJSON);
-            
-            // send this item to the server
-            sendToDash(dashJSON);
+            dashService.postDataPackage(dataPackage);
+
+            String packageDOI = dataPackage.getIdentifier();
             
             // provide output for the console
-            setResult("Last processed item = " + handle + " -- " + packageDOI);        
-            report(handle + ", " + packageDOI + ", " + articleDOI + ", \"" + journal + "\", " +
-                   numberOfFiles + ", " + packageSize);
-
-	} else {
-	    log.info("Skipping -- non-item DSpace object");
-	    setResult("Object skipped (not an item)");
-	    context.abort();
-	    return Curator.CURATE_SKIP;
+            setResult("Last processed item = " + packageDOI);        
+            report(packageDOI);
+        } else {
+            log.info("Skipping -- non-item DSpace object");
+            setResult("Object skipped (not an item)");
+            return Curator.CURATE_SKIP;
         }
 
-	// slow this down a bit so we don't overwhelm the production SOLR server with requests
-	try {
-	    Thread.sleep(20);
-	} catch(InterruptedException e) {
-	    // ignore it
-	}
-
-	log.debug("TransferToDash complete");
-
-	try { 
-	    context.complete();
-        } catch (SQLException e) {
-	    log.fatal("Unable to close database connection", e);
-	}
-	return Curator.CURATE_SUCCESS;
-    }
-
-    private void sendToDash(String jsonString) {
-        BufferedReader reader = null;
-
-        //TODO: replace this pattern matching with real JSON parsing
-        Pattern datasetIDPattern = Pattern.compile("(/api/datasets/.+?)\"},"); 
-        
+        // slow this down a bit so we don't overwhelm the production SOLR server with requests
         try {
-            URL url = new URL(dashServer + "/api/datasets");
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setRequestProperty("Authorization", "Bearer " + oauthToken);
-            connection.setDoOutput(true);
-            connection.setRequestMethod("POST");
-
-            OutputStreamWriter wr= new OutputStreamWriter(connection.getOutputStream());
-            wr.write(jsonString);
-            wr.close();
-
-            reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-            String line = null;
-            StringWriter out = new StringWriter(connection.getContentLength() > 0 ? connection.getContentLength() : 2048);
-            while ((line = reader.readLine()) != null) {
-                out.append(line);
-            }
-
-            String response = out.toString();
-            String datasetID = "";
-            Matcher matcher = datasetIDPattern.matcher(response);
-            if (matcher.matches() && matcher.groupCount() > 0) {
-                datasetID = matcher.group(1);
-            }
-
-            log.info("got dataset ID " + datasetID);
-            System.out.println("##### " + response);
-        } catch (Exception e) {
-            log.fatal("Unable to send item to DASH", e);
+            Thread.sleep(20);
+        } catch(InterruptedException e) {
+            // ignore it
         }
-    }
         
-    /**
-       An XML utility method that returns the text content of a node.
-    **/
-    private String getNodeText(Node aNode) {
-	return aNode.getChildNodes().item(0).getNodeValue();
+        log.info("TransferToDash complete");
+        return Curator.CURATE_SUCCESS;
     }
-
-    private Item getDSpaceItem(String itemID) {
-	Item dspaceItem = null;
-	try {
-	    dspaceItem = (Item)identifierService.resolve(context, itemID);  
-        } catch (IdentifierNotFoundException e) {
-	    log.fatal("Unable to get DSpace Item for " + itemID, e);
-	} catch (IdentifierNotResolvableException e) {
-	    log.fatal("Unable to get DSpace Item for " + itemID, e);
-	}
-
-	return dspaceItem;
-    }
-    
 }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -96,16 +96,16 @@ public class TransferToDash extends AbstractCurationTask {
         
         // init oauth connection with DASH
         dashServer = ConfigurationManager.getProperty("dash.server");
-        String dashUser = ConfigurationManager.getProperty("dash.application_id");
-        String dashPass = ConfigurationManager.getProperty("dash.application_secret");
+        String dashAppID = ConfigurationManager.getProperty("dash.application_id");
+        String dashAppSecret = ConfigurationManager.getProperty("dash.application_secret");
         
-        oauthToken = getOAUTHtoken(dashServer, dashUser, dashPass);
+        oauthToken = getOAUTHtoken(dashServer, dashAppID, dashAppSecret);
     }
     
-    private String getOAUTHtoken(String dashServer, String dashUser, String dashPass) {
+    private String getOAUTHtoken(String dashServer, String dashAppID, String dashAppSecret) {
         
         String url = dashServer + "/oauth/token";
-        String auth = dashUser + ":" + dashPass;
+        String auth = dashAppID + ":" + dashAppSecret;
         String authentication = Base64.getEncoder().encodeToString(auth.getBytes());
         Pattern pat = Pattern.compile(".*\"access_token\"\\s*:\\s*\"([^\"]+)\".*");
         String token = "";

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -282,133 +282,6 @@ public class TransferToDash extends AbstractCurationTask {
                 }
                 dataset.put("authors", allAuthors);
 
-                // ///////// Items below this are not yet added to json
-                
-		// journal
-	 	vals = item.getMetadata("prism.publicationName");
-		if (vals.length == 0) {
-		    setResult("Object has no prism.publicationName available " + handle);
-		    log.error("Skipping -- Object has no prism.publicationName available " + handle);
-		    context.abort();
-		    return Curator.CURATE_SKIP;
-		} else {
-		    journal = vals[0].value;
-		}
-		log.debug("journal = " + journal);
-
-		// accession date
-		vals = item.getMetadata("dc.date.accessioned");
-		if (vals.length == 0) {
-		    setResult("Object has no dc.date.accessioned available " + handle);
-		    log.error("Skipping -- Object has no dc.date.accessioned available " + handle);
-		    context.abort();
-		    return Curator.CURATE_SKIP;
-		} else {
-		    dateAccessioned = vals[0].value;
-		}
-		log.debug("dateAccessioned = " + dateAccessioned);
-
-		// manuscript number
-		DCValue[] manuvals = item.getMetadata("dc.identifier.manuscriptNumber");
-		manuscriptNum = null;
-		if(manuvals.length > 0) {
-		    manuscriptNum = manuvals[0].value;
-		}
-		if(manuscriptNum != null && manuscriptNum.trim().length() > 0) {
-		    log.debug("has a real manuscriptNum = " + manuscriptNum);
-
-		}
-		
-		// count the files, and compute statistics that depend on the files
-		log.debug("getting data file info");
-		DCValue[] dataFiles = item.getMetadata("dc.relation.haspart");
-		if (dataFiles.length == 0) {
-		    setResult("Object has no dc.relation.haspart available " + handle);
-		    log.error("Skipping -- Object has no dc.relation.haspart available " + handle);
-		    context.abort();
-		    return Curator.CURATE_SKIP;
-		} else {
-		    numberOfFiles = "" + dataFiles.length;
-		    packageSize = 0;
-		    
-		    // for each data file in the package
-
-		    for(int i = 0; i < dataFiles.length; i++) {
-			String fileID = dataFiles[i].value;
-			log.debug(" ======= processing fileID = " + fileID);
-
-			// get the DSpace Item for this fileID
-			Item fileItem = getDSpaceItem(fileID);
-
-			if(fileItem == null) {
-			    log.error("Skipping data file -- it's null");
-			    break;
-			}
-			log.debug("file internalID = " + fileItem.getID());
-			
-			// total package size
-			// add total size of the bitstreams in this data file 
-			// to the cumulative total for the package
-			// (includes metadata, readme, and textual conversions for indexing)
-			for (Bundle bn : fileItem.getBundles()) {
-			    for (Bitstream bs : bn.getBitstreams()) {
-				packageSize = packageSize + bs.getSize();
-			    }
-			}
-			log.debug("total package size (as of file " + fileID + ") = " + packageSize);
-
-			// Readmes
-			// Check for at least one readme bitstream. There may be more, due to indexing and cases
-			// where the file itself is named readme. We only count one readme per datafile.
-			boolean readmeFound = false;
-			for (Bundle bn : fileItem.getBundles()) {
-			    for (Bitstream bs : bn.getBitstreams()) {
-				String name = bs.getName().trim().toLowerCase();
-				if(name.startsWith("readme")) {
-				    readmeFound = true;
-				}
-			    }
-			}
-			
-			// embargo setting (of last file processed)
-			vals = fileItem.getMetadata("dc.type.embargo");
-			if (vals.length > 0) {
-			    embargoType = vals[0].value;
-			    log.debug("EMBARGO vals " + vals.length + " type " + embargoType);
-			}
-			vals = fileItem.getMetadata("dc.date.embargoedUntil");
-			if (vals.length > 0) {
-			    embargoDate = vals[0].value;
-			}
-			if((embargoType == null || embargoType.equals("") || embargoType.equals("none")) &&
-			   (embargoDate != null && !embargoDate.equals(""))) {
-			    // correctly encode embago type to "oneyear" if there is a date set, but the type is blank or none
-			    embargoType = "oneyear";
-			}
-			log.debug("embargoType = " + embargoType);
-			log.debug("embargoDate = " + embargoDate);
-			
-		       			    			
-			// number of downlaods for most downloaded file
-			// must use the DSpace item ID, since the solr stats system is based on this ID
-			// The SOLR address is hardcoded to the production system here, because even when we run on test servers,
-			// it's easiest to use the real stats --the test servers typically don't have useful stats available
-			URL downloadStatURL = new URL("http://datadryad.org/solr/statistics/select/?indent=on&q=owningItem:" + fileItem.getID());
-			log.debug("fetching " + downloadStatURL);
-			Document statsdoc = docb.parse(downloadStatURL.openStream());
-			NodeList nl = statsdoc.getElementsByTagName("result");
-			String downloadsAtt = nl.item(0).getAttributes().getNamedItem("numFound").getTextContent();
-			int currDownloads = Integer.parseInt(downloadsAtt);
-			if(currDownloads > maxDownloads) {
-			    maxDownloads = currDownloads;
-			    // rather than converting maxDownloads back to a string, just use the string we parsed above
-			    numberOfDownloads = downloadsAtt;
-			}
-			log.debug("max downloads (as of file " + fileID + ") = " + numberOfDownloads);
-			
-		    }
-
-		}
 		log.info(handle + " done.");
 	    } catch (Exception e) {
 		log.fatal("Skipping -- Exception in processing " + handle, e);
@@ -419,10 +292,10 @@ public class TransferToDash extends AbstractCurationTask {
 		return Curator.CURATE_SKIP;
 	    }
 
-            // write this item to json
+            // write this item to a file for easy debugging
             objectMapper.writerWithDefaultPrettyPrinter().writeValue(new File("/tmp/transferToDash.json"), dataset);
 
-            // send this item to the server
+            // send this item to the DASH server
             sendToDash(objectMapper.writeValueAsString(dataset));
             
             // provide output for the console
@@ -476,7 +349,7 @@ public class TransferToDash extends AbstractCurationTask {
                 out.append(line);
             }
             String response = out.toString();
-            System.out.println("##### " + response);
+            log.debug("transfer response " + response);
         } catch (Exception e) {
             log.fatal("Unable to send item to DASH", e);
         }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -26,8 +26,9 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import sun.net.www.protocol.http.HttpURLConnection;
-import javax.net.ssl.HttpsURLConnection;
+import java.net.HttpURLConnection;
+// import sun.net.www.protocol.http.HttpURLConnection;
+// import javax.net.ssl.HttpsURLConnection;
     
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -459,7 +460,8 @@ public class TransferToDash extends AbstractCurationTask {
         try {
             URL url = new URL(dashServer + "/api/datasets");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            //connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            connection.setRequestProperty("Content-Type", "application/json");
             connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Authorization", "Bearer " + token);
             connection.setDoOutput(true);

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -64,7 +64,7 @@ public class TransferToDash extends AbstractCurationTask {
             report("packageDOI");
         } else if (dso.getType() == Constants.ITEM) {
             DryadDataPackage dataPackage = new DryadDataPackage((Item)dso);
-            dashService.postDataPackage(dataPackage);
+            dashService.putDataPackage(dataPackage);
             
             String packageDOI = dataPackage.getIdentifier();
             

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -28,6 +28,9 @@ import org.dspace.core.Constants;
  * Side Effects: Data package is transferred to DASH-based Dryad, Data Package is updated
  *               with metadata indicating date of successfull transfer.
  *
+ * To use from the command line:
+ * /opt/dryad/bin/dspace curate -v -t transfertodash -i <handle-without-hdl-prefix> -r -
+ *
  * @author Ryan Scherle
  */
 

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -282,6 +282,133 @@ public class TransferToDash extends AbstractCurationTask {
                 }
                 dataset.put("authors", allAuthors);
 
+                // ///////// Items below this are not yet added to json
+                
+		// journal
+	 	vals = item.getMetadata("prism.publicationName");
+		if (vals.length == 0) {
+		    setResult("Object has no prism.publicationName available " + handle);
+		    log.error("Skipping -- Object has no prism.publicationName available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    journal = vals[0].value;
+		}
+		log.debug("journal = " + journal);
+
+		// accession date
+		vals = item.getMetadata("dc.date.accessioned");
+		if (vals.length == 0) {
+		    setResult("Object has no dc.date.accessioned available " + handle);
+		    log.error("Skipping -- Object has no dc.date.accessioned available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    dateAccessioned = vals[0].value;
+		}
+		log.debug("dateAccessioned = " + dateAccessioned);
+
+		// manuscript number
+		DCValue[] manuvals = item.getMetadata("dc.identifier.manuscriptNumber");
+		manuscriptNum = null;
+		if(manuvals.length > 0) {
+		    manuscriptNum = manuvals[0].value;
+		}
+		if(manuscriptNum != null && manuscriptNum.trim().length() > 0) {
+		    log.debug("has a real manuscriptNum = " + manuscriptNum);
+
+		}
+		
+		// count the files, and compute statistics that depend on the files
+		log.debug("getting data file info");
+		DCValue[] dataFiles = item.getMetadata("dc.relation.haspart");
+		if (dataFiles.length == 0) {
+		    setResult("Object has no dc.relation.haspart available " + handle);
+		    log.error("Skipping -- Object has no dc.relation.haspart available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    numberOfFiles = "" + dataFiles.length;
+		    packageSize = 0;
+		    
+		    // for each data file in the package
+
+		    for(int i = 0; i < dataFiles.length; i++) {
+			String fileID = dataFiles[i].value;
+			log.debug(" ======= processing fileID = " + fileID);
+
+			// get the DSpace Item for this fileID
+			Item fileItem = getDSpaceItem(fileID);
+
+			if(fileItem == null) {
+			    log.error("Skipping data file -- it's null");
+			    break;
+			}
+			log.debug("file internalID = " + fileItem.getID());
+			
+			// total package size
+			// add total size of the bitstreams in this data file 
+			// to the cumulative total for the package
+			// (includes metadata, readme, and textual conversions for indexing)
+			for (Bundle bn : fileItem.getBundles()) {
+			    for (Bitstream bs : bn.getBitstreams()) {
+				packageSize = packageSize + bs.getSize();
+			    }
+			}
+			log.debug("total package size (as of file " + fileID + ") = " + packageSize);
+
+			// Readmes
+			// Check for at least one readme bitstream. There may be more, due to indexing and cases
+			// where the file itself is named readme. We only count one readme per datafile.
+			boolean readmeFound = false;
+			for (Bundle bn : fileItem.getBundles()) {
+			    for (Bitstream bs : bn.getBitstreams()) {
+				String name = bs.getName().trim().toLowerCase();
+				if(name.startsWith("readme")) {
+				    readmeFound = true;
+				}
+			    }
+			}
+			
+			// embargo setting (of last file processed)
+			vals = fileItem.getMetadata("dc.type.embargo");
+			if (vals.length > 0) {
+			    embargoType = vals[0].value;
+			    log.debug("EMBARGO vals " + vals.length + " type " + embargoType);
+			}
+			vals = fileItem.getMetadata("dc.date.embargoedUntil");
+			if (vals.length > 0) {
+			    embargoDate = vals[0].value;
+			}
+			if((embargoType == null || embargoType.equals("") || embargoType.equals("none")) &&
+			   (embargoDate != null && !embargoDate.equals(""))) {
+			    // correctly encode embago type to "oneyear" if there is a date set, but the type is blank or none
+			    embargoType = "oneyear";
+			}
+			log.debug("embargoType = " + embargoType);
+			log.debug("embargoDate = " + embargoDate);
+			
+		       			    			
+			// number of downlaods for most downloaded file
+			// must use the DSpace item ID, since the solr stats system is based on this ID
+			// The SOLR address is hardcoded to the production system here, because even when we run on test servers,
+			// it's easiest to use the real stats --the test servers typically don't have useful stats available
+			URL downloadStatURL = new URL("http://datadryad.org/solr/statistics/select/?indent=on&q=owningItem:" + fileItem.getID());
+			log.debug("fetching " + downloadStatURL);
+			Document statsdoc = docb.parse(downloadStatURL.openStream());
+			NodeList nl = statsdoc.getElementsByTagName("result");
+			String downloadsAtt = nl.item(0).getAttributes().getNamedItem("numFound").getTextContent();
+			int currDownloads = Integer.parseInt(downloadsAtt);
+			if(currDownloads > maxDownloads) {
+			    maxDownloads = currDownloads;
+			    // rather than converting maxDownloads back to a string, just use the string we parsed above
+			    numberOfDownloads = downloadsAtt;
+			}
+			log.debug("max downloads (as of file " + fileID + ") = " + numberOfDownloads);
+			
+		    }
+
+		}
 		log.info(handle + " done.");
 	    } catch (Exception e) {
 		log.fatal("Skipping -- Exception in processing " + handle, e);
@@ -292,10 +419,10 @@ public class TransferToDash extends AbstractCurationTask {
 		return Curator.CURATE_SKIP;
 	    }
 
-            // write this item to a file for easy debugging
+            // write this item to json
             objectMapper.writerWithDefaultPrettyPrinter().writeValue(new File("/tmp/transferToDash.json"), dataset);
 
-            // send this item to the DASH server
+            // send this item to the server
             sendToDash(objectMapper.writeValueAsString(dataset));
             
             // provide output for the console
@@ -349,7 +476,7 @@ public class TransferToDash extends AbstractCurationTask {
                 out.append(line);
             }
             String response = out.toString();
-            log.debug("transfer response " + response);
+            System.out.println("##### " + response);
         } catch (Exception e) {
             log.fatal("Unable to send item to DASH", e);
         }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -107,7 +107,7 @@ public class TransferToDash extends AbstractCurationTask {
         String url = dashServer + "/oauth/token";
         String auth = dashAppID + ":" + dashAppSecret;
         String authentication = Base64.getEncoder().encodeToString(auth.getBytes());
-        Pattern pat = Pattern.compile(".*\"access_token\"\\s*:\\s*\"([^\"]+)\".*");
+        Pattern tokenPattern = Pattern.compile(".*\"access_token\"\\s*:\\s*\"([^\"]+)\".*");
         String token = "";
 
         try {
@@ -129,7 +129,7 @@ public class TransferToDash extends AbstractCurationTask {
                 out.append(line);
             }
             String response = out.toString();
-            Matcher matcher = pat.matcher(response);
+            Matcher matcher = tokenPattern.matcher(response);
             if (matcher.matches() && matcher.groupCount() > 0) {
                 token = matcher.group(1);
             }
@@ -313,7 +313,9 @@ public class TransferToDash extends AbstractCurationTask {
     }
 
     private void sendToDash(String jsonString) {
-        BufferedReader reader = null;
+        BufferedReader reader = null;                 
+        Pattern datasetIDPattern = Pattern.compile("(/api/datasets/.+?)\"},"); 
+        
         try {
             URL url = new URL(dashServer + "/api/datasets");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -334,7 +336,15 @@ public class TransferToDash extends AbstractCurationTask {
             while ((line = reader.readLine()) != null) {
                 out.append(line);
             }
+
             String response = out.toString();
+            String datasetID = "";
+            Matcher matcher = datasetIDPattern.matcher(response);
+            if (matcher.matches() && matcher.groupCount() > 0) {
+                datasetID = matcher.group(1);
+            }
+
+            log.info("got dataset ID " + datasetID);
             System.out.println("##### " + response);
         } catch (Exception e) {
             log.fatal("Unable to send item to DASH", e);

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -65,7 +65,7 @@ public class TransferToDash extends AbstractCurationTask {
         } else if (dso.getType() == Constants.ITEM) {
             DryadDataPackage dataPackage = new DryadDataPackage((Item)dso);
             dashService.postDataPackage(dataPackage);
-
+            
             String packageDOI = dataPackage.getIdentifier();
             
             // provide output for the console

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -166,7 +166,7 @@ public class TransferToDash extends AbstractCurationTask {
                 dataset.put("identifier", packageDOI);
 
                 // title
-                DCValue[] vals = item.getMetadata("dc.title");
+                vals = item.getMetadata("dc.title");
                 if (vals.length > 0) {
                     String title = vals[0].value;
                     log.debug("title = " + title);
@@ -176,8 +176,8 @@ public class TransferToDash extends AbstractCurationTask {
                 // abstract
                 vals = item.getMetadata("dc.description");
                 if (vals.length > 0) {
-                    String abstract = vals[0].value;
-                    dataset.put("abstract", abstract);
+                    String packageAbstract = vals[0].value;
+                    dataset.put("abstract", packageAbstract);
                 }
                        
                 // TODO -- fix this field! Need a real lookup!
@@ -309,11 +309,6 @@ public class TransferToDash extends AbstractCurationTask {
 				}
 			    }
 			}
-			if(readmeFound) {
-			    numReadmes++;
-			}
-			log.debug("total readmes (as of file " + fileID + ") = " + numReadmes);
-
 			
 			// embargo setting (of last file processed)
 			vals = fileItem.getMetadata("dc.type.embargo");
@@ -363,20 +358,21 @@ public class TransferToDash extends AbstractCurationTask {
 		context.abort();
 		return Curator.CURATE_SKIP;
 	    }
+
+            // write this item to json
+            objectMapper.writeValue(new File("/tmp/transferToDash.json"), dataset);
+
+            // provide output for the console
+            setResult("Last processed item = " + handle + " -- " + packageDOI);        
+            report(handle + ", " + packageDOI + ", " + articleDOI + ", \"" + journal + "\", " +
+                   numberOfFiles + ", " + packageSize);
+
 	} else {
 	    log.info("Skipping -- non-item DSpace object");
 	    setResult("Object skipped (not an item)");
 	    context.abort();
 	    return Curator.CURATE_SKIP;
         }
-
-        // write this item to json
-        objectMapper.writeValue(new File("/tmp/transferToDash.json"), dataset);
-
-        // provide output for the console
-	setResult("Last processed item = " + handle + " -- " + packageDOI);        
-	report(handle + ", " + packageDOI + ", " + articleDOI + ", \"" + journal + "\", " +
-	       numberOfFiles + ", " + packageSize);
 
 	// slow this down a bit so we don't overwhelm the production SOLR server with requests
 	try {

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -96,8 +96,8 @@ public class TransferToDash extends AbstractCurationTask {
         
         // init oauth connection with DASH
         dashServer = ConfigurationManager.getProperty("dash.server");
-        String dashAppID = ConfigurationManager.getProperty("dash.application_id");
-        String dashAppSecret = ConfigurationManager.getProperty("dash.application_secret");
+        String dashAppID = ConfigurationManager.getProperty("dash.application.id");
+        String dashAppSecret = ConfigurationManager.getProperty("dash.application.secret");
         
         oauthToken = getOAUTHtoken(dashServer, dashAppID, dashAppSecret);
     }
@@ -274,7 +274,7 @@ public class TransferToDash extends AbstractCurationTask {
 		report("Object has a fatal error: " + handle + "\n" + e.getMessage());
 		
 		context.abort();
-		return Curator.CURATE_SKIP;
+                return Curator.CURATE_SKIP;
 	    }
 
             // write this item to json
@@ -313,14 +313,15 @@ public class TransferToDash extends AbstractCurationTask {
     }
 
     private void sendToDash(String jsonString) {
-        BufferedReader reader = null;                 
+        BufferedReader reader = null;
+
+        //TODO: replace this pattern matching with real JSON parsing
         Pattern datasetIDPattern = Pattern.compile("(/api/datasets/.+?)\"},"); 
         
         try {
             URL url = new URL(dashServer + "/api/datasets");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            //connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
-            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
             connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Authorization", "Bearer " + oauthToken);
             connection.setDoOutput(true);

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -1,0 +1,360 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.curate;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Properties;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.dspace.JournalUtils;
+import org.dspace.content.authority.Concept;
+import org.dspace.content.authority.Scheme;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import org.dspace.handle.HandleManager;
+import org.dspace.app.util.DCInput;
+import org.dspace.app.util.DCInputSet;
+import org.dspace.app.util.DCInputsReader;
+import org.dspace.app.util.DCInputsReaderException;
+import org.dspace.content.DCValue;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.Bundle;
+import org.dspace.content.Bitstream;
+import org.dspace.content.crosswalk.MetadataValidationException;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.core.Constants;
+import org.dspace.identifier.IdentifierService;
+import org.dspace.identifier.IdentifierNotFoundException;
+import org.dspace.identifier.IdentifierNotResolvableException;
+import org.dspace.utils.DSpace;
+
+import org.apache.log4j.Logger;
+import org.datadryad.api.DryadJournalConcept;
+
+/**
+ * TransferToDash processes a data package and sends it to a DASH-based Dryad system.
+ *
+ * The task succeeds if it was able to process all required metadata and stats,
+ * otherwise it fails. If the transfer was successful, results are recorded in the
+ * metadata field dryad.dashTransferDate
+ *
+ * Originally based on the DataPackageStats curation task.
+ *
+ * Input: a single data package OR a collection that contains data packages
+ * Output: CSV file with appropriate stats
+ * Side Effects: Data package is transferred to DASH-based Dryad, Data Package is updated
+ *               with metadata indicating date of successfull transfer.
+ *
+ * @author Ryan Scherle
+ */
+
+@Suspendable
+public class TransferToDash extends AbstractCurationTask {
+
+    private static Logger log = Logger.getLogger(TransferToDash.class);
+    private IdentifierService identifierService = null;
+    DocumentBuilderFactory dbf = null;
+    DocumentBuilder docb = null;
+    static long total = 0;
+    private Context context;
+    
+    @Override 
+    public void init(Curator curator, String taskId) throws IOException {
+        super.init(curator, taskId);
+	
+        identifierService = new DSpace().getSingletonService(IdentifierService.class);            
+	
+	// init xml processing
+	try {
+	    dbf = DocumentBuilderFactory.newInstance();
+	    docb = dbf.newDocumentBuilder();
+	} catch (ParserConfigurationException e) {
+	    throw new IOException("unable to initiate xml processor", e);
+	}
+    }
+    
+    /**
+     * Perform the curation task upon passed DSO
+     *
+     * @param dso the DSpace object
+     * @throws IOException
+     */
+    @Override
+    public int perform(DSpaceObject dso) throws IOException {
+	log.info("performing TransferToDash task " + total++ );
+	
+	String handle = "\"[no handle found]\"";
+	String packageDOI = "\"[no package DOI found]\"";
+	String articleDOI = "\"[no article DOI found]\"";
+	String journal = "[no journal found]"; // don't add quotes here, because journal is always quoted when output below
+	String numberOfFiles = "\"[no numberOfFiles found]\"";
+	long packageSize = 0;
+	String embargoType = "none";
+	String embargoDate = "";
+	int maxDownloads = 0;
+	String numberOfDownloads = "\"[unknown]\"";
+	String manuscriptNum = null;
+	int numReadmes = 0;
+	String dateAccessioned = "\"[unknown]\"";
+
+	
+	try {
+	    context = new Context();
+        } catch (SQLException e) {
+	    log.fatal("Unable to open database connection", e);
+	    return Curator.CURATE_FAIL;
+	}
+	
+	if (dso.getType() == Constants.COLLECTION) {
+	    // output generic report header for the CSV file that will be created by processing all items in this collection
+	    report("handle, packageDOI, articleDOI, journal, numberOfFiles, packageSize, " +
+		   "embargoType, embargoDate, numberOfDownloads, manuscriptNum, numReadmes, dateAccessioned");
+	} else if (dso.getType() == Constants.ITEM) {
+            Item item = (Item)dso;
+
+	    try {
+		handle = item.getHandle();
+		log.info("handle = " + handle);
+		
+		if (handle == null) {
+		    // this item is still in workflow - no handle assigned
+		    handle = "in workflow";
+		}
+		
+		// package DOI
+		DCValue[] vals = item.getMetadata("dc.identifier");
+		if (vals.length == 0) {
+		    setResult("Object has no dc.identifier available " + handle);
+		    log.error("Skipping -- no dc.identifier available for " + handle);
+		    context.abort(); 
+		    return Curator.CURATE_SKIP;
+		} else {
+		    for(int i = 0; i < vals.length; i++) {
+			if (vals[i].value.startsWith("doi:")) {
+			    packageDOI = vals[i].value;
+			}
+		    }
+		}
+		log.debug("packageDOI = " + packageDOI);
+
+		// article DOI
+		vals = item.getMetadata("dc.relation.isreferencedby");
+		if (vals.length == 0) {
+		    log.debug("Object has no articleDOI (dc.relation.isreferencedby) " + handle);
+		} else {
+		    articleDOI = vals[0].value;
+		}
+		log.debug("articleDOI = " + articleDOI);
+
+		
+		// journal
+	 	vals = item.getMetadata("prism.publicationName");
+		if (vals.length == 0) {
+		    setResult("Object has no prism.publicationName available " + handle);
+		    log.error("Skipping -- Object has no prism.publicationName available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    journal = vals[0].value;
+		}
+		log.debug("journal = " + journal);
+
+		// accession date
+		vals = item.getMetadata("dc.date.accessioned");
+		if (vals.length == 0) {
+		    setResult("Object has no dc.date.accessioned available " + handle);
+		    log.error("Skipping -- Object has no dc.date.accessioned available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    dateAccessioned = vals[0].value;
+		}
+		log.debug("dateAccessioned = " + dateAccessioned);
+
+		// manuscript number
+		DCValue[] manuvals = item.getMetadata("dc.identifier.manuscriptNumber");
+		manuscriptNum = null;
+		if(manuvals.length > 0) {
+		    manuscriptNum = manuvals[0].value;
+		}
+		if(manuscriptNum != null && manuscriptNum.trim().length() > 0) {
+		    log.debug("has a real manuscriptNum = " + manuscriptNum);
+
+		}
+		
+		// count the files, and compute statistics that depend on the files
+		log.debug("getting data file info");
+		DCValue[] dataFiles = item.getMetadata("dc.relation.haspart");
+		if (dataFiles.length == 0) {
+		    setResult("Object has no dc.relation.haspart available " + handle);
+		    log.error("Skipping -- Object has no dc.relation.haspart available " + handle);
+		    context.abort();
+		    return Curator.CURATE_SKIP;
+		} else {
+		    numberOfFiles = "" + dataFiles.length;
+		    packageSize = 0;
+		    
+		    // for each data file in the package
+
+		    for(int i = 0; i < dataFiles.length; i++) {
+			String fileID = dataFiles[i].value;
+			log.debug(" ======= processing fileID = " + fileID);
+
+			// get the DSpace Item for this fileID
+			Item fileItem = getDSpaceItem(fileID);
+
+			if(fileItem == null) {
+			    log.error("Skipping data file -- it's null");
+			    break;
+			}
+			log.debug("file internalID = " + fileItem.getID());
+			
+			// total package size
+			// add total size of the bitstreams in this data file 
+			// to the cumulative total for the package
+			// (includes metadata, readme, and textual conversions for indexing)
+			for (Bundle bn : fileItem.getBundles()) {
+			    for (Bitstream bs : bn.getBitstreams()) {
+				packageSize = packageSize + bs.getSize();
+			    }
+			}
+			log.debug("total package size (as of file " + fileID + ") = " + packageSize);
+
+			// Readmes
+			// Check for at least one readme bitstream. There may be more, due to indexing and cases
+			// where the file itself is named readme. We only count one readme per datafile.
+			boolean readmeFound = false;
+			for (Bundle bn : fileItem.getBundles()) {
+			    for (Bitstream bs : bn.getBitstreams()) {
+				String name = bs.getName().trim().toLowerCase();
+				if(name.startsWith("readme")) {
+				    readmeFound = true;
+				}
+			    }
+			}
+			if(readmeFound) {
+			    numReadmes++;
+			}
+			log.debug("total readmes (as of file " + fileID + ") = " + numReadmes);
+
+			
+			// embargo setting (of last file processed)
+			vals = fileItem.getMetadata("dc.type.embargo");
+			if (vals.length > 0) {
+			    embargoType = vals[0].value;
+			    log.debug("EMBARGO vals " + vals.length + " type " + embargoType);
+			}
+			vals = fileItem.getMetadata("dc.date.embargoedUntil");
+			if (vals.length > 0) {
+			    embargoDate = vals[0].value;
+			}
+			if((embargoType == null || embargoType.equals("") || embargoType.equals("none")) &&
+			   (embargoDate != null && !embargoDate.equals(""))) {
+			    // correctly encode embago type to "oneyear" if there is a date set, but the type is blank or none
+			    embargoType = "oneyear";
+			}
+			log.debug("embargoType = " + embargoType);
+			log.debug("embargoDate = " + embargoDate);
+			
+		       			    			
+			// number of downlaods for most downloaded file
+			// must use the DSpace item ID, since the solr stats system is based on this ID
+			// The SOLR address is hardcoded to the production system here, because even when we run on test servers,
+			// it's easiest to use the real stats --the test servers typically don't have useful stats available
+			URL downloadStatURL = new URL("http://datadryad.org/solr/statistics/select/?indent=on&q=owningItem:" + fileItem.getID());
+			log.debug("fetching " + downloadStatURL);
+			Document statsdoc = docb.parse(downloadStatURL.openStream());
+			NodeList nl = statsdoc.getElementsByTagName("result");
+			String downloadsAtt = nl.item(0).getAttributes().getNamedItem("numFound").getTextContent();
+			int currDownloads = Integer.parseInt(downloadsAtt);
+			if(currDownloads > maxDownloads) {
+			    maxDownloads = currDownloads;
+			    // rather than converting maxDownloads back to a string, just use the string we parsed above
+			    numberOfDownloads = downloadsAtt;
+			}
+			log.debug("max downloads (as of file " + fileID + ") = " + numberOfDownloads);
+			
+		    }
+
+		}
+		log.info(handle + " done.");
+	    } catch (Exception e) {
+		log.fatal("Skipping -- Exception in processing " + handle, e);
+		setResult("Object has a fatal error: " + handle + "\n" + e.getMessage());
+		report("Object has a fatal error: " + handle + "\n" + e.getMessage());
+		
+		context.abort();
+		return Curator.CURATE_SKIP;
+	    }
+	} else {
+	    log.info("Skipping -- non-item DSpace object");
+	    setResult("Object skipped (not an item)");
+	    context.abort();
+	    return Curator.CURATE_SKIP;
+        }
+
+	setResult("Last processed item = " + handle + " -- " + packageDOI);
+	report(handle + ", " + packageDOI + ", " + articleDOI + ", \"" + journal + "\", " +
+	       numberOfFiles + ", " + packageSize + ", " +
+	       embargoType + ", " + embargoDate + ", " + numberOfDownloads + ", " + manuscriptNum + ", " +
+	       numReadmes + ", " + dateAccessioned);
+
+	// slow this down a bit so we don't overwhelm the production SOLR server with requests
+	try {
+	    Thread.sleep(20);
+	} catch(InterruptedException e) {
+	    // ignore it
+	}
+
+	log.debug("TransferToDash complete");
+
+	try { 
+	    context.complete();
+        } catch (SQLException e) {
+	    log.fatal("Unable to close database connection", e);
+	}
+	return Curator.CURATE_SUCCESS;
+    }
+
+    /**
+       An XML utility method that returns the text content of a node.
+    **/
+    private String getNodeText(Node aNode) {
+	return aNode.getChildNodes().item(0).getNodeValue();
+    }
+
+    private Item getDSpaceItem(String itemID) {
+	Item dspaceItem = null;
+	try {
+	    dspaceItem = (Item)identifierService.resolve(context, itemID);  
+        } catch (IdentifierNotFoundException e) {
+	    log.fatal("Unable to get DSpace Item for " + itemID, e);
+	} catch (IdentifierNotResolvableException e) {
+	    log.fatal("Unable to get DSpace Item for " + itemID, e);
+	}
+
+	return dspaceItem;
+    }
+    
+}


### PR DESCRIPTION
This subsumes #1477, and refactors the essential pieces into three separate parts:
- DryadDataPackage, Author, and Package = serialization of a Dryad package into Dash-formatted JSON
- DashService = API communications with Dash
- TransferToDash = curation task that manages bulk transfer of packages to Dash

Also cleaned up Daisie's notes from #1477.... note that the names of the maven parameters have changed.

To test:
1. Ensure your maven settings file has appropriate values for 
    - `default.dash.server` = protocol and hostname of the target server (e.g. http://ryandash.datadryad.org)
    -  `default.dash.application.id` = oauth application ID
    - `default.dash.application.secret` = oauth application secret
2. Find the handle or DOI of an item you want to transfer
3. To post a new item to Dash, call the curation tool from the command line, using the handle:
`/opt/dryad/bin/dspace curate -v -t transfertodash -i 10255/dryad.135814 -r -`
4. To view an item from Dash, call the dash-service tool from the command line, using the DOI: 
`/opt/dryad/bin/dspace dash-service doi:10.5072/fzpe-zz40`

Note: Most new functionality will be added into the dash-service tool, but the curation tool is being retained since it will likely be better for bulk transfers.