### PR TITLE
Ensure that the "real" identifier string is selected

### DIFF
--- a/dspace/config/crosswalks/DIM2DATACITE.xsl
+++ b/dspace/config/crosswalks/DIM2DATACITE.xsl
@@ -14,7 +14,7 @@
 	
 	<!-- Find the DOI information. -->
 	<xsl:template name="get_identifier">
-		<xsl:value-of select="dspace:field[@element ='identifier'][@mdschema='dc']"/>
+	  <xsl:value-of select="dspace:field[@element='identifier' and not(@qualifier)]" />
 	</xsl:template>
 
 	<!-- Main match for the root node: set up the root element, <resource> -->


### PR DESCRIPTION
For some sequences of actions, items contain a large number of dc.identifier.url elements. In these cases, sometimes the DataCite crosswalk grabs one of the dc.identifier.url elements instead of the plain dc.identifier, resulting in DataCite metadata that does not contain a DOI, and is rejected.

This ensures that only the main identifier string matches, and a valid DOI is used in the crosswalk.