### PR TITLE
Dash transfer -- with bitstreams

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -729,36 +729,4 @@ public class Bitstream extends DSpaceObject
             }                                   
         }
     }
-
-
-    // Convenience method to access a properly serialized JSON string, formatted for use with DASH.
-    public String getDashJSON() {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            mapper.registerModule(new SimpleModule().addSerializer(Bitstream.class, new Bitstream.DashSerializer()));
-            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
-        } catch (Exception e) {
-            log.error("Unable to serialize Dash-style JSON", e);
-            return "";
-        }
-    }
-
-    /**
-       Serializes this bitstream into a JSON object for use with DASH.
-       Assumes the bitstream is stored in Amazon S3.
-    **/
-    public static class DashSerializer extends JsonSerializer<Package> {
-        @Override
-        public void serialize(Bitstream bitstream, JsonGenerator jGen, SerializerProvider provider) throws IOException {
-            jGen.writeStartObject();
-            
-            jGen.writeStringField("url", BitstreamStorageManager.getS3AccessURL(bitstream));
-            jGen.writeStringField("path", bitstream.getName());
-            jGen.writeStringField("description", bitstream.getFileDescription());
-            jGen.writeStringField("mimeType", bitstream.getFormat().getMIMEType());
-
-            jGen.writeEndObject();
-        }
-    }
-    
 }

--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -135,7 +135,7 @@ public class Bitstream extends DSpaceObject
         if (log.isDebugEnabled())
         {
             log.debug(LogManager.getHeader(context, "find_bitstream",
-                    "bitstream_id=" + id));
+                                           "bitstream_id=" + id));
         }
 
         return new Bitstream(context, row);
@@ -252,13 +252,23 @@ public class Bitstream extends DSpaceObject
     }
 
     /**
-     * Get the internal identifier of this bitstream
+     * Get the bitstream (database) identifier of this bitstream
      * 
-     * @return the internal identifier
+     * @return the bitstream identifier
      */
     public int getID()
     {
         return bRow.getIntColumn("bitstream_id");
+    }
+
+    /**
+     * Get the internal (storage) identifier of this bitstream
+     * 
+     * @return the internal identifier
+     */
+    public String getInternalID()
+    {
+        return bRow.getStringColumn("internal_id");
     }
 
     public String getHandle()

--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -729,4 +729,36 @@ public class Bitstream extends DSpaceObject
             }                                   
         }
     }
+
+
+    // Convenience method to access a properly serialized JSON string, formatted for use with DASH.
+    public String getDashJSON() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            mapper.registerModule(new SimpleModule().addSerializer(Bitstream.class, new Bitstream.DashSerializer()));
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+        } catch (Exception e) {
+            log.error("Unable to serialize Dash-style JSON", e);
+            return "";
+        }
+    }
+
+    /**
+       Serializes this bitstream into a JSON object for use with DASH.
+       Assumes the bitstream is stored in Amazon S3.
+    **/
+    public static class DashSerializer extends JsonSerializer<Package> {
+        @Override
+        public void serialize(Bitstream bitstream, JsonGenerator jGen, SerializerProvider provider) throws IOException {
+            jGen.writeStartObject();
+            
+            jGen.writeStringField("url", BitstreamStorageManager.getS3AccessURL(bitstream));
+            jGen.writeStringField("path", bitstream.getName());
+            jGen.writeStringField("description", bitstream.getFileDescription());
+            jGen.writeStringField("mimeType", bitstream.getFormat().getMIMEType());
+
+            jGen.writeEndObject();
+        }
+    }
+    
 }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
