### PR TITLE
Dash stuff for journal autofill, APU

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.log4j.Logger;
-import org.datadryad.api.DryadDataFile;
+import org.datadryad.rest.models.Package;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.content.Bitstream;
@@ -163,15 +163,16 @@ public class DashService {
        existing submission (using the DOI contained in the Data Package).
 
        @return a HTTP response code
-    **/
-    public int putDataPackage(DryadDataPackage dataPackage) {
-        String dashJSON = dataPackage.getDashJSON();
+    *
+     * @param pkg*/
+    public int putDataset(Package pkg) {
+        String dashJSON = pkg.getDataPackage().getDashJSON();
         log.debug("Got JSON object: " + dashJSON);
         int responseCode = 0;
         BufferedReader reader = null;
 
         try {
-            String encodedDOI = URLEncoder.encode(dataPackage.getIdentifier(), "UTF-8");
+            String encodedDOI = URLEncoder.encode(pkg.getDataPackage().getIdentifier(), "UTF-8");
             URL url = new URL(dashServer + "/api/datasets/" + encodedDOI);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
@@ -200,7 +201,7 @@ public class DashService {
 
             if(responseCode == 200 || responseCode == 201 || responseCode == 202) {
                 log.debug("package create/update successful");
-                dataPackage.addDashTransferDate();
+                pkg.getDataPackage().addDashTransferDate();
             } else {
                 log.fatal("Unable to send item to DASH, response: " + responseCode +
                           connection.getResponseMessage());

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -329,7 +329,7 @@ public class DashService {
             if(responseCode == 200 || responseCode == 201 || responseCode == 202) {
                 log.debug("package submission successful");
             } else {
-                log.fatal("Unable to send curation activity to DASH, response: " + responseCode +
+                log.fatal("Unable to update submission status of item in DASH, response: " + responseCode +
                         connection.getResponseMessage());
             }
 

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -327,7 +327,7 @@ public class DashService {
             responseCode = connection.getResponseCode();
 
             if(responseCode == 200 || responseCode == 201 || responseCode == 202) {
-                log.debug("curation activity added");
+                log.debug("package submission successful");
             } else {
                 log.fatal("Unable to send curation activity to DASH, response: " + responseCode +
                         connection.getResponseMessage());

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -422,6 +422,10 @@ public class DryadDataPackage extends DryadObject {
         authors.add(author);
     }
 
+    public void clearAuthors() {
+        authors = new ArrayList<>();
+    }
+
     public List<DryadDataPackage> getDuplicatePackages(Context context) {
         ArrayList<DryadDataPackage> resultList = new ArrayList<>();
         try {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -276,6 +276,8 @@ public class DryadDataPackage extends DryadObject {
     public void setFormerManuscriptNumber(String manuscriptNumber) {
         if (getItem() != null) {
             addSingleMetadataValue(Boolean.TRUE, FORMER_MANUSCRIPT_NUMBER_SCHEMA, FORMER_MANUSCRIPT_NUMBER_ELEMENT, FORMER_MANUSCRIPT_NUMBER_QUALIFIER, manuscriptNumber);
+        } else {
+            dashService.addFormerManuscriptNumber(new Package(this), this.getIdentifier());
         }
     }
 
@@ -289,6 +291,8 @@ public class DryadDataPackage extends DryadObject {
     public void setMismatchedDOIs(String mismatchedDOI) {
         if (getItem() != null) {
             addSingleMetadataValue(Boolean.TRUE, MISMATCHED_DOI_SCHEMA, MISMATCHED_DOI_ELEMENT, MISMATCHED_DOI_QUALIFIER, mismatchedDOI);
+        } else {
+            dashService.addMismatchedDOI(new Package(this), this.getIdentifier());
         }
     }
 
@@ -467,7 +471,7 @@ public class DryadDataPackage extends DryadObject {
                 getItem().addMetadata("dryad.duplicateItem", null, String.valueOf(getItem().getID()), null, Choices.CF_NOVALUE);
             }
         } else {
-
+            dashService.addDuplicateItem(new Package(this), this.getIdentifier());
         }
     }
 

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -97,6 +97,7 @@ public class DryadDataPackage extends DryadObject {
     private String abstractString = "";
     private ArrayList<Author> authors = new ArrayList<>();
     private DryadJournalConcept journalConcept = null;
+    private String manuscriptNumber = "";
 
     private static Logger log = Logger.getLogger(DryadDataPackage.class);
 
@@ -189,7 +190,7 @@ public class DryadDataPackage extends DryadObject {
             result = getSingleMetadataValue(MANUSCRIPT_NUMBER_SCHEMA, MANUSCRIPT_NUMBER_ELEMENT, MANUSCRIPT_NUMBER_QUALIFIER);
             result = (result == null ? "" : result);
         } else {
-
+            result = manuscriptNumber;
         }
         return result;
     }
@@ -198,24 +199,34 @@ public class DryadDataPackage extends DryadObject {
         if (getItem() != null) {
             addSingleMetadataValue(Boolean.TRUE, MANUSCRIPT_NUMBER_SCHEMA, MANUSCRIPT_NUMBER_ELEMENT, MANUSCRIPT_NUMBER_QUALIFIER, manuscriptNumber);
         } else {
-
+            this.manuscriptNumber = manuscriptNumber;
         }
     }
 
     public List<String> getFormerManuscriptNumbers() {
-        return getMultipleMetadataValues(FORMER_MANUSCRIPT_NUMBER_SCHEMA, FORMER_MANUSCRIPT_NUMBER_ELEMENT, FORMER_MANUSCRIPT_NUMBER_QUALIFIER);
+        if (getItem() != null) {
+            return getMultipleMetadataValues(FORMER_MANUSCRIPT_NUMBER_SCHEMA, FORMER_MANUSCRIPT_NUMBER_ELEMENT, FORMER_MANUSCRIPT_NUMBER_QUALIFIER);
+        }
+        return new ArrayList<>();
     }
 
     public void setFormerManuscriptNumber(String manuscriptNumber) {
-        addSingleMetadataValue(Boolean.TRUE, FORMER_MANUSCRIPT_NUMBER_SCHEMA, FORMER_MANUSCRIPT_NUMBER_ELEMENT, FORMER_MANUSCRIPT_NUMBER_QUALIFIER, manuscriptNumber);
+        if (getItem() != null) {
+            addSingleMetadataValue(Boolean.TRUE, FORMER_MANUSCRIPT_NUMBER_SCHEMA, FORMER_MANUSCRIPT_NUMBER_ELEMENT, FORMER_MANUSCRIPT_NUMBER_QUALIFIER, manuscriptNumber);
+        }
     }
 
     public List<String> getMismatchedDOIs() {
-        return getMultipleMetadataValues(MISMATCHED_DOI_SCHEMA, MISMATCHED_DOI_ELEMENT, MISMATCHED_DOI_QUALIFIER);
+        if (getItem() != null) {
+            return getMultipleMetadataValues(MISMATCHED_DOI_SCHEMA, MISMATCHED_DOI_ELEMENT, MISMATCHED_DOI_QUALIFIER);
+        }
+        return new ArrayList<>();
     }
 
     public void setMismatchedDOIs(String mismatchedDOI) {
-        addSingleMetadataValue(Boolean.TRUE, MISMATCHED_DOI_SCHEMA, MISMATCHED_DOI_ELEMENT, MISMATCHED_DOI_QUALIFIER, mismatchedDOI);
+        if (getItem() != null) {
+            addSingleMetadataValue(Boolean.TRUE, MISMATCHED_DOI_SCHEMA, MISMATCHED_DOI_ELEMENT, MISMATCHED_DOI_QUALIFIER, mismatchedDOI);
+        }
     }
 
     public void setBlackoutUntilDate(Date blackoutUntilDate) {
@@ -304,15 +315,23 @@ public class DryadDataPackage extends DryadObject {
     }
 
     public List<String> getKeywords() {
-        return getMultipleMetadataValues(KEYWORD_SCHEMA, KEYWORD_ELEMENT, null);
+        if (getItem() != null) {
+            return getMultipleMetadataValues(KEYWORD_SCHEMA, KEYWORD_ELEMENT, null);
+        } else {
+            return new ArrayList<>();
+        }
     }
 
     public void setKeywords(List<String> keywords) {
-        addMultipleMetadataValues(Boolean.TRUE, KEYWORD_SCHEMA, KEYWORD_ELEMENT, null, keywords);
+        if (getItem() != null) {
+            addMultipleMetadataValues(Boolean.TRUE, KEYWORD_SCHEMA, KEYWORD_ELEMENT, null, keywords);
+        }
     }
 
     public void addKeywords(List<String> keywords) {
-        addMultipleMetadataValues(Boolean.FALSE, KEYWORD_SCHEMA, KEYWORD_ELEMENT, null, keywords);
+        if (getItem() != null) {
+            addMultipleMetadataValues(Boolean.FALSE, KEYWORD_SCHEMA, KEYWORD_ELEMENT, null, keywords);
+        }
     }
 
     public List<Author> getAuthors() {
@@ -769,10 +788,12 @@ public class DryadDataPackage extends DryadObject {
     }
 
     public void addDashTransferDate() {
-        Date now = new Date();
-        SimpleDateFormat sdf = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss.SSSZ");
-        String transferDate = sdf.format(now);
-        addSingleMetadataValue(Boolean.FALSE, DASH_TRANSFER_SCHEMA, DASH_TRANSFER_ELEMENT, null, transferDate);
+        if (getItem() != null) {
+            Date now = new Date();
+            SimpleDateFormat sdf = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss.SSSZ");
+            String transferDate = sdf.format(now);
+            addSingleMetadataValue(Boolean.FALSE, DASH_TRANSFER_SCHEMA, DASH_TRANSFER_ELEMENT, null, transferDate);
+        }
     }
 
     /**

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
@@ -296,6 +296,9 @@ public abstract class DryadObject {
     }
 
     public String getDryadDOI() {
-        return DOIIdentifierProvider.getDoiValue(item);
+        if (getItem() != null) {
+            return DOIIdentifierProvider.getDoiValue(item);
+        }
+        return identifier;
     }
 }

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
@@ -192,9 +192,12 @@ public abstract class DryadObject {
     }
 
     public String getTitle() {
-        String result = getSingleMetadataValue(TITLE_SCHEMA, TITLE_ELEMENT, null);
-        if (result == null) {
-            result = "Untitled";
+        String result = "";
+        if (getItem() != null) {
+            result = getSingleMetadataValue(TITLE_SCHEMA, TITLE_ELEMENT, null);
+            result = (result == null) ? "" : result;
+        } else {
+            result = title;
         }
         return result;
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
@@ -5,7 +5,6 @@ package org.datadryad.rest.models;
 import java.lang.Exception;
 import java.lang.Override;
 import java.lang.String;
-import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -124,7 +123,7 @@ public class Manuscript {
     private String manuscript_abstract = "";
     private AuthorsList authors = new AuthorsList();
     private CorrespondingAuthor correspondingAuthor = new CorrespondingAuthor();
-    private String dryadDataDOI;
+    private String dryadDataDOI = "";
     private String manuscriptId = "";
     private String status = "";
     private String title = "";
@@ -356,6 +355,14 @@ public class Manuscript {
 
     public Date getPublicationDate() {
         return publicationDate;
+    }
+
+    public String getPublicationDateAsString() {
+        if (getPublicationDate() != null) {
+            SimpleDateFormat dateIso = new SimpleDateFormat("yyyy-MM-dd");
+            return dateIso.format(getPublicationDate());
+        }
+        return "";
     }
 
     public void setPublicationDate(Date date) {

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.log4j.Logger;
 import org.datadryad.api.DryadDataPackage;
 import org.datadryad.api.DryadJournalConcept;
@@ -45,13 +44,21 @@ public class Package {
     static {
     }
 
-    public Package() {} // JAXB needs this
+    public Package() {
+        this.dataPackage = new DryadDataPackage();
+    } // JAXB needs this
 
     public Package(DryadDataPackage dataPackage) {
         this.dataPackage = dataPackage;
         if (this.dataPackage.getItem() != null) {
             this.itemID = dataPackage.getItem().getID();
+        } else {
+            this.itemID = 0;
         }
+    }
+
+    public DryadDataPackage getDataPackage() {
+        return dataPackage;
     }
 
     public Integer getItemID() {
@@ -66,8 +73,23 @@ public class Package {
         return publicationDOI;
     }
 
+    public void setPublicationDOI(String doi) {
+        dataPackage.setPublicationDOI(doi);
+    }
+
     public String getPublicationDate() {
         return sdf.format(dataPackage.getDateAccessioned());
+    }
+
+    public void setPublicationDate(String date) {
+        dataPackage.setPublicationDate(date);
+    }
+
+    public void setAuthors(List<Author> authorList) {
+        dataPackage.clearAuthors();
+        for (Author author : authorList) {
+            dataPackage.addAuthor(author);
+        }
     }
 
     public AuthorsList getAuthors() {
@@ -89,8 +111,24 @@ public class Package {
         return dataPackage.getKeywords();
     }
 
+    public void setKeywords(List<String> keywords) {
+        dataPackage.setKeywords(keywords);
+    }
+
     public String getDryadDOI() {
         return dataPackage.getDryadDOI();
+    }
+
+    public void setDryadDOI(String doi) {
+        dataPackage.setIdentifier(doi);
+    }
+
+    public String getManuscriptNumber() {
+        return dataPackage.getManuscriptNumber();
+    }
+
+    public void setManuscriptNumber(String msID) {
+        dataPackage.setManuscriptNumber(msID);
     }
 
     @JsonIgnore
@@ -102,9 +140,17 @@ public class Package {
         return dataPackage.getTitle();
     }
 
+    public void setTitle(String title) {
+        dataPackage.setTitle(title);
+    }
+
     @JsonIgnore
     public String getAbstract() {
         return dataPackage.getAbstract();
+    }
+
+    public void setAbstract(String theAbstract) {
+        dataPackage.setAbstract(theAbstract);
     }
 
     @Override

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
@@ -144,7 +144,6 @@ public class Package {
         dataPackage.setTitle(title);
     }
 
-    @JsonIgnore
     public String getAbstract() {
         return dataPackage.getAbstract();
     }

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import org.apache.log4j.Logger;
 import org.datadryad.api.DryadDataPackage;
 import org.datadryad.api.DashService;
+import org.datadryad.rest.models.Package;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
@@ -76,7 +77,7 @@ public class TransferToDash extends AbstractCurationTask {
         } else if (dso.getType() == Constants.ITEM) {
             DryadDataPackage dataPackage = new DryadDataPackage((Item)dso);
             String packageDOI = dataPackage.getIdentifier();
-            dashService.putDataPackage(dataPackage);
+            dashService.putDataset(new Package(dataPackage));
             dashService.postDataFileReferences(context, dataPackage);
             dashService.submitDashDataset(packageDOI);
             


### PR DESCRIPTION
EDIT: I think this works for APU now. ~~This is still in progress for APU, but it works for starting a new dataset based on journal-submitted metadata.~~

To test, send a json body with manuscript number and Dryad DOI (because Dash will have already chosen the identifier) like so: `{"manuscriptNumber":"APPS-D-17-00113", "dryadDOI":"doi:10.5072/xxx"}` and PUT it to the url endpoint for the journal: `PUT /api/v1/journals/2168-0450/packages` (use a valid access token for Dryad Classic in the query string).

The result should be a new dataset in the authorized Dash dashboard with the manuscript metadata and internal data for the publicationISSN and manuscriptNumber. You can see those two internal data items by inspecting the database directly; I don't think you can see it in the GUI.