### PR TITLE
updateToDash both puts and adds metadata

### DIFF
--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -78,8 +78,7 @@ public class TransferToDash extends AbstractCurationTask {
             DryadDataPackage dataPackage = new DryadDataPackage((Item)dso);
             Package pkg = new Package(dataPackage);
             String packageDOI = dataPackage.getIdentifier();
-            dashService.putDataset(pkg);
-            dashService.migrateProvenances(pkg);
+            pkg.getDataPackage().updateToDash();
             dashService.postDataFileReferences(context, dataPackage);
             dashService.submitDashDataset(packageDOI);
             


### PR DESCRIPTION
I don't know how this slipped through, but the method updateToDash wraps the putDataset functionality and updates the metadata that are stored as internal data in Dash.

To test, migrate any old archived item and see that the journal name is now present when you edit the dataset on the new system and internal data are visible in the admin activity log.