### PR TITLE
Submission logout -- Remove requirement that each page request uses the same IP

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
@@ -248,7 +248,7 @@ public class AuthenticationUtil
             if (id != null)
             {
                 String address = (String)session.getAttribute(CURRENT_IP_ADDRESS);
-                if (address != null && address.equals(request.getRemoteAddr()))
+                if (address != null)
                 {
                     EPerson eperson = EPerson.find(context, id);
                     context.setCurrentUser(eperson);


### PR DESCRIPTION
Fix for https://trello.com/c/kfYV90fX

Some networks will assign different IP addresses to a machine throughout a session,
so we cannot assume that all requests will come from the same IP.

To test: 
1. Login to the server and start a submission. 
2. At some point during the submission, pause and change the IP address of your machine. This can be done easily by switching to another wifi network (such as a phone hotspot).
3. When you load the next page of the submission system (without this pull request in place) you will get a "Page Not Found" error. When this pull request is in place, the submission should continue as normal despite a changing IP.