@@ -189,7 +189,7 @@ public class BitstreamStorageManager
 
         // bucket name
         if (s3BucketName == null || s3BucketName.length() == 0) {
-            s3BucketName = "dspace-asset-" + ConfigurationManager.getProperty("dspace.hostname");
+            s3BucketName = "dspace-asset-" + ConfigurationManager.getProperty("dspace.hostname").replace('.','-');
             log.warn("S3 BucketName is not configured, setting default: " + s3BucketName);
         }
 

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageManager.java
@@ -570,10 +570,11 @@ public class BitstreamStorageManager
     {
         InputStream resultInputStream = null;
         TableRow bitstream = DatabaseManager.find(context, "bitstream", id);
+        String sInternalId = bitstream.getStringColumn("internal_id");
         int storeNumber = bitstream.getIntColumn("store_number");
        
         if(storeNumber == S3_ASSETSTORE) {
-            URL url = getS3AccessURL(bitstream);
+            URL url = getS3AccessURL(sInternalId);
             resultInputStream = url.openStream();
         } else {
             // retrieve from local file storage
@@ -582,7 +583,7 @@ public class BitstreamStorageManager
         }
 
         if(resultInputStream == null) {
-            throw new IOException("Unable to get S3 presigned url " + key + " from bucket " + s3BucketName);
+            throw new IOException("Unable to open input stream for bitstream " + id);
         }
         
         return resultInputStream;
@@ -592,12 +593,10 @@ public class BitstreamStorageManager
        Returns a URL that allows access to a bitstream stored in Amazon S3.
     **/
     public static URL getS3AccessURL(Bitstream bitstream) throws SQLException {
-        TableRow bitstreamRow = DatabaseManager.find(context, "bitstream", bitstream.getID());
-        return getS3AccessURL(bitstreamRow);
+        return getS3AccessURL(bitstream.getInternalID());
     }
 
-    private static URL getS3AccessURL(TableRow bitstream) {
-        String sInternalId = bitstreamRow.getStringColumn("internal_id");
+    private static URL getS3AccessURL(String sInternalId) {
         String key = getFullS3Key(sInternalId + "");
         URL url = null;
         

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -336,6 +336,7 @@ dash.server = ${default.dash.server}
 dash.application.id = ${default.dash.application.id}
 dash.application.secret = ${default.dash.application.secret}
 dash.submissions.finalize = ${default.dash.submissions.finalize}
+dash.submissions.delaySeconds = ${default.dash.submissions.delaySeconds}
 
 ##### Authorization system configuration - Delegate ADMIN #####
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -335,6 +335,7 @@ doi.datacite.connected = ${default.doi.datacite.connected}
 dash.server = ${default.dash.server}
 dash.application.id = ${default.dash.application.id}
 dash.application.secret = ${default.dash.application.secret}
+dash.submissions.finalize = ${default.dash.submissions.finalize}
 
 ##### Authorization system configuration - Delegate ADMIN #####
 

--- a/dspace/config/log4j-console.properties
+++ b/dspace/config/log4j-console.properties
@@ -24,3 +24,6 @@ log4j.logger.org.dspace.doi=DEBUG
 log4j.logger.org.dspace.servicemanager=WARN
 log4j.logger.org.dspace.kernel=WARN
 log4j.logger.org.springframework=WARN 
+
+# Ensure DASH migration has complete logging
+log4j.logger.org.datadryad.api=DEBUG

--- a/dspace/config/log4j-dspace-cli.properties
+++ b/dspace/config/log4j-dspace-cli.properties
@@ -99,6 +99,8 @@ log4j.additivity.org.dspace.dataonemn=false
 # AssociationAnywhere connection
 log4j.logger.org.datadryad.anywhere=FATAL
 
+# Ensure DASH migration has complete logging
+log4j.logger.org.datadryad.api=DEBUG
 
 
 # In earlier XML configuration, some package names were specified

--- a/dspace/config/log4j-dspace-cli.properties
+++ b/dspace/config/log4j-dspace-cli.properties
@@ -97,7 +97,9 @@ log4j.logger.org.dspace.dataonemn=WARN,DATAONE_MN_FILE
 log4j.additivity.org.dspace.dataonemn=false
 
 # AssociationAnywhere connection
-log4j.logger.org.datadryad.anywhere=DEBUG
+log4j.logger.org.datadryad.anywhere=FATAL
+
+
 
 # In earlier XML configuration, some package names were specified
 # to log at a different level than WARN, overriding the root default

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -27,8 +27,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.log4j.Logger;
 import org.dspace.core.ConfigurationManager;
-
-
+import org.dspace.content.Bitstream;
 
 public class DashService {
 
@@ -213,7 +212,7 @@ public class DashService {
     // - expand to all bitstreams and readmes
     // - check character ecoding
     private int putDataFile(DryadDataFile dataFile, DryadDataPackage dataPackage) {
-        String dashJSON = dataFile.getDashJSON();
+        String dashJSON = ""; //TODO dataFile.getDashJSON();
         log.debug("Got JSON object: " + dashJSON);
         int responseCode = 0;
         BufferedReader reader = null;
@@ -222,7 +221,7 @@ public class DashService {
             Bitstream firstBitstream = dataFile.getFirstBitstream();
             String encodedFileName = URLEncoder.encode(firstBitstream.getName(), "UTF-8");
             String encodedPackageDOI = URLEncoder.encode(dataPackage.getIdentifier(), "UTF-8");
-            URL url = new URL(dashServer + "/api/datasets/" + encodedDOI + "/files/" + encodedFileName);
+            URL url = new URL(dashServer + "/api/datasets/" + encodedPackageDOI + "/files/" + encodedFileName);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
             connection.setRequestProperty("Authorization", "Bearer " + oauthToken);

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -267,6 +267,12 @@ public class DashService {
     public int submitDashDataset(String doi) {
         int responseCode = 0;
         BufferedReader reader = null;
+
+        String submissionsFinalize = ConfigurationManager.getProperty("dash.submissions.finalize");
+        if(!submissionsFinalize.equals("true")) {
+            log.info("Skipping finalization of " + doi + " due to dash.submissios.finalize = " + submissionsFinalize);
+            return 200;
+        }
         
         try {
             String encodedDOI = URLEncoder.encode(doi, "UTF-8");

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -214,19 +214,11 @@ public class DashService {
     }
 
     /**
-       POSTs references for all data files Dash, attaching them to the DryadDataPackage.
+       POSTs references for all data files to Dash, attaching them to the DryadDataPackage.
        The DryadDataPackage must already have been PUT to Dash.
 
        @return a HTTP response code, or -1 if there is an exception that prevents getting a response code
     **/
-    // TODO
-    // - add json transformer in DryadBitstream
-    // - submit to proper PUT URL
-    // - use a temporary URL
-    // - document how to get/use the amazon tmp URLs
-    // - figure out the mime types for the http request
-    // - expand to all bitstreams and readmes
-    // - check character ecoding
     public int postDataFileReferences(Context context, DryadDataPackage dataPackage) {
         int responseCode = 0;
         BufferedReader reader = null;

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadBitstream.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadBitstream.java
@@ -64,8 +64,12 @@ public class DryadBitstream {
                 
                 jGen.writeStringField("url", BitstreamStorageManager.getS3AccessURL(dspaceBitstream).toString());
                 jGen.writeStringField("path", dspaceBitstream.getName());
+                jGen.writeNumberField("size", dspaceBitstream.getSize());
                 jGen.writeStringField("description", dryadBitstream.getFileDescription());
                 jGen.writeStringField("mimeType", dspaceBitstream.getFormat().getMIMEType());
+                jGen.writeStringField("digest", dspaceBitstream.getChecksum());
+                jGen.writeStringField("digestType", dspaceBitstream.getChecksumAlgorithm().toLowerCase());
+                jGen.writeBooleanField("skipValidation", true);
                 
                 jGen.writeEndObject();
             } catch (Exception e) {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadBitstream.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadBitstream.java
@@ -4,25 +4,46 @@
 
 package org.datadryad.api;
 
+import org.apache.log4j.Logger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
 
 import org.dspace.content.Bitstream;
+import org.dspace.storage.bitstore.BitstreamStorageManager;
 
 public class DryadBitstream {
+    private static final Logger log = Logger.getLogger(DryadBitstream.class);
     private Bitstream bitstream;
+    private String fileDescription = "<not initialized>";
     
     public DryadBitstream(Bitstream bitstream) {
         this.bitstream = bitstream;
     }
 
+    public Bitstream getDSpaceBitstream() {
+        return bitstream;
+    }
+
+    public void setFileDescription(String description) {
+        fileDescription = description;
+    }
+    
+    public String getFileDescription() {
+        return fileDescription;
+    }
+    
     // Convenience method to access a properly serialized JSON string, formatted for use with DASH.
-    public String getDashJSON() {
+    public String getDashReferenceJSON() {
         ObjectMapper mapper = new ObjectMapper();
         try {
-            mapper.registerModule(new SimpleModule().addSerializer(Bitstream.class, new Bitstream.DashSerializer()));
+            mapper.registerModule(new SimpleModule().addSerializer(DryadBitstream.class, new DashSerializer()));
             return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
         } catch (Exception e) {
             log.error("Unable to serialize Dash-style JSON", e);
@@ -34,21 +55,21 @@ public class DryadBitstream {
        Serializes this bitstream into a JSON object for use with DASH.
        Assumes the bitstream is stored in Amazon S3.
     **/
-    public static class DashSerializer extends JsonSerializer<Package> {
+    public static class DashSerializer extends JsonSerializer<DryadBitstream> {
         @Override
-        public void serialize(Bitstream bitstream, JsonGenerator jGen, SerializerProvider provider) throws IOException {
+        public void serialize(DryadBitstream dryadBitstream, JsonGenerator jGen, SerializerProvider provider) throws IOException {
+            Bitstream dspaceBitstream = dryadBitstream.getDSpaceBitstream();
             try {
                 jGen.writeStartObject();
                 
-                jGen.writeStringField("url", BitstreamStorageManager.getS3AccessURL(bitstream));
-                jGen.writeStringField("path", bitstream.getName());
-                jGen.writeStringField("description", bitstream.getFileDescription());
-                jGen.writeStringField("mimeType", bitstream.getFormat().getMIMEType());
+                jGen.writeStringField("url", BitstreamStorageManager.getS3AccessURL(dspaceBitstream).toString());
+                jGen.writeStringField("path", dspaceBitstream.getName());
+                jGen.writeStringField("description", dryadBitstream.getFileDescription());
+                jGen.writeStringField("mimeType", dspaceBitstream.getFormat().getMIMEType());
                 
                 jGen.writeEndObject();
             } catch (Exception e) {
-                throw new IOException("Unable to create DASH-formatted JSON for bitstream " + bitstream.getID(), e);
-                
+                throw new IOException("Unable to create DASH-formatted JSON for bitstream " + dspaceBitstream.getID(), e);                
             }
         }
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadBitstream.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadBitstream.java
@@ -1,0 +1,55 @@
+/**
+   Some tools for bitstreams that are specific to Dryad.
+**/
+
+package org.datadryad.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+import org.dspace.content.Bitstream;
+
+public class DryadBitstream {
+    private Bitstream bitstream;
+    
+    public DryadBitstream(Bitstream bitstream) {
+        this.bitstream = bitstream;
+    }
+
+    // Convenience method to access a properly serialized JSON string, formatted for use with DASH.
+    public String getDashJSON() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            mapper.registerModule(new SimpleModule().addSerializer(Bitstream.class, new Bitstream.DashSerializer()));
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+        } catch (Exception e) {
+            log.error("Unable to serialize Dash-style JSON", e);
+            return "";
+        }
+    }
+    
+    /**
+       Serializes this bitstream into a JSON object for use with DASH.
+       Assumes the bitstream is stored in Amazon S3.
+    **/
+    public static class DashSerializer extends JsonSerializer<Package> {
+        @Override
+        public void serialize(Bitstream bitstream, JsonGenerator jGen, SerializerProvider provider) throws IOException {
+            try {
+                jGen.writeStartObject();
+                
+                jGen.writeStringField("url", BitstreamStorageManager.getS3AccessURL(bitstream));
+                jGen.writeStringField("path", bitstream.getName());
+                jGen.writeStringField("description", bitstream.getFileDescription());
+                jGen.writeStringField("mimeType", bitstream.getFormat().getMIMEType());
+                
+                jGen.writeEndObject();
+            } catch (Exception e) {
+                throw new IOException("Unable to create DASH-formatted JSON for bitstream " + bitstream.getID(), e);
+                
+            }
+        }
+    }
+}

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
@@ -234,6 +234,33 @@ public class DryadDataFile extends DryadObject {
         return result;
     }
 
+    public List<Bitstream> getAllBitstreams() {
+        List<Bitstream> bitstreamList = new ArrayList<Bitstream>();
+        Item item = getItem();
+                
+        Bitstream readme = getREADME();
+        if(readme != null) {
+            bitstreamList.add(readme);
+        }
+
+        Bitstream aBitstream = null;
+        Bundle[] bundles = item.getBundles("ORIGINAL"); // anything not ORIGINAL is not a "real" bitstream
+        if (bundles.length == 0) {
+            log.error("Didn't find any original bundles for " + item.getHandle());
+            throw new IOException("data bundle for " + item.getHandle() + " not found");
+        }
+        log.debug("This object has " + bundles.length + " bundles");
+
+        for(int b = 0; b < bundles.length; b++) {
+            Bitstream[] bitstreams = bundles[b].getBitstreams();
+            for(int i = 0; i < bitstreams.length; i++) {
+                bitstreamList.add(bitstreams[i]);
+            }
+        }
+
+        return bitstreamList;
+    }
+
     public Bitstream getREADME() {
         Item item = getItem();
 
@@ -264,6 +291,17 @@ public class DryadDataFile extends DryadObject {
             }
         }
         return size;
+    }
+
+    public String getDescription() throws SQLException {
+        String theAbstract = getSingleMetadataValue("dc", "description", null);
+        String extraAbstract = getSingleMetadataValue("dc", "description", "abstract");
+
+        if (extraAbstract != null && extraAbstract.length() > 0) {
+            theAbstract = theAbstract + "\n" + extraAbstract;
+        }
+
+        return theAbstract;
     }
 
     @Override

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
@@ -5,8 +5,10 @@ package org.datadryad.api;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
@@ -244,18 +246,22 @@ public class DryadDataFile extends DryadObject {
         }
 
         Bitstream aBitstream = null;
-        Bundle[] bundles = item.getBundles("ORIGINAL"); // anything not ORIGINAL is not a "real" bitstream
-        if (bundles.length == 0) {
-            log.error("Didn't find any original bundles for " + item.getHandle());
-            throw new IOException("data bundle for " + item.getHandle() + " not found");
-        }
-        log.debug("This object has " + bundles.length + " bundles");
-
-        for(int b = 0; b < bundles.length; b++) {
-            Bitstream[] bitstreams = bundles[b].getBitstreams();
-            for(int i = 0; i < bitstreams.length; i++) {
-                bitstreamList.add(bitstreams[i]);
+        try {
+            Bundle[] bundles = item.getBundles("ORIGINAL"); // anything not ORIGINAL is not a "real" bitstream
+            if (bundles.length == 0) {
+                log.error("Didn't find any original bundles for " + item.getHandle());
+                throw new IOException("data bundle for " + item.getHandle() + " not found");
             }
+            log.debug("This object has " + bundles.length + " bundles");
+
+            for(int b = 0; b < bundles.length; b++) {
+                Bitstream[] bitstreams = bundles[b].getBitstreams();
+                for(int i = 0; i < bitstreams.length; i++) {
+                    bitstreamList.add(bitstreams[i]);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Unable to process bitstreams of type ORIGINAL", e);
         }
 
         return bitstreamList;

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -1,4 +1,7 @@
 /*
+  The main class that provides access to Dryad Data Package objects. Each
+  DryadDataPackage contains a DSpace Item object, and adds Dryad-specific functionality
+  on top of it.
  */
 package org.datadryad.api;
 

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -15,6 +15,7 @@ import org.datadryad.api.DashService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
+import org.dspace.core.ConfigurationManager;
 
 /**
  * TransferToDash processes a data package and sends it to a DASH-based Dryad system.
@@ -39,6 +40,7 @@ public class TransferToDash extends AbstractCurationTask {
     
     private static Logger log = Logger.getLogger(TransferToDash.class);
     private static long total = 0;
+    private static int delaySecs = 0;
     private DashService dashService;
 
     
@@ -46,6 +48,13 @@ public class TransferToDash extends AbstractCurationTask {
     public void init(Curator curator, String taskId) throws IOException {
         super.init(curator, taskId);
         dashService = new DashService();
+
+        String stringDelaySecs = ConfigurationManager.getProperty("dash.submissions.delaySeconds");
+        try {
+            delaySecs = Integer.parseInt(stringDelaySecs);
+        } catch (Exception e) {
+            log.error("Unable to initialize submission delay", e);
+        }
     }
  
     
@@ -72,7 +81,7 @@ public class TransferToDash extends AbstractCurationTask {
             setResult("Last processed item = " + packageDOI);        
             report(packageDOI);
             try {
-                Thread.sleep(2000);
+                Thread.sleep(delaySecs * 1000);
             } catch (Exception e) {
                 // ignore
             }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -15,6 +15,7 @@ import org.datadryad.api.DashService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
+import org.dspace.core.Context;
 import org.dspace.core.ConfigurationManager;
 
 /**
@@ -42,18 +43,19 @@ public class TransferToDash extends AbstractCurationTask {
     private static long total = 0;
     private static int delaySecs = 0;
     private DashService dashService;
+    private Context context;
 
     
     @Override 
     public void init(Curator curator, String taskId) throws IOException {
         super.init(curator, taskId);
         dashService = new DashService();
-
         String stringDelaySecs = ConfigurationManager.getProperty("dash.submissions.delaySeconds");
         try {
             delaySecs = Integer.parseInt(stringDelaySecs);
+            context = new Context();
         } catch (Exception e) {
-            log.error("Unable to initialize submission delay", e);
+            log.error("Unable to initialize transfer", e);
         }
     }
  
@@ -75,6 +77,7 @@ public class TransferToDash extends AbstractCurationTask {
             DryadDataPackage dataPackage = new DryadDataPackage((Item)dso);
             String packageDOI = dataPackage.getIdentifier();
             dashService.putDataPackage(dataPackage);
+            dashService.postDataFileReferences(context, dataPackage);
             dashService.submitDashDataset(packageDOI);
             
             // provide output for the console

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -71,6 +71,11 @@ public class TransferToDash extends AbstractCurationTask {
             // provide output for the console
             setResult("Last processed item = " + packageDOI);        
             report(packageDOI);
+            try {
+                Thread.sleep(2000);
+            } catch (Exception e) {
+                // ignore
+            }
         } else {
             log.info("Skipping -- non-item DSpace object");
             setResult("Object skipped (not an item)");

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -64,9 +64,9 @@ public class TransferToDash extends AbstractCurationTask {
             report("packageDOI");
         } else if (dso.getType() == Constants.ITEM) {
             DryadDataPackage dataPackage = new DryadDataPackage((Item)dso);
-            dashService.putDataPackage(dataPackage);
-            
             String packageDOI = dataPackage.getIdentifier();
+            dashService.putDataPackage(dataPackage);
+            dashService.submitDashDataset(packageDOI);
             
             // provide output for the console
             setResult("Last processed item = " + packageDOI);        


### PR DESCRIPTION
Update for the Dash transfer process to include bitstreams. Also includes the code to "finalize" a submission and send it to Merritt (somehow I thought that was merged earlier). Sorry this is so long!

See 

- https://github.com/CDL-Dryad/dryad-product-roadmap/issues/57
- https://github.com/CDL-Dryad/dryad-product-roadmap/issues/58

Random notes:

- This includes a small bugfix for S3 bucket names. It ensures that if you don't specify a bucket name, the automatically-generated name will not include a period. AWS discourages you from using periods in a bucket name, but doesn't forbid it. If the bucket name includes a period, the AWS presigned URLs will generate SSL certificate errors, so don't do this!
- Handling of HTTP Response streams. The API calls have been changed to first test for the presence of an error stream, and get the normal input stream when there is no error stream. This is incredibly helpful in actually seeing the contents of an error message when it exists.

To test:
1. Ensure your maven settings file has appropriate values for the variables introduced in #1480, as well as these new variables:
    - `default.dash.submissions.finalize` = If true, the submission will be submitted for processing by Merritt. If false, all transfer will be done *except* the final submission (useful for dev servers).
    -  `default.dash.submissions.delaySeconds` = number of seconds to delay after each data package is submitted, to not overwhelm the dash server (a good default is 5)
2. Find the handle of an item you want to transfer
3. To post a new item to Dash, call the curation tool from the command line, using the handle:
`/opt/dryad/bin/dspace curate -v -t transfertodash -i 10255/dryad.135814 -r -`
4. Login to the Dash server and view the item.
