### PR TITLE
Dash transfer -- Improve README filenames

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -228,12 +228,18 @@ public class DashService {
         try {
             log.debug("number of files: " + dataPackage.getDataFiles(context).size());
             for(DryadDataFile dryadFile : dataPackage.getDataFiles(context)) {
-                String fileName = dryadFile.getTitle();
+                String fileTitle = dryadFile.getTitle();
                 String fileDescription = dryadFile.getDescription();
+                String previousBitstreamFilename = "";
                 for(Bitstream dspaceBitstream : dryadFile.getAllBitstreams()) {
                     log.debug("transferring bitstream " + dspaceBitstream.getName());
                     DryadBitstream dryadBitstream = new DryadBitstream(dspaceBitstream);
                     dryadBitstream.setFileDescription(fileDescription);
+                    if(dryadBitstream.isReadme()) {
+                        dryadBitstream.setReadmeFilename(previousBitstreamFilename);
+                    } else {
+                        previousBitstreamFilename = dspaceBitstream.getName();                        
+                    }
                     String dashJSON = dryadBitstream.getDashReferenceJSON();
                     log.debug("Got JSON object: " + dashJSON);
                     String encodedPackageDOI = URLEncoder.encode(dataPackage.getIdentifier(), "UTF-8");

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
@@ -240,11 +240,6 @@ public class DryadDataFile extends DryadObject {
         List<Bitstream> bitstreamList = new ArrayList<Bitstream>();
         Item item = getItem();
                 
-        Bitstream readme = getREADME();
-        if(readme != null) {
-            bitstreamList.add(readme);
-        }
-
         Bitstream aBitstream = null;
         try {
             Bundle[] bundles = item.getBundles("ORIGINAL"); // anything not ORIGINAL is not a "real" bitstream
@@ -256,8 +251,17 @@ public class DryadDataFile extends DryadObject {
 
             for(int b = 0; b < bundles.length; b++) {
                 Bitstream[] bitstreams = bundles[b].getBitstreams();
+                Bitstream readmeBitstream = null;
                 for(int i = 0; i < bitstreams.length; i++) {
-                    bitstreamList.add(bitstreams[i]);
+                    if(bitstreams[i].getName().toLowerCase().startsWith("readme")) {
+                        readmeBitstream = bitstreams[i];
+                    } else {
+                        bitstreamList.add(bitstreams[i]);
+                    }
+                }
+                // always add the readme at the end of the list of bitstreams
+                if(readmeBitstream != null) {
+                    bitstreamList.add(readmeBitstream);
                 }
             }
         } catch (Exception e) {

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataPackage.java
@@ -94,7 +94,7 @@ public class DryadDataPackage extends DryadObject {
     private final static String PROVENANCE = "dc.description.provenance";
 
     // title and identifier are declared in DryadObject
-    private Set<DryadDataFile> dataFiles;
+    private List<DryadDataFile> dataFiles;
     private String curationStatus = "";
     private String curationStatusReason = "";
     private String abstractString = "";
@@ -777,9 +777,9 @@ public class DryadDataPackage extends DryadObject {
         return packageSet;
     }
 
-    static Set<DryadDataFile> getFilesInPackage(Context context, DryadDataPackage dataPackage) throws SQLException {
+    static List<DryadDataFile> getFilesInPackage(Context context, DryadDataPackage dataPackage) throws SQLException {
         // files and packages are linked by DOI
-        Set<DryadDataFile> fileSet = new HashSet<DryadDataFile>();
+        List<DryadDataFile> fileList = new ArrayList<DryadDataFile>();
         String packageIdentifier = dataPackage.getIdentifier();
         if(packageIdentifier == null || packageIdentifier.length() == 0) {
             throw new IllegalArgumentException("Data package must have an identifier");
@@ -787,17 +787,17 @@ public class DryadDataPackage extends DryadObject {
         try {
             ItemIterator dataFiles = Item.findByMetadataField(context, RELATION_SCHEMA, RELATION_ELEMENT, RELATION_ISPARTOF_QUALIFIER, packageIdentifier);
             while(dataFiles.hasNext()) {
-                fileSet.add(new DryadDataFile(dataFiles.next()));
+                fileList.add(new DryadDataFile(dataFiles.next()));
             }
         } catch (AuthorizeException ex) {
             log.error("Authorize exception getting files for data package", ex);
         } catch (IOException ex) {
             log.error("IO exception getting files for data package", ex);
         }
-        return fileSet;
+        return fileList;
     }
 
-    public Set<DryadDataFile> getDataFiles(Context context) throws SQLException {
+    public List<DryadDataFile> getDataFiles(Context context) throws SQLException {
         if(dataFiles == null) {
             // how are data files and packages linked? By DOI
             dataFiles = DryadDataPackage.getFilesInPackage(context, this);

--- a/dspace/modules/api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace/modules/api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -306,7 +306,7 @@ public class DOIIdentifierProvider extends IdentifierProvider implements org.spr
             }
             if (getCollection(context, item).equals(myDataPkgColl)) {
                 DryadDataPackage dryadDataPackage = new DryadDataPackage(item);
-                Set<DryadDataFile> dryadDataFiles = dryadDataPackage.getDataFiles(context);
+                List<DryadDataFile> dryadDataFiles = dryadDataPackage.getDataFiles(context);
                 for (DryadDataFile dryadDataFile : dryadDataFiles) {
                     mintDOIAtVersion(context, dryadDataFile.getDryadDOI(), dryadDataFile.getItem(), 1);
                 }

--- a/dspace/modules/api/src/test/java/org/datadryad/api/DryadDataPackageTest.java
+++ b/dspace/modules/api/src/test/java/org/datadryad/api/DryadDataPackageTest.java
@@ -2,6 +2,7 @@
  */
 package org.datadryad.api;
 
+import java.util.List;
 import java.util.Set;
 import org.apache.log4j.Logger;
 import org.datadryad.test.ContextUnitTest;
@@ -141,7 +142,7 @@ public class DryadDataPackageTest extends ContextUnitTest {
         DryadDataFile dataFile3 = DryadDataFile.create(context, dataPackage2);
         dataPackage1.addDataFile(context, dataFile1);
         dataPackage1.addDataFile(context, dataFile2);
-        Set result = DryadDataPackage.getFilesInPackage(context, dataPackage1);
+        List result = DryadDataPackage.getFilesInPackage(context, dataPackage1);
         assertTrue(result.contains(dataFile1));
         assertTrue(result.contains(dataFile2));
         assertFalse(result.contains(dataFile3));


### PR DESCRIPTION
Since README bitstreams are no longer grouped with the bitstreams they describe, this PR changes the filenames as they are being sent to DASH to be more descriptive, such as README_for_SomeGreatFile.txt

Also changes DryadDataPackage to return the package's files in a List rather than a Set, to ensure they stay ordered properly.