### PR TITLE
Don't look for manuscript matches if the field is empty

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -285,12 +285,17 @@ public class DryadDataPackage extends DryadObject {
         if (getItem() != null) {
             String theAbstract = getSingleMetadataValue("dc", "description", null);
             String extraAbstract = getSingleMetadataValue("dc", "description", "abstract");
-
+            if (theAbstract == null) {
+                theAbstract = "";
+            }
             if (extraAbstract != null && extraAbstract.length() > 0) {
                 theAbstract = theAbstract + "\n" + extraAbstract;
             }
             return theAbstract;
         } else {
+            if (abstractString == null) {
+                abstractString = "";
+            }
             return abstractString;
         }
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -30,6 +30,7 @@ import org.dspace.content.authority.Choices;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.identifier.DOIIdentifierProvider;
 import org.dspace.identifier.IdentifierException;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
@@ -111,6 +112,8 @@ public class DryadDataPackage extends DryadObject {
 
     public DryadDataPackage(Item item) {
         super(item);
+        log.error("making a package from item " + item.getID());
+        log.error("its identifier is " + DOIIdentifierProvider.getDoiValue(item));
         String pubName = getSingleMetadataValue(PUBLICATION_NAME_SCHEMA, PUBLICATION_NAME_ELEMENT, PUBLICATION_NAME_QUALIFIER);
         if (pubName != null && !pubName.equals("")) {
             journalConcept = JournalUtils.getJournalConceptByJournalName(pubName);
@@ -367,6 +370,8 @@ public class DryadDataPackage extends DryadObject {
         try {
             // get the current duplicate packages
             resultList.addAll(getDuplicatePackages(context));
+            log.error("this package is item " + this.getItem().getID());
+            log.error("this package is identifier " + this.getIdentifier());
             List<DryadDataPackage> matchingPackages = findAllByManuscript(context, new Manuscript(this));
             for (DryadDataPackage dryadDataPackage : matchingPackages) {
                 if (!dryadDataPackage.getIdentifier().equals(this.getIdentifier())) {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -113,7 +113,7 @@ public class DryadDataPackage extends DryadObject {
         super(item);
         String pubName = getSingleMetadataValue(PUBLICATION_NAME_SCHEMA, PUBLICATION_NAME_ELEMENT, PUBLICATION_NAME_QUALIFIER);
         if (pubName != null && !pubName.equals("")) {
-            journalConcept = JournalUtils.getJournalConceptByJournalName(getPublicationName());
+            journalConcept = JournalUtils.getJournalConceptByJournalName(pubName);
         }
     }
 

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -489,11 +489,11 @@ public class DryadDataPackage extends DryadObject {
         // update the data package's metadata:
         if (useDryadClassic) {
             getItem().clearMetadata("dryad.duplicateItem");
-            for (DryadDataPackage dryadDataPackage : resultSet) {
+            for (DryadDataPackage dryadDataPackage : resultList) {
                 getItem().addMetadata("dryad.duplicateItem", null, String.valueOf(dryadDataPackage.getItem().getID()), null, Choices.CF_NOVALUE);
             }
         } else {
-            duplicateItems.addAll(resultSet);
+            duplicateItems.addAll(resultList);
         }
     }
 

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -491,6 +491,8 @@ public class DryadDataPackage extends DryadObject {
             getItem().clearMetadata("dryad.duplicateItem");
             for (DryadDataPackage dryadDataPackage : resultList) {
                 getItem().addMetadata("dryad.duplicateItem", null, String.valueOf(dryadDataPackage.getItem().getID()), null, Choices.CF_NOVALUE);
+                // this is a temporary log to see when this is happening
+                log.error("adding duplicate " + dryadDataPackage.getItem().getID() + " to package " + getItem().getID());
             }
         } else {
             duplicateItems.addAll(resultList);

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -367,7 +367,13 @@ public class DryadDataPackage extends DryadObject {
         try {
             // get the current duplicate packages
             resultList.addAll(getDuplicatePackages(context));
-            resultList.addAll(findAllByManuscript(context, new Manuscript(this)));
+            List<DryadDataPackage> matchingPackages = findAllByManuscript(context, new Manuscript(this));
+            for (DryadDataPackage dryadDataPackage : matchingPackages) {
+                if (!dryadDataPackage.getIdentifier().equals(this.getIdentifier())) {
+                    resultList.add(dryadDataPackage);
+                    log.error("adding package " + dryadDataPackage.getIdentifier());
+                }
+            }
             // look for items that have the same journal + title + authors?
 
         } catch (Exception e) {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -367,7 +367,12 @@ public class DryadDataPackage extends DryadObject {
         try {
             // get the current duplicate packages
             resultList.addAll(getDuplicatePackages(context));
-            resultList.addAll(findAllByManuscript(context, new Manuscript(this)));
+            List<DryadDataPackage> matchingPackages = findAllByManuscript(context, new Manuscript(this));
+            for (DryadDataPackage dryadDataPackage : matchingPackages) {
+                if (!dryadDataPackage.getIdentifier().equals(this.getIdentifier())) {
+                    resultList.add(dryadDataPackage);
+                }
+            }
             // look for items that have the same journal + title + authors?
 
         } catch (Exception e) {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -743,21 +743,29 @@ public class DryadDataPackage extends DryadObject {
         if (useDryadClassic) {
             try {
                 // find all with same Dryad DOI
-                ItemIterator itemIterator = Item.findByMetadataField(context, "dc", "identifier", null, manuscript.getDryadDataDOI(), false);
-                while (itemIterator.hasNext()) {
-                    dataPackageList.add(new DryadDataPackage(itemIterator.next()));
+                if (!"".equals(manuscript.getDryadDataDOI())) {
+                    ItemIterator itemIterator = Item.findByMetadataField(context, "dc", "identifier", null, manuscript.getDryadDataDOI(), false);
+                    while (itemIterator.hasNext()) {
+                        dataPackageList.add(new DryadDataPackage(itemIterator.next()));
+                    }
                 }
+
                 // find all with same publication DOI
-                itemIterator = Item.findByMetadataField(context, "dc", "relation", "isreferencedby", manuscript.getPublicationDOI(), false);
-                while (itemIterator.hasNext()) {
-                    dataPackageList.add(new DryadDataPackage(itemIterator.next()));
+                if (!"".equals(manuscript.getPublicationDOI())) {
+                    ItemIterator itemIterator = Item.findByMetadataField(context, "dc", "relation", "isreferencedby", manuscript.getPublicationDOI(), false);
+                    while (itemIterator.hasNext()) {
+                        dataPackageList.add(new DryadDataPackage(itemIterator.next()));
+                    }
                 }
+
                 // find all with same manuscript ID (in the same journal)
-                itemIterator = Item.findByMetadataField(context, MANUSCRIPT_NUMBER_SCHEMA, MANUSCRIPT_NUMBER_ELEMENT, MANUSCRIPT_NUMBER_QUALIFIER, manuscript.getManuscriptId(), false);
-                while (itemIterator.hasNext()) {
-                    DryadDataPackage dataPackage = new DryadDataPackage(itemIterator.next());
-                    if (dataPackage.getPublicationName().equals(manuscript.getJournalName()))
-                        dataPackageList.add(dataPackage);
+                if (!"".equals(manuscript.getManuscriptId())) {
+                    ItemIterator itemIterator = Item.findByMetadataField(context, MANUSCRIPT_NUMBER_SCHEMA, MANUSCRIPT_NUMBER_ELEMENT, MANUSCRIPT_NUMBER_QUALIFIER, manuscript.getManuscriptId(), false);
+                    while (itemIterator.hasNext()) {
+                        DryadDataPackage dataPackage = new DryadDataPackage(itemIterator.next());
+                        if (dataPackage.getPublicationName().equals(manuscript.getJournalName()))
+                            dataPackageList.add(dataPackage);
+                    }
                 }
             } catch (Exception ex) {
                 log.error("Exception getting data package from publication DOI", ex);

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
@@ -170,7 +170,11 @@ public abstract class DryadObject {
 
     public String getIdentifier() {
         if (getItem() != null) {
-            return DOIIdentifierProvider.getDoiValue(getItem());
+            String id = DOIIdentifierProvider.getDoiValue(getItem());
+            if (id == null) {
+                id = Integer.valueOf(getItem().getID()).toString();
+            }
+            return id;
         }
         return identifier;
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
@@ -245,7 +245,7 @@ public class Manuscript {
     }
 
     public Manuscript(DryadDataPackage dryadDataPackage) {
-        journalConcept = JournalUtils.getJournalConceptByJournalName(dryadDataPackage.getPublicationName());
+        journalConcept = dryadDataPackage.getJournalConcept();
         setManuscriptId(dryadDataPackage.getManuscriptNumber());
         setPublicationDOI(dryadDataPackage.getPublicationDOI());
         String title = dryadDataPackage.getTitle().replaceAll("Data from: ", "");

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Manuscript.java
@@ -305,6 +305,9 @@ public class Manuscript {
     }
 
     public String getAbstract() {
+        if (manuscript_abstract == null) {
+            manuscript_abstract = "";
+        }
         return manuscript_abstract;
     }
 


### PR DESCRIPTION
This fixes https://trello.com/c/TFmDxd3u/675-bug-new-submissions-incorrectly-marked-as-duplicates. I’ve already deployed this on prod (as a similarly-named branch), so if we redeploy dryad-master before this gets merged, it’ll go away.