### PR TITLE
Curation slowness: Allow DOI server to be configured, don't check DOI when changing workflow state

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -310,7 +310,7 @@ dryad.blackout.url = http://datadryad.org/publicationBlackout
 doi.prefix = ${default.doi.prefix}
 
 doi.service.url = ${default.doi.service}
-
+doi.server = ${default.doi.server}
 doi.service.testmode= ${default.doi.testmode}
 
 doi.dir = ${dspace.dir}/doi-minter

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
@@ -35,8 +35,6 @@ public class CDLDataCiteService {
 
     private static final Logger log = Logger.getLogger(CDLDataCiteService.class);
 
-    private static final String DEFAULT_BASEURL = ConfigurationManager.getProperty("doi.server");
-
     private String myUsername;
     private String myPassword;
 
@@ -105,7 +103,7 @@ public class CDLDataCiteService {
             aDOI = aDOI.substring(4);
         }
 
-        String baseUrl = DEFAULT_BASEURL;
+        String baseUrl = ConfigurationManager.getProperty("doi.server");
         String doiEnv = System.getenv("DOI_SERVER");
         if(doiEnv != null) {
             baseUrl = doiEnv;

--- a/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
+++ b/dspace/modules/doi/dspace-doi-api/src/main/java/org/dspace/doi/CDLDataCiteService.java
@@ -35,7 +35,7 @@ public class CDLDataCiteService {
 
     private static final Logger log = Logger.getLogger(CDLDataCiteService.class);
 
-    private static final String DEFAULT_BASEURL = "https://ez.datacite.org";
+    private static final String DEFAULT_BASEURL = ConfigurationManager.getProperty("doi.server");
 
     private String myUsername;
     private String myPassword;

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/MyTasksTransformer.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/MyTasksTransformer.java
@@ -206,7 +206,7 @@ public class MyTasksTransformer extends DiscoverySubmissions{
 
 
                 // Registration Status Row
-                Row registrationRow = t.addRow();
+                /*                Row registrationRow = t.addRow();
                 registrationRow.addCell(Cell.ROLE_HEADER).addContent(T_doi_registration_status);
                 c = registrationRow.addCell(Cell.ROLE_DATA);
 
@@ -219,6 +219,7 @@ public class MyTasksTransformer extends DiscoverySubmissions{
                     // no DOI registration info
                     c.addContent(T_doi_not_registered);
                 }
+                */
 
                 Row titleRow = t.addRow();
                 titleRow.addCell(Cell.ROLE_HEADER).addContent(T_item_title);


### PR DESCRIPTION
This is a start at addressing https://trello.com/c/gTy0EFUX

- Make it easier to test with different DOI settings by allowing the DOI server to be configured, so slowness can be more easily examined (note that this server can be overriden with environment variables, but it's still annoying to have a hardcoded value)
- Based on some testing with the DataCite test server, one source of slowness for curation pages is excessive testing of the DOI's status at DataCite. Commenting out the test that is performed when an item's state is changed.