### PR TITLE
If a file can't be found in the file statuses, assume it's a retained file.

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
@@ -1523,7 +1523,11 @@ public class FlowUtils {
 			DCValue[] fileStatusMDVs = publication.getMetadata("workflow.review.fileStatus");
 			publication.clearMetadata("workflow.review.fileStatus");
 			for (DCValue fileStatusMDV : fileStatusMDVs) {
-				fileStatusMDV.confidence = filestatuses.get(fileStatusMDV.value);
+				int conf = Choices.CF_ACCEPTED;
+				if (filestatuses.containsKey(fileStatusMDV.value)) {
+					conf = filestatuses.get(fileStatusMDV.value);
+				}
+				fileStatusMDV.confidence = conf;
 				publication.addMetadata(fileStatusMDV);
 			}
 			publication.update();


### PR DESCRIPTION
Fixes https://trello.com/c/gJqUiqtW/677-bug-if-a-file-is-in-a-weird-non-workflow-state-file-statuses-for-review-items-dont-work