### PR TITLE
remove CORS restrictions

### DIFF
--- a/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/resources/v1/PackageResource.java
+++ b/dspace/modules/dryad-rest-webapp/src/main/java/org/datadryad/rest/resources/v1/PackageResource.java
@@ -119,7 +119,7 @@ public class PackageResource {
                 URI prevLink = uriInfo.getRequestUriBuilder().replaceQueryParam("cursor", resultSet.getPreviousCursor()).build();
                 responseBuilder.link(prevLink, "prev");
             }
-            return responseBuilder.build();
+            return responseBuilder.header("Access-Control-Allow-Origin", "*").build();
         } catch (StorageException ex) {
             ErrorsResponse error = ResponseFactory.makeError(ex.getMessage(), "Unable to list journals", uriInfo, Status.INTERNAL_SERVER_ERROR.getStatusCode());
             return error.toResponse().build();


### PR DESCRIPTION
Allow the journal search to be called from within a browser, and not just directly from a server.