### PR TITLE
send package-level embargo settings

### DIFF
--- a/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DashService.java
@@ -21,6 +21,9 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -28,6 +31,7 @@ import java.util.regex.Pattern;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang.time.DateUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.log4j.Logger;
 import org.datadryad.rest.models.Package;
@@ -44,6 +48,7 @@ public class DashService {
     private String dashServer = "";
     private String oauthToken = "";
     private ObjectMapper mapper = null;
+    private String lastCurationStatus = "";
 
     public DashService() {
         // init oauth connection with DASH
@@ -270,7 +275,71 @@ public class DashService {
         return responseCode;
     }
 
+    /**
+       Set this package to have the appropriate embargo status in Dash. Assumes that the package has
+       already transferred curation statuses to Dash, so the CurationStatusForDash has a meaningful value.
+     **/
+    public void setEmbargoStatus(Package pkg) {
+        log.debug("setting embargo status for this package");
+        SimpleDateFormat sdf = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss.SSSZ");
+        DryadDataPackage ddp = pkg.getDataPackage();
+        String curationStatus = ddp.getCurationStatusForDash();
+        log.debug("-- curationStatus " + curationStatus);
+        
+        // get target embargo settings
+        String embargoType = ddp.getPackageEmbargoType();
+        Date embargoDate = ddp.getPackageEmbargoDate();
+        log.debug("-- embargoType " + embargoType);
+        log.debug("-- embargoDate " + embargoDate);
 
+        if(curationStatus.equals("published") || curationStatus.equals("embargoed")) {
+            // if it's published or embargoed, and a file is still under embargo, set the
+            // status to embargoed
+            if (embargoType.equals("custom")) {
+                addCurationActivity(ddp, "embargoed",
+                                    "Setting package-level embargo to reflect file-level embargo. Type=" + embargoType + ", PublicationDate=" +sdf.format(embargoDate), 
+                                    getNowString(),
+                                    "migration");
+            } else if (embargoType.equals("oneyear") || embargoType.equals("one year")) {
+                // set to the target date, or if no date, 2 years after today
+                if(embargoDate == null) {
+                    embargoDate = DateUtils.addYears(new Date(), 2);
+                }
+                addCurationActivity(ddp, "embargoed",
+                                    "Setting package-level embargo to reflect file-level embargo. Type=" + embargoType + ", PublicationDate=" +sdf.format(embargoDate), 
+                                    getNowString(),
+                                    "migration");
+            } else if (embargoType.equals("untilArticleAppears")) {
+                // set to the date, or if no date, 1 year after today
+                if(embargoDate == null) {
+                    embargoDate = DateUtils.addYears(new Date(), 1);
+                }
+                addCurationActivity(ddp, "embargoed", 
+                                    "Setting package-level embargo to reflect file-level embargo. Type=" + embargoType + ", PublicationDate=" +sdf.format(embargoDate), 
+                                    getNowString(),
+                                    "migration");
+            } else {
+                // no embargo, do nothing
+            }                            
+        } else {
+            // it's in curation and a file has embargo, we can't set the
+            // status to embargoed yet -- how will the curators know? just
+            // make a note that curators can notice.
+            if (embargoType != null && !embargoType.equals("none")) {
+                addCurationActivity(ddp, "",
+                                    "User has requested embargo. Type=" + embargoType + ", PublicationDate=" +sdf.format(embargoDate), 
+                                    getNowString(),
+                                    "migration");
+            } 
+        }
+    }
+
+    private String getNowString() {
+        Date now = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss.SSSZ");
+        return sdf.format(now);
+    }
+    
     /**
        Update the internal metadata in the Dash dataset for a given Package
     **/
@@ -442,7 +511,8 @@ public class DashService {
         log.debug("migrating provenances");
         // get curationActivities from Dash package
         JsonNode curationActivities = getCurationActivity(pkg);
-        // if the only curation activity is the default "in_progress," delete it
+        // if the only curation activity is the default "in_progress," delete it,
+        // but not if the package is in user workspace!
         if (curationActivities != null && curationActivities.size() == 1) {
             if (curationActivities.get(0).get("status").textValue().equals("In Progress")) {
                 int unsubmittedID = curationActivities.get(0).get("id").intValue();
@@ -530,10 +600,14 @@ public class DashService {
         return responseCode;
     }
 
-    public int addCurationActivity(DryadDataPackage dataPackage, String status, String reason, String processKeyword) {
+    public int addCurationActivity(DryadDataPackage dataPackage, String status, String reason, String createdAt, String processKeyword) {
         ObjectNode node = mapper.createObjectNode();
+        lastCurationStatus = status;
         node.put("status", status);
         node.put("note", reason);
+        if(createdAt != null) {
+            node.put("created_at", createdAt);
+        }
         if(processKeyword != null) {
             node.put("keywords", processKeyword);
         }
@@ -545,6 +619,7 @@ public class DashService {
 
         log.debug("starting addCurationActivity");
         try {
+            lastCurationStatus = node.get("status").textValue();
             String dashJSON = mapper.writeValueAsString(node);
             log.debug("curation activity json is " + dashJSON);
             String encodedDOI = URLEncoder.encode(dataPackage.getVersionlessIdentifier(), "UTF-8");

--- a/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
+++ b/dspace/modules/api/src/main/java/org/datadryad/api/DryadDataFile.java
@@ -175,6 +175,14 @@ public class DryadDataFile extends DryadObject {
         return isEmbargoed;
     }
 
+    public Date getEmbargoDate() {
+        DCValue[] embargoLiftDateMetadata = getItem().getMetadata(EMBARGO_DATE_SCHEMA, EMBARGO_DATE_ELEMENT, EMBARGO_DATE_QUALIFIER, Item.ANY);
+        if(embargoLiftDateMetadata.length > 0) {
+            return getEarliestDate(embargoLiftDateMetadata);
+        }
+        return null;
+    }
+
     public void clearEmbargo() {
         addSingleMetadataValue(Boolean.TRUE, EMBARGO_TYPE_SCHEMA, EMBARGO_TYPE_ELEMENT, EMBARGO_TYPE_QUALIFIER, Item.ANY, null);
         addSingleMetadataValue(Boolean.TRUE, EMBARGO_DATE_SCHEMA, EMBARGO_DATE_ELEMENT, EMBARGO_DATE_QUALIFIER, Item.ANY, null);
@@ -317,6 +325,10 @@ public class DryadDataFile extends DryadObject {
 
     public List<String> getKeywords() {
         return getMultipleMetadataValues("dc", "subject", null);
+    }
+
+    public String getEmbargoType() {
+        return getSingleMetadataValue("dc", "type", "embargo");
     }
     
     public String getDescription() throws SQLException {

--- a/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
+++ b/dspace/modules/api/src/main/java/org/dspace/curate/TransferToDash.java
@@ -94,6 +94,7 @@ public class TransferToDash extends AbstractCurationTask {
                 dashService.deleteDataFiles(pkg);
             }
             dashService.postDataFileReferences(context, dataPackage);
+            dashService.setEmbargoStatus(pkg);
             dashService.submitDashDataset(versionlessPackageDOI);
                         
             // provide output for the console


### PR DESCRIPTION
After a data package has been transferred, send an extra curation activity that represents a package-level embargo.