### PR TITLE
Dash transfer -- versioning

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -179,7 +179,8 @@ public class DashService {
         BufferedReader reader = null;
 
         try {
-            String encodedDOI = URLEncoder.encode(pkg.getDataPackage().getIdentifier(), "UTF-8");
+            String versionlessDOI = pkg.getDataPackage().getVersionlessIdentifier();
+            String encodedDOI = URLEncoder.encode(versionlessDOI, "UTF-8");
             URL url = new URL(dashServer + "/api/datasets/" + encodedDOI);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
@@ -270,8 +271,8 @@ public class DashService {
         if (ddp.getDuplicatePackages(null).size() > 0) {
             List<String> prevDuplicates = getDuplicateItems(pkg);
             for (DryadDataPackage dup : ddp.getDuplicatePackages(null)) {
-                if (!prevDuplicates.contains(dup.getIdentifier())) {
-                    addDuplicateItem(pkg, dup.getIdentifier());
+                if (!prevDuplicates.contains(dup.getVersionlessIdentifier())) {
+                    addDuplicateItem(pkg, dup.getVersionlessIdentifier());
                 }
             }
         }
@@ -305,7 +306,7 @@ public class DashService {
                     }
                     String dashJSON = dryadBitstream.getDashReferenceJSON();
                     log.debug("Got JSON object: " + dashJSON);
-                    String encodedPackageDOI = URLEncoder.encode(dataPackage.getIdentifier(), "UTF-8");
+                    String encodedPackageDOI = URLEncoder.encode(dataPackage.getVersionlessIdentifier(), "UTF-8");
                     URL url = new URL(dashServer + "/api/datasets/" + encodedPackageDOI + "/urls");
                     HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                     connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
@@ -351,6 +352,44 @@ public class DashService {
         return responseCode;
     }
 
+    /**
+       Delete the data files in a dataset. Assumes that the dataset is in_progress.
+    **/
+    public void deleteDataFiles(Package pkg) {
+
+        // get file list
+        JsonNode fileJson = getFiles(pkg);
+        
+        // for each file, call a delete
+        for(int i = 0; i < fileJson.size(); i++) {
+            try {
+                String fileID = fileJson.get(i).get("_links").get("self").get("href").textValue();
+                URL url = new URL(dashServer + fileID);
+                log.info("deleting " + url);
+                HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+                connection.setRequestProperty("Accept", "application/json");
+                connection.setRequestProperty("Authorization", "Bearer " + oauthToken);
+                connection.setRequestMethod("DELETE");
+                
+                InputStream stream = connection.getErrorStream();
+                if (stream == null) {
+                    stream = connection.getInputStream();
+                }
+                BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+                String line = null;
+                StringWriter out = new StringWriter(connection.getContentLength() > 0 ? connection.getContentLength() : 2048);
+                while ((line = reader.readLine()) != null) {
+                    out.append(line);
+                }
+                String response = out.toString();
+                log.info("result object " + response);
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to delete file from Dash", e);
+            }
+        }
+    }
+    
     public void migrateProvenances(Package pkg) {
         log.debug("migrating provenances");
         // get curationActivities from Dash package
@@ -460,7 +499,7 @@ public class DashService {
         try {
             String dashJSON = mapper.writeValueAsString(node);
             log.debug("curation activity json is " + dashJSON);
-            String encodedDOI = URLEncoder.encode(dataPackage.getIdentifier(), "UTF-8");
+            String encodedDOI = URLEncoder.encode(dataPackage.getVersionlessIdentifier(), "UTF-8");
             URL url = new URL(dashServer + "/api/datasets/" + encodedDOI + "/curation_activity");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
@@ -502,9 +541,53 @@ public class DashService {
         return responseCode;
     }
 
+    public String getVersionID(Package pkg) {
+        String result = null;
+        
+        try {
+            String packageDOI = pkg.getDataPackage().getVersionlessIdentifier();
+            String jsonString = getDashJSON(packageDOI);
+            JsonNode rootNode = mapper.readTree(jsonString);
+            result = rootNode.get("_links").get("stash:version").get("href").textValue();
+        } catch (Exception e) {
+            log.fatal("Unable to retrieve versionID for package", e);
+        }
+
+        return result;
+    }
+    
+    public JsonNode getFiles(Package pkg) {
+        String dashVersionID = getVersionID(pkg);
+        log.debug("getting files for version " + dashVersionID);
+        try {
+            URL url = new URL(dashServer + dashVersionID + "/files");
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("Authorization", "Bearer " + oauthToken);
+            connection.setRequestMethod("GET");
+
+            InputStream stream = connection.getErrorStream();
+            if (stream == null) {
+                stream = connection.getInputStream();
+            }
+            BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+            String line = null;
+            StringWriter out = new StringWriter(connection.getContentLength() > 0 ? connection.getContentLength() : 2048);
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+            }
+            JsonNode rootNode = mapper.readTree(out.toString());
+            return rootNode.get("_embedded").get("stash:files");
+        } catch (Exception e) {
+            log.fatal("Unable to get file list from Dash", e);
+        }
+        return null;
+    }
+
     public JsonNode getCurationActivity(Package pkg) {
         try {
-            String encodedDOI = URLEncoder.encode(pkg.getDataPackage().getIdentifier(), "UTF-8");
+            String encodedDOI = URLEncoder.encode(pkg.getDataPackage().getVersionlessIdentifier(), "UTF-8");
             URL url = new URL(dashServer + "/api/datasets/" + encodedDOI + "/curation_activity");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
@@ -573,7 +656,7 @@ public class DashService {
         BufferedReader reader = null;
 
         try {
-            String encodedDOI = URLEncoder.encode(pkg.getDataPackage().getIdentifier(), "UTF-8");
+            String encodedDOI = URLEncoder.encode(pkg.getDataPackage().getVersionlessIdentifier(), "UTF-8");
             URL url = new URL(dashServer + "/api/datasets/" + encodedDOI + "/internal_data");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadObject.java
@@ -179,6 +179,26 @@ public abstract class DryadObject {
         return identifier;
     }
 
+    /**
+       Return the identifier of this item. If the identifier is a DOI, detect
+       and remove any version string. For example, for the identifier
+       doi:10.5061/dryad.abc123.4, return the string doi:10.5061/dryad.abc123
+    **/
+    public String getVersionlessIdentifier() {
+        String fullID = getIdentifier();
+
+        if(fullID.contains("dryad.")) {
+            String dryadPart = fullID.substring(fullID.indexOf("dryad."));
+            String afterDot = dryadPart.substring(dryadPart.indexOf(".") + 1);
+            
+            if(afterDot.contains(".")) {
+                fullID = fullID.substring(0, fullID.lastIndexOf("."));
+            }
+        }
+        
+        return fullID;
+    }
+
     public void setIdentifier(String newIdentifier) {
         identifier = newIdentifier;
     }

--- a/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/rest/models/Package.java
@@ -191,12 +191,14 @@ public class Package {
     public static class SchemaDotOrgSerializer extends JsonSerializer<Package> {
         @Override
         public void serialize(Package dataPackage, JsonGenerator jGen, SerializerProvider provider) throws IOException {
+            String packageDOI = dataPackage.getDryadDOI();
+            
             jGen.writeStartObject();
             jGen.writeStringField("@context", "http://schema.org/");
             jGen.writeStringField("@type", "Dataset");
-            jGen.writeStringField("@id", DOIIdentifierProvider.getFullDOIURL(dataPackage.getDryadDOI()));
-            jGen.writeStringField("url", DOIIdentifierProvider.getFullDOIURL(dataPackage.getDryadDOI()));
-            jGen.writeStringField("identifier", dataPackage.getDryadDOI());
+            jGen.writeStringField("@id", DOIIdentifierProvider.getFullDOIURL(packageDOI));
+            jGen.writeStringField("url", DOIIdentifierProvider.getFullDOIURL(packageDOI));
+            jGen.writeStringField("identifier", packageDOI);
             jGen.writeStringField("name", dataPackage.getTitle());
             jGen.writeObjectField("author", dataPackage.getAuthorList());
             jGen.writeStringField("datePublished", dataPackage.getPublicationDate());
@@ -233,7 +235,7 @@ public class Package {
             
             jGen.writeStartObject();
 
-            jGen.writeStringField("identifier", dataPackage.getDryadDOI());
+            jGen.writeStringField("identifier", ddp.getVersionlessIdentifier());
             jGen.writeStringField("title", dataPackage.getTitle());
             jGen.writeStringField("abstract", dataPackage.getAbstract());
             jGen.writeObjectField("authors", dataPackage.getAuthorList());


### PR DESCRIPTION
When migrating items to Dash, allow versions to be maintained.
- The Dryad DOI has a version number. When sending content to Dash, remove the version number so all updates affect the same dataset.
- Each version of an item in Dryad may have a different set of files. When transferring the files, first delete any files from the latest Dash version (which is *in_progress*), then transfer URL references to all of the files that exist in the latest Dryad version. Merritt will have to re-download any files that are preserved across versions, but this is cleaner than comparing each file individually.